### PR TITLE
Patch: Supported Files Lists on Edit Assistants Page 

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -95,11 +95,13 @@
   let codeInterpreterOptions: SelectOptionType<string>[] = [];
   const fileSearchFilter = data.uploadInfo.getFileSupportFilter({
     code_interpreter: false,
-    file_search: true
+    file_search: true,
+    vision: false
   });
   const codeInterpreterFilter = data.uploadInfo.getFileSupportFilter({
     code_interpreter: true,
-    file_search: false
+    file_search: false,
+    vision: false
   });
   $: fileSearchOptions = (asstFiles || [])
     .filter(fileSearchFilter)


### PR DESCRIPTION
Fixes a bug from #303, where FileSearch and CodeInterpreter compatible files lists would return all files.