### PR TITLE
Fix db init script

### DIFF
--- a/start-dev-docker.sh
+++ b/start-dev-docker.sh
@@ -30,9 +30,14 @@ docker exec pingpong-db psql -Upingpong -c "CREATE SCHEMA IF NOT EXISTS authz;"
 # Run the OpenFGA migrate command to init the database
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run authz migrate
 
-# Init the Pingpong db stuff
+# Update the PingPong srv image
 docker compose -f docker-compose.yml -f docker-compose.dev.yml build srv
+
+# Init/update the PingPong DB. It's ok if the DB already exists - in that
+# case the init command does not do anything. We will apply migrations to
+# put the DB in the correct state.
 docker compose -f docker-compose.yml -f docker-compose.dev.yml run srv poetry run python -m pingpong db init
+docker compose -f docker-compose.yml -f docker-compose.dev.yml run srv poetry run python -m pingpong db migrate
 
 # Run the app
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up authz srv -d


### PR DESCRIPTION
Fix a bug @kylelarkin encountered with the `start-dev-docker.sh` script.

The `db init` command was aggressively stamping the database with the latest DB migration version, even if it had not applied the latest migrations. This would cause the `db migrate` command to do nothing when trying to apply future migrations because it thought it was at the latest version.

Fixes:
 - Revise `db init` to do nothing at all if the DB already exists, unless `clean` is explicitly requested (in which case we drop, recreate, and stamp at head, which will be correct in that case)
 - Run `db migrate` after `db init` in the `start-dev-docker.sh` script in order to apply new migrations and get the DB into the latest revision state the right way.