### PR TITLE
make_root cmd fix

### DIFF
--- a/pingpong/__main__.py
+++ b/pingpong/__main__.py
@@ -51,6 +51,15 @@ def make_root(email: str) -> None:
         await config.authz.driver.init()
         async with config.db.driver.async_session() as session:
             user = await User.get_by_email(session, email)
+            if not user:
+                user = User(email=email)
+                user.super_admin = True
+            else:
+                user.super_admin = True
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+
             async with config.authz.driver.get_client() as c:
                 await c.create_root_user(user.id)
 


### PR DESCRIPTION
Fixes an issue where adding a super user who does not exist would result in an error. Now, the user is first created and then given super_user privileges if they do not exist.