### PR TITLE
Remove the `class#admin` userset on `can_manage_assistants`

### DIFF
--- a/pingpong/authz/authz.fga
+++ b/pingpong/authz/authz.fga
@@ -20,7 +20,7 @@ type institution
 type class
   relations
     define parent: [institution]
-    define admin: [user] or admin from parent
+    define admin: admin from parent
     define teacher: [user]
     define student: [user]
     define supervisor: admin or teacher

--- a/pingpong/authz/authz.fga.json
+++ b/pingpong/authz/authz.fga.json
@@ -150,22 +150,13 @@
           "this": {}
         },
         "admin": {
-          "union": {
-            "child": [
-              {
-                "this": {}
-              },
-              {
-                "tupleToUserset": {
-                  "computedUserset": {
-                    "relation": "admin"
-                  },
-                  "tupleset": {
-                    "relation": "parent"
-                  }
-                }
-              }
-            ]
+          "tupleToUserset": {
+            "computedUserset": {
+              "relation": "admin"
+            },
+            "tupleset": {
+              "relation": "parent"
+            }
           }
         },
         "teacher": {
@@ -329,11 +320,7 @@
             ]
           },
           "admin": {
-            "directly_related_user_types": [
-              {
-                "type": "user"
-              }
-            ]
+            "directly_related_user_types": []
           },
           "teacher": {
             "directly_related_user_types": [


### PR DESCRIPTION
Fixes #502 and finalizes #488 by ensuring that only `admin` from `parent` can be group `admin`.