### PR TITLE
Option to avoid sending invite emails when adding users to group

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -311,7 +311,7 @@ class CreateUserClassRole(BaseModel):
 
 class CreateUserClassRoles(BaseModel):
     roles: list[CreateUserClassRole]
-    notify: bool = True
+    silent: bool = False
 
 
 class UserClassRole(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -807,7 +807,7 @@ async def add_users_to_class(
                 )
             )
 
-    if new_ucr.notify:
+    if not new_ucr.silent:
         # Send emails to new users in the background
         nowfn = get_now_fn(request)
         for invite in new_:

--- a/scripts/loadtest.py
+++ b/scripts/loadtest.py
@@ -209,7 +209,7 @@ class TestInstance:
                     }
                     for i in range(num_users)
                 ],
-                "notify": False,
+                "silent": True,
             },
         )
         self._ctr += num_users

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1126,7 +1126,7 @@ export type CreateClassUserRequest = {
  */
 export type CreateClassUsersRequest = {
   roles: CreateClassUserRequest[];
-  notify: boolean;
+  silent: boolean;
 };
 
 /**

--- a/web/pingpong/src/lib/components/BulkAddUsers.svelte
+++ b/web/pingpong/src/lib/components/BulkAddUsers.svelte
@@ -39,7 +39,7 @@
       sadToast('Role is required');
     }
 
-    const notify = d.notify === 'on';
+    const silent = d.notify !== 'on';
 
     const request: api.CreateClassUsersRequest = {
       roles: emailList.map((e) => ({
@@ -50,7 +50,7 @@
           student: role === 'student'
         }
       })),
-      notify: notify
+      silent: silent
     };
 
     dispatch('submit', request);


### PR DESCRIPTION
Closes #441 by adding a new option to avoid sending invite emails when adding users to group.