### PR TITLE
280 / Disable start a chat button on new chat page

### DIFF
--- a/web/pingpong/src/lib/components/Sidebar.svelte
+++ b/web/pingpong/src/lib/components/Sidebar.svelte
@@ -46,6 +46,7 @@
   );
   $: threads = ($page.data.threads || []) as api.Thread[];
   $: currentClassId = parseInt($page.params.classId, 10);
+  $: onNewChatPage = $page.url.pathname === `/class/${currentClassId}`;
 
   // Toggle whether menu is open.
   const togglePanel = (state?: boolean) => {
@@ -87,9 +88,14 @@
 
     <SidebarGroup class="mt-6 mb-10">
       <SidebarItem
-        href={currentClassId ? `/class/${currentClassId}` : '/'}
+        href={onNewChatPage ? undefined : currentClassId ? `/class/${currentClassId}` : '/'}
+        disabled={onNewChatPage}
         label="Start a new chat"
-        class="flex flex-row-reverse justify-between pr-4 bg-orange text-white rounded-full hover:bg-orange-dark"
+        class={`flex flex-row-reverse justify-between pr-4 text-white rounded-full ${
+          onNewChatPage
+            ? 'bg-gray-400 hover:bg-gray-400 cursor-default text-gray-100'
+            : 'bg-orange hover:bg-orange-dark'
+        }`}
       >
         <svelte:fragment slot="icon">
           <CirclePlusSolid size="sm" />


### PR DESCRIPTION
Per conversation on Friday, one improvement to the "Start a new chat" button is to disable it when we're on the "new chat" screen.

The `SidebarItem` doesn't have a proper "disabled" state we can toggle on, so instead we just conditionally remove the `href` and apply grayscale styles.

<img width="313" alt="image" src="https://github.com/stanford-policylab/pingpong/assets/1069899/6a3fabc3-ef2a-4345-a537-ec00121e3b81">

fixes #280 