### PR TITLE
Fix: Inconsistent maximum allowed file upload sizes across the app

### DIFF
--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -198,7 +198,7 @@ SupportSettings = Union[DiscordSettings, NoSupportSettings]
 class UploadSettings(BaseSettings):
     """Settings for file uploads."""
 
-    private_file_max_size: int = Field(10 * 1024 * 1024)  # 10 MB
+    private_file_max_size: int = Field(512 * 1024 * 1024)  # 512 MB
     class_file_max_size: int = Field(512 * 1024 * 1024)  # 512 MB
 
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Annotated, Any
 import jwt
 import openai
+import humanize
 from fastapi import (
     BackgroundTasks,
     Depends,
@@ -1736,7 +1737,7 @@ async def create_file(
     if upload.size > config.upload.class_file_max_size:
         raise HTTPException(
             status_code=413,
-            detail=f"File too large. Max size is {config.upload.class_file_max_size} bytes.",
+            detail=f"File too large. Max size is {humanize.naturalsize(config.upload.private_file_max_size)}.",
         )
 
     return await handle_create_file(
@@ -1766,7 +1767,7 @@ async def create_user_file(
     if upload.size > config.upload.private_file_max_size:
         raise HTTPException(
             status_code=413,
-            detail=f"File too large. Max size is {config.upload.private_file_max_size} bytes.",
+            detail=f"File too large. Max size is {humanize.naturalsize(config.upload.private_file_max_size)}.",
         )
 
     return await handle_create_file(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1263,6 +1263,20 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 
 [[package]]
+name = "humanize"
+version = "4.10.0"
+description = "Python humanize utilities"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "humanize-4.10.0-py3-none-any.whl", hash = "sha256:39e7ccb96923e732b5c2e27aeaa3b10a8dfeeba3eb965ba7b74a3eb0e30040a6"},
+    {file = "humanize-4.10.0.tar.gz", hash = "sha256:06b6eb0293e4b85e8d385397c5868926820db32b9b654b932f57fa41c23c9978"},
+]
+
+[package.extras]
+tests = ["freezegun", "pytest", "pytest-cov"]
+
+[[package]]
 name = "identify"
 version = "2.6.0"
 description = "File identification library for Python"
@@ -3715,4 +3729,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b403bd5c07f00b057980a84f773b541b3b05451854e6c5813ce20bf49fe78baa"
+content-hash = "8dce9debf8879d638ace0de0dfc745638f36bacb8fbb9ea7ac5c85a1efee368b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ mmh3 = "4.1.0"
 python-glowplug = "0.3.9"
 python3-saml = "^1.16.0"
 arrow = "^1.3.0"
+humanize = "^4.10.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -923,7 +923,9 @@ export const uploadUserFile = (
  * File upload error.
  */
 export interface FileUploadFailure {
-  error: string;
+  error: {
+    detail: string;
+  };
 }
 
 /**
@@ -1008,7 +1010,9 @@ const _doUpload = (
           resolve(info.response);
         } else {
           info.state = 'error';
-          info.response = { error: xhr.responseText };
+          info.response = {
+            error: xhr.responseText ? JSON.parse(xhr.responseText) : { detail: '' }
+          };
           reject(info.response);
         }
       }

--- a/web/pingpong/src/lib/components/FileUpload.svelte
+++ b/web/pingpong/src/lib/components/FileUpload.svelte
@@ -20,9 +20,10 @@
     const newFiles: FileUploadInfo[] = [];
     toUpload.forEach((f) => {
       if (maxSize && f.size > maxSize) {
+        const maxUploadSize = humanSize(maxSize);
         dispatch('error', {
           file: f,
-          message: `<strong>Upload unsuccessful: File is too large</strong><br>Max size is ${maxSize} bytes.`
+          message: `<strong>Upload unsuccessful: File is too large</strong><br>Max size is ${maxUploadSize}.`
         });
         return;
       }
@@ -65,7 +66,10 @@
             }
             return existingFiles;
           });
-          dispatch('error', { file: f, message: `Could not upload file ${f.name}: ${error}.` });
+          dispatch('error', {
+            file: f,
+            message: `Could not upload file ${f.name}: ${error.error.detail || 'unknown error'}`
+          });
         });
 
       newFiles.push(fp);
@@ -119,7 +123,7 @@
   import { writable, type Writable } from 'svelte/store';
   import { Button } from 'flowbite-svelte';
   import type { FileUploader, FileUploadInfo, FileUploadPurpose } from '$lib/api';
-
+  import { humanSize } from '$lib/size';
   /**
    * Whether to allow uploading.
    */

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -645,6 +645,7 @@
             code_interpreter: false,
             vision: false
           })}
+          maxSize={data.uploadInfo.class_file_max_size}
           maxCount={fileSearchMetadata.max_count}
           uploadType="File Search"
           on:error={(e) => sadToast(e.detail.message)}
@@ -676,6 +677,7 @@
             code_interpreter: true,
             vision: false
           })}
+          maxSize={data.uploadInfo.class_file_max_size}
           maxCount={codeInterpreterMetadata.max_count}
           uploadType="Code Interpreter"
           on:error={(e) => sadToast(e.detail.message)}


### PR DESCRIPTION
Fixes #432 by changing the allowed upload file size for private uploads to 512 MB, consistent with class file uploads.

### Other changes:
- Fixes an error where the error message when uploading a file would be an Object instead of a string. Fixed by updating the expected error return type in the `FileUploadFailure` interface.
- Fixes an error where `MultiSelectWithUpload` were not passed the applicable `maxSize`.
- Updates all size-related upload error messages to display `humanize.naturalsize`/`humanSize` size strings server- and client-side.