### PR TITLE
235 / re-arrange new chat page

### DIFF
--- a/web/pingpong/src/routes/class/[classId]/assistant/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/assistant/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Assistant } from '$lib/api.js';
+  import type { Assistant } from '$lib/api';
   import ViewAssistant from '$lib/components/ViewAssistant.svelte';
   import {
     Heading,


### PR DESCRIPTION
Per conversation last Friday, a few changes to the New Chat page:

 - Move assistant selector to original position in the upper left of the chat area
 - Group assistants in selector by course vs. other assistants
 - Hide picker when there is only one bot
 - Add a "view all assistants" link into the assistant detail card
 - Remove specific names from "course" assistants (just indicate they are created by the teaching team)

Put very little energy into styling. It doesn't look terrible, but handing over to @kylelarkin for improvements.