### PR TITLE
Enable Vision for all

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/+page.svelte
@@ -82,7 +82,7 @@
     );
     supportsVision = supportVisionModels.includes(assistant.model);
   }
-  $: allowVisionUpload = !!data?.isSupervisor;
+  $: allowVisionUpload = true;
 
   // Handle file upload
   const handleUpload = (

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -119,7 +119,7 @@
     (model) => model.id
   );
   $: supportsVision = supportVisionModels.includes(selectedModel);
-  $: allowVisionUpload = !!data?.grants?.isSupervisor;
+  $: allowVisionUpload = true;
   $: asstFSFiles = [...data.files, ...allFSPrivateFiles];
   $: asstCIFiles = [...data.files, ...allCIPrivateFiles];
 


### PR DESCRIPTION
Enables Vision capabilities for Members. Keeping `allowVisionUpload` around in case something comes up and we need to quickly limit access.