### PR TITLE
[chore] Bump mypy version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,10 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.11.1
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
-        additional_dependencies: [types-all]
+        args: [--ignore-missing-imports, --install-types, --non-interactive]
         exclude: alembic/
   - repo: https://github.com/python-poetry/poetry
     rev: 1.6.1


### PR DESCRIPTION
@ekassos FYI the `types-all` package used by `mypy` pre-commit hook started hitting issues tonight when [one of its dependencies was yanked](https://pypi.org/project/types-pkg-resources/) from PyPi. I hit this error on the blind-charging CI, fixing here as well. 