### PR TITLE
310 / make loading styles consistent everywhere

### DIFF
--- a/web/pingpong/src/lib/components/Main.svelte
+++ b/web/pingpong/src/lib/components/Main.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { appMenuOpen } from '$lib/stores/general';
+  import { navigating } from '$app/stores';
+  import { Pulse } from 'svelte-loading-spinners';
+  import { blur } from 'svelte/transition';
+  import { loading } from '$lib/stores/general';
 </script>
 
 <div
@@ -7,7 +11,16 @@
     $appMenuOpen ? 'left-[90%]' : ''
   }`}
 >
-  <div class="h-full flex-grow bg-white rounded-t-4xl overflow-hidden">
+  <div class="h-full flex-grow bg-white rounded-t-4xl overflow-hidden relative">
+    {#if !!$navigating || $loading}
+      <div
+        class="absolute top-0 left-0 flex h-full w-full items-center bg-white bg-opacity-75 z-50"
+      >
+        <div class="m-auto" transition:blur={{ amount: 10 }}>
+          <Pulse color="#0ea5e9" />
+        </div>
+      </div>
+    {/if}
     <slot />
   </div>
 </div>

--- a/web/pingpong/src/lib/stores/general.ts
+++ b/web/pingpong/src/lib/stores/general.ts
@@ -4,3 +4,11 @@ import { writable } from 'svelte/store';
  * Store for the app menu open state.
  */
 export const appMenuOpen = writable(false);
+
+/**
+ * Store for a big loading indicator over the main page.
+ *
+ * TODO(jnu): there could be race conditions with this shared store;
+ * consider using a fancier counter-based system instead.
+ */
+export const loading = writable(false);

--- a/web/pingpong/src/routes/+page.svelte
+++ b/web/pingpong/src/routes/+page.svelte
@@ -1,12 +1,13 @@
 <!-- We don't really expect anyone to ever see this page.
   -- Just add some loose directions in case we're wrong about that!
   -->
-<div class="m-auto">
-  <h1>Welcome to PingPong!</h1>
+<div class="m-auto p-16 gap-4 flex flex-col">
+  <h1 class="text-2xl">Welcome to PingPong!</h1>
   <p>It looks like you have not been added to any classes and you are also not an admin.</p>
   <p>
     This suggests something might be misconfigured. Please contact your site admin, or see our <a
-      href="/about">about</a
+      href="/about"
+      class="text-orange hover:text-orange-dark">about</a
     > page for more help.
   </p>
 </div>

--- a/web/pingpong/src/routes/class/[classId]/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/+page.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-  import { blur } from 'svelte/transition';
-  import { writable } from 'svelte/store';
   import { goto } from '$app/navigation';
   import { navigating, page } from '$app/stores';
-  import { Pulse } from 'svelte-loading-spinners';
   import ChatInput, { type ChatInputMessage } from '$lib/components/ChatInput.svelte';
   import {
     Button,
@@ -21,6 +18,7 @@
   import { errorMessage } from '$lib/errors';
   import type { Assistant } from '$lib/api';
   import { onMount } from 'svelte';
+  import { loading } from '$lib/stores/general';
 
   /**
    * Application data.
@@ -51,8 +49,6 @@
     };
   };
 
-  // Whether the app is currently loading.
-  let loading = writable(false);
   // Currently selected assistant.
   $: assistants = data?.assistants || [];
   $: courseAssistants = assistants.filter((asst) => asst.endorsed);
@@ -109,6 +105,7 @@
         })
       );
       data.threads = [newThread, ...data.threads];
+      $loading = false;
       await goto(`/class/${$page.params.classId}/thread/${newThread.id}`);
     } catch (e) {
       sadToast(`Failed to create thread. Error: ${errorMessage(e)}`);
@@ -123,13 +120,6 @@
 </script>
 
 <div class="flex justify-center relative min-h-0 grow shrink">
-  {#if $loading || !!$navigating}
-    <div class="absolute top-0 left-0 flex h-full w-full items-center bg-white bg-opacity-75 z-50">
-      <div class="m-auto" transition:blur={{ amount: 10 }}>
-        <Pulse color="#0ea5e9" />
-      </div>
-    </div>
-  {/if}
   <div
     class="w-11/12 transition-opacity ease-in flex flex-col h-full justify-between"
     class:opacity-0={$loading}

--- a/web/pingpong/src/routes/class/[classId]/thread/[threadId]/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/thread/[threadId]/+page.svelte
@@ -6,7 +6,7 @@
   import { errorMessage } from '$lib/errors';
   import { blur } from 'svelte/transition';
   import { Span, Avatar, Button, Dropdown, DropdownItem } from 'flowbite-svelte';
-  import { Pulse, DoubleBounce } from 'svelte-loading-spinners';
+  import { DoubleBounce } from 'svelte-loading-spinners';
   import Markdown from '$lib/components/Markdown.svelte';
   import Logo from '$lib/components/Logo.svelte';
   import ChatInput, { type ChatInputMessage } from '$lib/components/ChatInput.svelte';
@@ -174,14 +174,6 @@
 </script>
 
 <div class="w-full flex flex-col justify-between grow min-h-0 relative">
-  {#if $loading || $navigating}
-    <div class="absolute top-0 left-0 flex h-full w-full items-center bg-white bg-opacity-75">
-      <div class="m-auto" transition:blur={{ amount: 10 }}>
-        <Pulse color="#0ea5e9" />
-      </div>
-    </div>
-  {/if}
-
   <div class="overflow-y-auto pb-4 px-2 lg:px-4" use:scroll={$messages}>
     {#if $canFetchMore}
       <div class="flex justify-center grow">

--- a/web/pingpong/src/routes/threads/+page.svelte
+++ b/web/pingpong/src/routes/threads/+page.svelte
@@ -5,6 +5,7 @@
   import { Select, Button } from 'flowbite-svelte';
   import { page } from '$app/stores';
   import { getValue, updateSearch } from '$lib/urlstate';
+  import { loading } from '$lib/stores/general';
 
   export let data;
 
@@ -35,9 +36,13 @@
     if (error) {
       return;
     }
+
+    $loading = true;
+
     const lastTs = threads.length ? threads[threads.length - 1].updated : undefined;
     const currentClassId = parseInt(currentClass, 10) || undefined;
     const more = await api.getAllThreads(fetch, { before: lastTs, class_id: currentClassId });
+    $loading = false;
     if (more.error) {
       error = more.error;
     } else {


### PR DESCRIPTION
Write loading indicator into the root layout so it's used on all app navigation and make styles more consistent across screens.

Fixes #310 