### PR TITLE
Improve engine quota monitoring

### DIFF
--- a/aitutor/metrics.py
+++ b/aitutor/metrics.py
@@ -1,4 +1,4 @@
-from .otel import Counter, Gauge, Histogram
+from .otel import Counter, AsyncGauge, Gauge, Histogram
 
 
 inbound_messages = Counter(
@@ -25,10 +25,10 @@ reply_duration = Histogram(
         )
 
 
-engine_quota = Gauge(
+engine_quota = AsyncGauge(
         "engine_quota",
-        "TPM quota usage for the engine",
-        unit="TPM",
+        "Token quota usage for the engine",
+        unit="tokens",
         labels=["engine"])
 
 


### PR DESCRIPTION
Poll continuously for quota usage from the throttle and report it, instead of just when the engine is used, so the graphs do not need to interpolate missing values.