### PR TITLE
Fix loading on main thread page

### DIFF
--- a/web/pingpong/src/routes/+page.svelte
+++ b/web/pingpong/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <!-- We don't really expect anyone to ever see this page.
   -- Just add some loose directions in case we're wrong about that!
   -->
-<div>
+<div class="m-auto">
   <h1>Welcome to PingPong!</h1>
   <p>It looks like you have not been added to any classes and you are also not an admin.</p>
   <p>

--- a/web/pingpong/src/routes/class/[classId]/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/+page.svelte
@@ -239,7 +239,7 @@
         <input type="hidden" name="parties" bind:value={parties} />
       </div>
     {:else}
-      <div class="text-center">
+      <div class="text-center m-auto">
         {#if !data.hasAssistants}
           <h1 class="text-2xl font-bold">No assistants configured.</h1>
         {:else if !data.hasBilling}


### PR DESCRIPTION
 - Main thread page loading spinner was buried in the stacking order
 - Show loading spinner on navigation changes
 - Center text that's shown on various no data states

There's a small inconsistency now between the loading screen on the thread page and on the landing page where on the former the chat input is left uncovered by the modal backdrop, while on the latter the chat input is covered. Not sure which is right, so we'll wait and see who complains about the inconsistency to find out which it should be.