### PR TITLE
Replace "Course Assistant" Badge with "Group Assistant"

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/+page.svelte
@@ -194,7 +194,7 @@
                 {asst.name}
                 <div>
                   <Badge class="bg-blue-light-50 mt-1 text-blue-dark-30 text-xs normal-case"
-                    >Course assistant</Badge
+                    >Group assistant</Badge
                   >
                 </div>
               </DropdownItem>
@@ -220,7 +220,7 @@
                 <div>
                   {#if meta.isCourseAssistant}
                     <Badge class="bg-blue-light-50 mt-1 text-blue-dark-30 text-xs normal-case"
-                      >Course assistant</Badge
+                      >Group assistant</Badge
                     >
                   {:else if meta.isMyAssistant}
                     <Badge class="bg-blue-light-50 mt-1 text-blue-dark-30 text-xs normal-case"


### PR DESCRIPTION
Fixes #466. Should be the last leftover element from the course -> group transition.