### PR TITLE
Fix: Adding users silently might fail

### DIFF
--- a/pingpong/users.py
+++ b/pingpong/users.py
@@ -215,8 +215,7 @@ class AddNewUsers(ABC):
                 self.session, user.id, self.class_id
             )
 
-            if not self.new_ucr.silent:
-                invite_roles = []
+            invite_roles = []
             for role in ["admin", "teacher", "student"]:
                 if getattr(ucr.roles, role):
                     grants.append((f"user:{user.id}", role, f"class:{self.class_id}"))


### PR DESCRIPTION
Fixes an issue where adding users might fail when choosing not to send out email invites. Fixed the issue by making sure that `invite_roles` is always initialized.