### PR TITLE
311 / force newlines to be \n

### DIFF
--- a/web/pingpong/src/lib/content.ts
+++ b/web/pingpong/src/lib/content.ts
@@ -32,3 +32,8 @@ export const parseTextContent = (text: Text, baseUrl: string = '') => {
 
   return content;
 };
+
+/**
+ * Normalize newlines to use only '\n'.
+ */
+export const normalizeNewlines = (text: string) => text.replace(/\r\n/g, '\n');

--- a/web/pingpong/src/routes/class/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/class/[classId]/assistant/[assistantId]/+page.svelte
@@ -16,6 +16,7 @@
   import * as api from '$lib/api';
   import { setsEqual } from '$lib/set';
   import { happyToast, sadToast } from '$lib/toast';
+  import { normalizeNewlines } from '$lib/content.js';
 
   export let data;
 
@@ -75,10 +76,14 @@
         dirty = newValue !== (oldValue || '');
         break;
       case 'description':
-        dirty = newValue !== (oldValue || '');
+        dirty =
+          normalizeNewlines((newValue as string | undefined) || '') !==
+          normalizeNewlines((oldValue as string) || '');
         break;
       case 'instructions':
-        dirty = newValue !== (oldValue || '');
+        dirty =
+          normalizeNewlines((newValue as string | undefined) || '') !==
+          ((oldValue as string) || '');
         break;
       case 'model':
         dirty = newValue !== oldValue;
@@ -161,8 +166,8 @@
 
     const params = {
       name: body.name.toString(),
-      description: body.description.toString(),
-      instructions: body.instructions.toString(),
+      description: normalizeNewlines(body.description.toString()),
+      instructions: normalizeNewlines(body.instructions.toString()),
       model: body.model.toString(),
       tools,
       file_ids: selectedFiles,


### PR DESCRIPTION
Ensure prompts are always saved with Unix-style `\n` newlines instead of Windows-style CRLF `\r\n` newlines. Otherwise each platform will convert to the other style in the textbox when viewing the page, leading to unintended text modifications. This is what causes the create/edit assistant page to prompt about unsaved changed instructions in some cases despite the user not having made any changes.

Fixes #311 