### PR TITLE
172 / fix scrolling on chrome, safari

### DIFF
--- a/web/pingpong/src/lib/components/Main.svelte
+++ b/web/pingpong/src/lib/components/Main.svelte
@@ -1,5 +1,5 @@
-<div class="flex flex-col flex-grow overflow-x-auto">
-  <div class="flex-grow bg-white overflow-y-auto">
+<div class="flex flex-col flex-grow overflow-x-hidden">
+  <div class="flex-grow bg-white overflow-y-hidden">
     <slot />
   </div>
 </div>


### PR DESCRIPTION
Fixes #172 


Not sure when this changed (it wasn't recently, though maybe the new styles from #171 competed with the existing styles and revealed this somehow). Fix by making the `Main` component unscrollable, and leaving it up to the inner chat thread container to manage scroll bars (which was intended all along).