### PR TITLE
Patch: `send_invites` accepts 4 arguments

### DIFF
--- a/pingpong/users.py
+++ b/pingpong/users.py
@@ -277,7 +277,6 @@ class AddNewUsersManual(AddNewUsers):
                 invite,
                 magic_link,
                 86_400 * 7,
-                self.new_ucr.silent,
             )
 
 
@@ -307,5 +306,4 @@ class AddNewUsersScript(AddNewUsers):
                 invite,
                 magic_link,
                 86_400 * 7,
-                self.new_ucr.silent,
             )


### PR DESCRIPTION
Merging checks didn't catch the following change in #442: `send_invites` accepts 4 arguments, as we no longer pass the `silent` argument.