### PR TITLE
Add support for gpt-4o-2024-08-06

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -1044,7 +1044,7 @@ async def list_class_models(
             "is_new": True,
             "highlight": False,
             "supports_vision": True,
-            "description": "Latest GPT-4o model snapshot. GPT-4o (Latest) does not point to this snapshot yet.",
+            "description": "Latest GPT-4o model snapshot. GPT-4o (Latest) points to gpt-4o-2024-05-13 and not this snapshot yet.",
         },
         "gpt-4o-2024-05-13": {
             "name": "gpt-4o-2024-05-13",


### PR DESCRIPTION
Latest snapshot that supports [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).