### PR TITLE
117 / show all models someone has access to

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -271,6 +271,16 @@ class ApiKey(BaseModel):
     api_key: str | None
 
 
+class AssistantModel(BaseModel):
+    id: str
+    created: datetime
+    owner: str
+
+
+class AssistantModels(BaseModel):
+    models: list[AssistantModel]
+
+
 class Classes(BaseModel):
     classes: list[Class]
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -198,6 +198,14 @@ export const getApiKey = async (f: Fetcher, classId: number) => {
 }
 
 /**
+ * Get models available with the api key for the class.
+ */
+export const getModels = async (f: Fetcher, classId: number) => {
+  const url = `class/${classId}/models`;
+  return await GET(f, url);
+}
+
+/**
  * Fetch a class by ID.
  */
 export const getClass = async (f: Fetcher, classId: number) => {
@@ -453,14 +461,6 @@ export const loginWithMagicLink = async (f: Fetcher, email: string) => {
   const url = `login/magic`;
   return await POST(f, url, {email});
 }
-
-/**
- * List of available language models.
- */
-export const languageModels = [
-    // "gpt-4-vision-preview",
-    "gpt-4-1106-preview",
-];
 
 /**
  * List of available roles. These map to the API.

--- a/web/pingpong/src/lib/components/ManageAssistant.svelte
+++ b/web/pingpong/src/lib/components/ManageAssistant.svelte
@@ -8,16 +8,17 @@
   export let files;
   export let assistant = null;
   export let canPublish = true;
+  export let models = [];
 
   const action = assistant ? "?/updateAssistant" : "?/createAssistant";
 
   let selectedFiles = (assistant?.files || []).map((file) => file.file_id);
-  const models = api.languageModels.map((model) => ({ value: model, name: model }));
   const tools = [
     { value: "code_interpreter", name: "Code Interpreter" },
   ];
   const defaultTools = [{type: "code_interpreter"}];
   const selectedTools = (assistant?.tools ? JSON.parse(assistant.tools) : defaultTools).map(t => t.type);
+  $: models = (models || []).map((model) => ({ value: model.id, name: model.id }));
   $: fileOptions = (files || []).map((file) => ({ value: file.file_id, name: file.name }));
 
   // Revert edits

--- a/web/pingpong/src/routes/class/[classId]/manage/+page.server.ts
+++ b/web/pingpong/src/routes/class/[classId]/manage/+page.server.ts
@@ -1,6 +1,6 @@
 import * as api from '$lib/api';
 import {forwardRequest} from '$lib/proxy';
-import {redirect} from "@sveltejs/kit";
+import {fail, redirect} from "@sveltejs/kit";
 
 export const actions = {
 
@@ -84,7 +84,12 @@ export const actions = {
       hide_prompt: body.get('hide_prompt') === "on",
     };
 
-    return await api.createAssistant(event.fetch, event.params.classId, data);
+    const resp = await api.createAssistant(event.fetch, event.params.classId, data);
+    if (resp.$status >= 400) {
+      return fail(resp.$status, resp);
+    }
+
+    return resp;
   },
 
   /**

--- a/web/pingpong/src/routes/class/[classId]/manage/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/manage/+page.svelte
@@ -11,8 +11,26 @@
   import ViewAssistant from "$lib/components/ViewAssistant.svelte";
   import Info from "$lib/components/Info.svelte";
   import {PenOutline} from "flowbite-svelte-icons";
+  import {toast} from "@zerodevx/svelte-toast";
 
   export let data;
+  export let form;
+
+  $: {
+    // Show an error if the form failed
+    // TODO -- more universal way of showing validation errors
+    if (form?.$status >= 400) {
+      toast.push(form?.detail || "An unknown error occurred", {
+        duration: 5000,
+        theme: {
+          // Error color
+          '--toastBackground': '#F87171',
+          '--toastBarBackground': '#EF4444',
+          '--toastColor': '#fff',
+        },
+      })
+    }
+  }
 
   let ttModal = false;
   let studentModal = false;
@@ -22,6 +40,7 @@
   $: editingAssistant = parseInt($page.url.searchParams.get('edit-assistant') || '0', 10);
   $: creators = data?.assistantCreators || {};
   $: assistants = data?.assistants || [];
+  $: models = data?.models || [];
   $: files = data?.files || [];
   $: students = (data?.classUsers || []).filter(u => u.title.toLowerCase() === 'student');
   $: tt = (data?.classUsers || []).filter(u => u.title.toLowerCase() !== 'student');
@@ -219,7 +238,7 @@
         {#each assistants as assistant}
           {#if assistant.id == editingAssistant}
           <Card class="w-full max-w-full">
-            <ManageAssistant {files} {assistant} canPublish={canPublishAssistant} />
+            <ManageAssistant {files} {assistant} {models} canPublish={canPublishAssistant} />
           </Card>
           {:else}
           <Card class="w-full max-w-full space-y-2" href={assistant.creator_id === data.me.user.id && canCreateAssistant ?`${$page.url.pathname}?edit-assistant=${assistant.id}` : null}>
@@ -230,7 +249,7 @@
         {#if !editingAssistant && canCreateAssistant}
         <Card class="w-full max-w-full">
           <Heading tag="h4" class="pb-3">Add new AI assistant</Heading>
-          <ManageAssistant {files} canPublish={canPublishAssistant} />
+          <ManageAssistant {files} {models} canPublish={canPublishAssistant} />
         </Card>
         {/if}
       {/if}

--- a/web/pingpong/src/routes/class/[classId]/manage/+page.ts
+++ b/web/pingpong/src/routes/class/[classId]/manage/+page.ts
@@ -3,7 +3,15 @@ import * as api from "$lib/api";
 export async function load({ fetch, params }) {
   const {api_key}= await api.getApiKey(fetch, params.classId);
   const {users} = await api.getClassUsers(fetch, params.classId);
+
+  let models = [];
+  if (api_key) {
+    const modelResponse = await api.getModels(fetch, params.classId);
+    models = modelResponse.models;
+  }
+
   return {
+    models,
     apiKey: api_key || '',
     classUsers: users,
   };


### PR DESCRIPTION
Get the proper list of models for an API key.

Prevents showing models someone doesn't have access to, and surfaces models someone might want that we haven't hardcoded (such as newly released GPT-4 version).

It's not possible to tell exactly which models will be accepted by the Assistants API. For example, the `gpt-4-vision-preview` model is not currently accepted. But the general rule of thumb is that any `gpt-*` models can be used. Added changes to surface the error if OpenAI rejects the config.

Fixes #117 