### PR TITLE
155 / fix student assistant creation

### DIFF
--- a/web/pingpong/src/routes/class/[classId]/manage/+page.ts
+++ b/web/pingpong/src/routes/class/[classId]/manage/+page.ts
@@ -8,12 +8,7 @@ export const load: PageLoad = async ({ fetch, params }) => {
   const classId = parseInt(params.classId, 10);
   const {api_key}= await api.getApiKey(fetch, classId);
   const {users} = await api.getClassUsers(fetch, classId);
-
-  let models = [];
-  if (api_key) {
-    const modelResponse = await api.getModels(fetch, classId);
-    models = modelResponse.models;
-  }
+  const {models} = await api.getModels(fetch, classId);
 
   return {
     models,


### PR DESCRIPTION
Fix regression due to dynamic model loading from api key. On the frontend, the available models were incorrectly not being loaded for students since they `api_key` was incorrectly presumed to be absent (since the API key is not visible on the frontend to students). Fix is to just try to load models and let the request error out when the api key is not set.