### PR TITLE
Canvas: Ensure removal of LMSClass objects

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1124,10 +1124,11 @@ class Class(Base):
         class_instance = await session.scalar(stmt)
 
         if class_instance.lms_class_id:
-            await LMSClass.delete_if_unused(session, class_instance.lms_class_id)
+            old_lms_class_id = class_instance.lms_class_id
             class_instance.lms_class_id = None
             class_instance.lms_status = schemas.LMSStatus.AUTHORIZED
             class_instance.lms_last_synced = None
+            await LMSClass.delete_if_unused(session, old_lms_class_id)
 
         # Remove class AND LMS account connection
         if kill_connection:


### PR DESCRIPTION
Fixes an issue where an `LMSClass` might not have been deleted when no longer associated with any `Class` object by removing the reference from the current Class before running the unused check.