### PR TITLE
Create user and group in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,15 +18,23 @@ scp cert/aitutor.hks.harvard.edu.cer aitutor:~/
 scp cert/aitutor.hks.harvard.edu.key aitutor:~/
 ssh -T aitutor << EOF
   source ./docker.env
+
+  sudo useradd -m -s /bin/bash aitutor || true
+  sudo groupadd -f aitutor
+  sudo usermod -aG aitutor aitutor
+
   sudo mkdir -p /opt/aitutor
   sudo mkdir -p /opt/aitutor/cert
   sudo mkdir -p /opt/aitutor/db
+
   sudo cp docker-compose.yml /opt/aitutor/
   sudo cp docker-compose.prod.yml /opt/aitutor/
   sudo cp config.prod.toml /opt/aitutor/
   sudo cp nginx.conf /opt/aitutor/
   sudo cp aitutor.hks.harvard.edu.cer /opt/aitutor/cert/
   sudo cp aitutor.hks.harvard.edu.key /opt/aitutor/cert/
+
+  sudo chown -R aitutor:aitutor /opt/aitutor
 
   cd /opt/aitutor
   sudo systemctl start docker


### PR DESCRIPTION
Use an `aitutor` user and group for all files. Fixes #50 but note docker still needs to run as root- probably long term makes more sense to deploy this in a serverless fashion.