### PR TITLE
312 / Smarter selection of assistant when clicking new chat

### DIFF
--- a/web/pingpong/src/lib/components/Sidebar.svelte
+++ b/web/pingpong/src/lib/components/Sidebar.svelte
@@ -46,6 +46,7 @@
   );
   $: threads = ($page.data.threads || []) as api.Thread[];
   $: currentClassId = parseInt($page.params.classId, 10);
+  $: currentAssistantId = $page.data.threadData?.thread?.assistant_id;
   $: onNewChatPage = $page.url.pathname === `/class/${currentClassId}`;
 
   // Toggle whether menu is open.
@@ -88,7 +89,13 @@
 
     <SidebarGroup class="mt-6 mb-10">
       <SidebarItem
-        href={onNewChatPage ? undefined : currentClassId ? `/class/${currentClassId}` : '/'}
+        href={onNewChatPage
+          ? undefined
+          : currentClassId
+            ? `/class/${currentClassId}${
+                currentAssistantId ? `?assistant=${currentAssistantId}` : ''
+              }`
+            : '/'}
         disabled={onNewChatPage}
         label="Start a new chat"
         class={`flex flex-row-reverse justify-between pr-4 text-white rounded-full ${


### PR DESCRIPTION
Fixes #312 

If there is an obvious assistant to choose when clicking "New Chat" (namely, the assistant used in the thread that is opened in the UI), specify this in the link.