### PR TITLE
Fix: SSO Redirect AssertionError

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -318,7 +318,12 @@ async def login_sso_saml_acs(provider: str, request: Request):
     for uid in user_ids:
         await merge(request.state.db, request.state.authz, user.id, uid)
 
-    next_url = saml_client.redirect_to()
+    url = "/"
+    if "RelayState" in saml_client._request_data["get_data"]:
+        url = saml_client._request_data["get_data"]["RelayState"]
+    elif "RelayState" in saml_client._request_data["post_data"]:
+        url = saml_client._request_data["post_data"]["RelayState"]
+    next_url = saml_client.redirect_to(url)
     return redirect_with_session(next_url, user.id, nowfn=get_now_fn(request))
 
 


### PR DESCRIPTION
Closes #515 by not relying on `saml_client.redirect_to` to find the correct `RelayState`. Also added a default fallback state of the homepage.