### PR TITLE
Pass LMS Course ID instead of DB PK when interacting with Canvas API

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -585,7 +585,7 @@ class CanvasCourseClient(ABC):
 
         self._sync_allowed(class_.lms_last_synced, now)
         self.new_ucr = CreateUserClassRoles(
-            roles=await self._get_course_users(class_.lms_class_id),
+            roles=await self._get_course_users(class_.lms_class.lms_id),
             silent=False,
             lms_tenant=self.config.tenant,
             lms_type=self.config.type,


### PR DESCRIPTION
Users might not have been able to sync the course roster in Canvas when the DB PK did not match the LMS Course ID, returning error Forbidden.