### PR TITLE
388 / Fixes Duplicate Assistants List

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/assistant/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/+page.svelte
@@ -28,7 +28,6 @@
   let otherAssistants: Assistant[] = [];
   $: {
     const allAssistants = data?.assistants || [];
-    console.log('assistants', allAssistants);
     // Split all assistants into categories
     courseAssistants = allAssistants.filter((assistant) => assistant.endorsed);
     myAssistants = allAssistants.filter(


### PR DESCRIPTION
Fixes #388 by active filtering `allAssistants` list instead of pushing new records to existing category lists.