### PR TITLE
399/ Add assistant publishing permissions to can_manage_assistants permission

### DIFF
--- a/pingpong/authz/authz.fga
+++ b/pingpong/authz/authz.fga
@@ -47,7 +47,7 @@ type thread
     define can_view: [class#member] or party or can_manage_threads from parent
     define can_participate: party
     define can_delete: can_manage_threads from parent
-    define can_publish: (party and can_publish_threads from parent) or can_manage_threads from parent
+    define can_publish: (party and can_publish_threads from parent) or (can_manage_threads from parent and can_publish_threads from parent)
 
 type assistant
   relations

--- a/pingpong/authz/authz.fga.json
+++ b/pingpong/authz/authz.fga.json
@@ -508,13 +508,29 @@
                 }
               },
               {
-                "tupleToUserset": {
-                  "computedUserset": {
-                    "relation": "can_manage_threads"
-                  },
-                  "tupleset": {
-                    "relation": "parent"
-                  }
+                "intersection": {
+                  "child": [
+                    {
+                      "tupleToUserset": {
+                        "computedUserset": {
+                          "relation": "can_manage_threads"
+                        },
+                        "tupleset": {
+                          "relation": "parent"
+                        }
+                      }
+                    },
+                    {
+                      "tupleToUserset": {
+                        "computedUserset": {
+                          "relation": "can_publish_threads"
+                        },
+                        "tupleset": {
+                          "relation": "parent"
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             ]


### PR DESCRIPTION
Closes #399 by allowing Administrators to publish any assistant they can manage.