### PR TITLE
384/ Patch: Private files might show as group files on the non-uploading file list

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -98,7 +98,8 @@
   );
   $: supportsVision = supportVisionModels.includes(selectedModel);
   let allowVisionUpload = false;
-  $: asstFiles = [...data.files, ...allFSPrivateFiles, ...allCIPrivateFiles];
+  $: asstFSFiles = [...data.files, ...allFSPrivateFiles];
+  $: asstCIFiles = [...data.files, ...allCIPrivateFiles];
 
   let fileSearchOptions: SelectOptionType<string>[] = [];
   let codeInterpreterOptions: SelectOptionType<string>[] = [];
@@ -112,10 +113,10 @@
     file_search: false,
     vision: false
   });
-  $: fileSearchOptions = (asstFiles || [])
+  $: fileSearchOptions = (asstFSFiles || [])
     .filter(fileSearchFilter)
     .map((file) => ({ value: file.file_id, name: file.name }));
-  $: codeInterpreterOptions = (asstFiles || [])
+  $: codeInterpreterOptions = (asstCIFiles || [])
     .filter(codeInterpreterFilter)
     .map((file) => ({ value: file.file_id, name: file.name }));
 


### PR DESCRIPTION
Closes #384 by introducing better separation of assistant files between File Search and Code Interpreter lists.