### PR TITLE
Fix: Uploaded Files cannot be deleted

### DIFF
--- a/web/pingpong/src/lib/components/FilePlaceholder.svelte
+++ b/web/pingpong/src/lib/components/FilePlaceholder.svelte
@@ -75,8 +75,8 @@
   </div>
   {#if state !== 'pending' && state !== 'deleting'}
     <div class="absolute top-[-6px] right-[-6px] -delete-button">
-      <Button pill color="dark" class="p-0">
-        <CloseOutline class="w-4 h-4" on:click={deleteFile} />
+      <Button pill color="dark" class="p-0" on:click={deleteFile}>
+        <CloseOutline class="w-4 h-4" />
       </Button>
     </div>
   {/if}


### PR DESCRIPTION
Fixes #497 where the `on:click={deleteFile}` is applied to the `CloseOutline` icon, but the icon itself is inside a `Button` component.