### PR TITLE
New workflow to push images on staging from PRs

### DIFF
--- a/.github/workflows/test-on-staging.yml
+++ b/.github/workflows/test-on-staging.yml
@@ -85,12 +85,12 @@ jobs:
           docker push ${{ vars.PINGPONG_WEB_REGISTRY }}:${{ env.ENVIRONMENT }}
           echo "Built and pushed Web Image (${{ env.WEB_VERSION }}) with ${{ env.ENVIRONMENT }} tag"
 
-      - name: Reply to the PR comment (Server image pushed)
+      - name: Reply to the PR comment (Web image pushed)
         env:
           ENVIRONMENT: 'stage'
           WEB_VERSION: ${{ env.WEB_VERSION }}
         run: |
-          COMMENT_BODY="*Built* and pushed *Server Image (${{ env.WEB_VERSION }})* for testing on *${{ env.ENVIRONMENT }}* environment"
+          COMMENT_BODY="*Built* and pushed *Web Image (${{ env.WEB_VERSION }})* for testing on *${{ env.ENVIRONMENT }}* environment"
           PR_NUMBER=${{ github.event.issue.number }}
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
                 -X POST \


### PR DESCRIPTION
This new workflow allows for testing on PR images without the need to push to `main`. This workflow pushes a `stage` and `pr_###` on the new-built image. When we push a different image with the same `stage` and `pr_###`, the old image remains untagged. A new lifecycle policy in the ECR repository collects and deletes those untagged images.

To trigger the workflow, type `/test-on-staging` in a PR comment.