### PR TITLE
Rewrite how prompts are shared between workspaces and channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The config file will be loaded from the path specified in the `CONFIG_PATH` envi
 | `openai.api_key` | The Azure OpenAI key | _None_ | `aaa111222333abcabc123abc987` |
 | `models[].name` | Name to use for the model | _None_ | `general` |
 | `models[].description` | Description of the model, which will be used to classify inputs and select this model for answering questions | _None_ | `A general-purpose language model that can answer most questions` |
+| `models[].prompt.system` | System prompt for the LLM. | _None_ | `You are a friendly chat bot named $name.` |
+| `models[].prompt.examples[]` | List of example responses to use for few-shot tuning. | `[]` | `{ user = "what is your name?", ai = "Glen" }` |
+| `models[].prompt.variables` | Variables to inject into the prompt template. | `{}` | `{ name = "glen" }` |
 | `models[].params.type` | `llm` for general models, `csm` for cognitive search | _None_ | `llm` |
 | `models[].params.engine` | The name of your Azure OpenAI GPT-4 deployment | _None_ | `stats-tutor-gpt4` |
 | `models[].params.temperature` | The temperature setting for the LLM | `0.2` | `0.2` |
@@ -85,13 +88,15 @@ The config file will be loaded from the path specified in the `CONFIG_PATH` envi
 | `sentry.dsn` | (Optional) Sentry DSN for error reporting | _None_ | `https://aaabbbcccdddeeefff000111222@o111111.ingest.sentry.io/0001112223334445555` |
 | `tutor.db_dir` | Directory where local app data can be cached | `.db/` | `/cache/statstutor` |
 | `tutor.loading_reaction` | Default loading emoji to post as a reaction | `thinking_face` | `thinking_face` |
-| `tutor.models[]` | Default list of names of `models` available in this workspace | _None_ | `["general"]` |
-| `tutor.channels[].team_id` | Workspace (team) ID from Slack where bot will be integrated | _None_ | `T000AAAZZZ` |
-| `tutor.channels[].channel_id` | Channel in the Workspace where Slack bot will be integrated | _None_ | `C000AAAZZZ` |
-| `tutor.channels[].prompt_file` | Path to text file containing system prompt for this channel | _None_ | `/opt/aitutor/prompts/cs101.txt` |
-| `tutor.channels[].examples_file` | (Optional) path to few-shot examples to use with the system prompt | _None_ | `/opt/aitutor/prompts/cs101.examples.jsonl` |
-| `tutor.channels[].loading_reaction` | Reaction to use to indicate that the bot is processing a message | `thinking_face` | `dancing_robot` |
-| `tutor.channels[].models[]` | Overrides `tutor.models[]` | `[]` | `[ "general", "my-class" ]` |
+| `tutor.variables` | Common variables to inject into templates | `{}` | `{ name = "glen" }` |
+| `tutor.greeting` | Message to send when bot responds for the very first time in the channel. | _See text.py_ | `"Hi, I'm a friendly bot!"` |
+| `tutor.models[]` | Default list of `models` available in this workspace. Can either be string names or dicts with a `name` key that override values in the model. | _None_ | `["general"]` |
+| `tutor.workspaces[].models[]` | Overrides `tutor.models[]` | `[]` | `[ "general", "my-class" ]` |
+| `tutor.workspaces[].team_id` | Workspace (team) ID from Slack where bot will be integrated | _None_ | `T000AAAZZZ` |
+| `tutor.workspaces[].loading_reaction` | Override for inherited `loading_reaction`. | `thinking_face` | `thinking_face` |
+| `tutor.workspaces[].channels[].channel_id` | Channel in the Workspace where Slack bot will be integrated | _None_ | `C000AAAZZZ` |
+| `tutor.workspaces[].channels[].loading_reaction` | Override for inherited `loading_reaction`. | `thinking_face` | `dancing_robot` |
+| `tutor.workspaces[].channels[].models[]` | Overrides `tutor.workspaces[].models[]` | `[]` | `[ "general", "my-class" ]` |
 
 #### `models[]` settings
 
@@ -114,10 +119,15 @@ This model will be used to direct input to one of the other models.
 You will also probably want at least one GPT-4 deployment to answer general questions,
 and a CognitiveSearch model to answer additional questions.
 
+You should define a `[models.prompt]` section with the system prompt here.
+These (and the `params`) values can be overridden for a specific workspace / channel.
 
-#### `tutor.channels[]` settings
 
-You need to configure the app explicitly for _each_ channel you want to integrate the app with. This has two purposes: 1) so that multiple classes can tailor the bot to their subject areas using their own search indexes and model prompts, and 2) to prevent unauthorized usage of the services, which all have costs and quotas associated with them.
+#### `tutor.workspaces[]` and `.channels[]` settings
+
+You _must_ set the `tutor.models[]` list to provide default models available for use.
+Optionally, you can override which models are available on a per-workspace and per-channel basis.
+
 
 ## Local development
 

--- a/aitutor/template.py
+++ b/aitutor/template.py
@@ -1,0 +1,46 @@
+import string
+from datetime import datetime
+
+
+def _get_date():
+    return datetime.today().strftime("%A, %B %d, %Y")
+
+
+HARDCODED = {
+        "date": _get_date(),
+        }
+
+
+def validate_template(tpl: str, variables: dict[str, str]) -> None:
+    """Validate that a template string has all variables.
+
+    Args:
+        tpl: The template string to validate.
+        variables: A dictionary of variables to substitute into the template.
+
+    Raises:
+        ValueError: If the template string has variables that are not defined
+    """
+    needed = set(string.Template(tpl).get_identifiers())
+    supplied = set(HARDCODED.keys()) | set(variables.keys())
+    missing = needed - supplied
+    if missing:
+        raise ValueError(f"Missing variables {missing} in template {tpl}")
+
+
+def format_template(tpl: str, variables: dict[str, str]) -> str:
+    """Format a template string with variables.
+
+    Args:
+        tpl: The template string to format.
+        variables: A dictionary of variables to substitute into the template.
+
+    Returns:
+        The formatted string.
+    """
+    all_vars = {
+            k: v() if callable(v) else v
+            for k, v in HARDCODED.items()
+            }
+    all_vars.update(variables)
+    return string.Template(tpl).safe_substitute(all_vars)

--- a/aitutor/text.py
+++ b/aitutor/text.py
@@ -1,5 +1,5 @@
 GREETING = """\
-Hi! I'm an experimental AI tutor. I am here to help answer questions about course material. In particular I have been instructed to answer questions about {focus}, as well as questions about the course in general (logistics, readings, etc.).
+Hi! I'm an experimental AI tutor. I am here to help answer questions about course material.
 
 When you @-mention me in a channel or send me a DM, I will answer as best I can.
 
@@ -12,28 +12,26 @@ Sorry, an error occurred while generating a reply. You can try to repeat the que
 """
 
 
-DEFAULT_SYSTEM_PROMPT = """\
-You are a friendly teaching assistant for a college-level class focused on {focus}.
-
-Help answer students questions by asking them questions in response. Don't tell them answers directly. Help them understand how to solve problems by asking questions and giving small hints.
-
-The current date is {date}.\
-"""
-
-
 SWITCH_PROMPT = """\
 Your task is to inspect incoming messages from students and identify which model is best able to answer their question.
 
 The models you have access to are:
-{descriptions}
+$descriptions
 
 Instructions:
  - First, generate a short list of observations about the intent of the input.
  - Then, choose one of the available models that is the best fit to respond to the input.
  - Generate your output as JSON matching the following Typescript schema:
 
-interface Response {{
+interface Response {
   intent: string[];
-  model: {slugs};
-}}\
+  model: $slugs;
+}\
+"""
+
+
+DEFAULT_PROMPT = """\
+You are a friendly AI tutor. Your job is to help students with their questions about course material.
+
+Today's date is $date.\
 """


### PR DESCRIPTION
 - Models are now configured with their own prompts in the config
 - Model prompts now can define template variables to inject into the template
 - Let list of available models be configured at the app level, the workspace level, and the channel level
 - Allow each of those levels to override settings of the model to customize the prompt, template variables, and other params
 - Improved validation for templates and models
 - Some refactoring to make things a little smoother