### PR TITLE
Add Issue templates for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yaml
@@ -6,15 +6,16 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report! Please complete all questions and provide a descriptive title, e.g. Assistant files are missing after creating an assistant.
+        Thanks for taking the time to fill out this bug report! 
+        
+        Please complete all questions and provide a descriptive title, e.g. *Assistant files are missing after creating an assistant*
   - type: markdown
     attributes:
       value: "## Basic Information"
   - type: dropdown
     id: problem-area
     attributes:
-      label: Problem Area
-      description: Which area are you seeing an issue with?
+      label: Which area are you seeing an issue with?
       options:
         - Admin Page
         - Assistants — Creating & Managing
@@ -35,62 +36,53 @@ body:
   - type: dropdown
     id: problem-type
     attributes:
-      label: Issue type
-      description: What type of issue are you reporting?
+      label: What type of issue are you reporting?
       options:
         - Incorrect/Unexpected Behavior
         - Application Crash
         - Application Slow/Unresponsive
   - type: markdown
     attributes:
-      value: "## Description"
+      value: |
+        ## Description
+        Please describe the issue and what steps we can take to reproduce it.
   - type: textarea
     id: what-happened
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
       placeholder: Tell us what you see!
-    validations:
-      required: false
   - type: textarea
     id: to-reproduce
     attributes:
-      label: To Reproduce
+      label: Steps to reproduce
       description: A step-by-step set of instructions to reproduce the problem (if possible).
       placeholder: |
         1. Go to '...'
         2. Click on '....'
         3. Scroll down to '....'
         4. See error
-    validations:
-      required: false
   - type: textarea
     id: expected
     attributes:
-      label: Expected Behavior
+      label: Expected behavior
       description: A clear and concise description of what you expected to happen.
-    validations:
-      required: false
   - type: textarea
     id: actual
     attributes:
-      label: Actual Behavior
+      label: Actual behavior
       description: A clear and concise description of what actually happened.
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: "## Attachments"
   - type: textarea
     id: attachments
     attributes:
-      label: Relevant Files
+      label: Relevant files
       description: Please provide any relevant files or screenshots that might help demonstrate the problem. Use the Attach files button to add files and screenshots here.
-    validations:
-      required: false
   - type: textarea
     id: logs
     attributes:
-      label: Relevant Log Output
+      label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell

--- a/.github/ISSUE_TEMPLATE/02-suggestion.yaml
+++ b/.github/ISSUE_TEMPLATE/02-suggestion.yaml
@@ -6,15 +6,16 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request! Please complete all questions and provide a descriptive title, e.g. Assistant names should accept multi-line input.
+        Thanks for taking the time to fill out this feature request!
+        
+        Please complete all questions and provide a descriptive title, e.g. *Assistant names should accept multi-line input*
   - type: markdown
     attributes:
       value: "## Basic Information"
   - type: dropdown
     id: problem-area
     attributes:
-      label: Suggestion Area
-      description: Which area are you seeing an issue with?
+      label: Which area are you seeing an issue with?
       options:
         - Admin Page
         - Assistants — Creating & Managing
@@ -34,48 +35,40 @@ body:
         - Something else not on this list
   - type: markdown
     attributes:
-      value: "## Description"
+      value: |
+        ## Description
+        Please describe the issue and what steps we can take to reproduce it.
   - type: textarea
     id: what-happened
     attributes:
       label: Is your feature request related to a problem? Please describe.
       description: A clear and concise description of what the issue is.
       placeholder: Ex. I'm always frustrated when [...]
-    validations:
-      required: false
   - type: textarea
     id: to-reproduce
     attributes:
-      label: To Reproduce
+      label: Steps to reproduce
       description: A step-by-step set of instructions to reproduce the problem (if applicable).
       placeholder: |
         1. Go to '...'
         2. Click on '....'
         3. Scroll down to '....'
         4. See error
-    validations:
-      required: false
   - type: textarea
     id: suggestion
     attributes:
-      label: Suggestion
+      label: What's your suggestion?
       description: A clear and concise description of the solution you'd like to see.
-    validations:
-      required: false
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives Considered
+      label: What alternatives have you considered?
       description: A clear and concise description of any alternative solutions or features you've considered.
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: "## Attachments"
   - type: textarea
     id: attachments
     attributes:
-      label: Additional Context & Relevant Files
+      label: Additional context & relevant files
       description: Please provide any relevant context, files or screenshots that might help demonstrate the problem or suggestion. Use the Attach files button to add files and screenshots here.
-    validations:
-      required: false


### PR DESCRIPTION
Adds new issue templates for Bug Reports & Feature Requests that contributors can use to add new issues to the repo. This should save us all time by having to constantly monitor Slack for issues that may come up.