### PR TITLE
Fix: Threads with empty annotations might fail to load

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -154,7 +154,7 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
         for content in message_delta["content"]:
             if content.get("type") == "text" and content["text"].get("annotations"):
                 for annotation in content["text"]["annotations"]:
-                    if annotation["type"] == "file_citation":
+                    if annotation.get("file_citation"):
                         annotation["file_citation"]["file_name"] = self.file_names.get(
                             annotation["file_citation"]["file_id"], ""
                         )

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -1478,7 +1478,7 @@ async def get_thread(
         for content in message.content:
             if content.type == "text" and content.text.annotations:
                 for annotation in content.text.annotations:
-                    if annotation.type == "file_citation":
+                    if annotation.type == "file_citation" and annotation.file_citation:
                         annotation.file_citation.file_name = file_names.get(
                             annotation.file_citation.file_id, "Unknown citation"
                         )
@@ -1582,7 +1582,7 @@ async def list_thread_messages(
         for content in message.content:
             if content.type == "text" and content.text.annotations:
                 for annotation in content.text.annotations:
-                    if annotation.type == "file_citation":
+                    if annotation.type == "file_citation" and annotation.file_citation:
                         annotation.file_citation.file_name = file_names.get(
                             annotation.file_citation.file_id, "Unknown citation"
                         )


### PR DESCRIPTION
Closes #513 by making sure the nested dictionaries exist before trying to access them.