### PR TITLE
Patch: Invite call not passing down `expires` argument

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -816,6 +816,7 @@ async def add_users_to_class(
             config.email.sender,
             invite,
             magic_link,
+            86_400 * 7,
             new_ucr.silent,
         )
 


### PR DESCRIPTION
Fixes an issue where the `expires` argument was not passed to `send_invite` when being added as a task during `server.py/add_users_to_class`.