### PR TITLE
OAI Thread API: Handle `incomplete` run status

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -652,6 +652,7 @@ class OpenAIRun(BaseModel):
         | Literal["cancelling"]
         | Literal["cancelled"]
         | Literal["failed"]
+        | Literal["incomplete"]
         | Literal["completed"]
         | Literal["expired"]
     )

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -1650,7 +1650,13 @@ async def get_last_run(
         return {"thread": thread, "run": last_run}
 
     t0 = time.monotonic()
-    while last_run.status not in {"completed", "failed", "expired", "cancelled"}:
+    while last_run.status not in {
+        "completed",
+        "failed",
+        "incomplete",
+        "expired",
+        "cancelled",
+    }:
         if time.monotonic() - t0 > TIMEOUT:
             raise HTTPException(
                 status_code=504, detail="Timeout waiting for run to complete"

--- a/scripts/quickload.py
+++ b/scripts/quickload.py
@@ -271,7 +271,13 @@ class AssistantsApiRateLimitLoadTest(LoadTest):
         )
 
         # Poll until run is in terminal state
-        while run.status not in {"completed", "failed", "expired", "cancelled"}:
+        while run.status not in {
+            "completed",
+            "failed",
+            "incomplete",
+            "expired",
+            "cancelled",
+        }:
             time.sleep(1)
             run = client.beta.threads.runs.retrieve(
                 run_id=run.id,

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1286,6 +1286,7 @@ export type OpenAIRun = {
     | 'cancelling'
     | 'cancelled'
     | 'failed'
+    | 'incomplete'
     | 'completed'
     | 'expired';
   thread_id: string;
@@ -1704,7 +1705,7 @@ export const postSupportRequest = async (f: Fetcher, data: SupportRequest) => {
 /**
  * OpenAI generation states.
  */
-const TERMINAL_STATES = new Set(['expired', 'completed', 'failed', 'cancelled']);
+const TERMINAL_STATES = new Set(['expired', 'completed', 'incomplete', 'failed', 'cancelled']);
 
 /**
  * Check if a run is in a terminal state.


### PR DESCRIPTION
Closes #472 by introducing a new accepted `status` type of `incomplete`. The treatment shouldn't be any different than the other terminal states. Of note, for future reference, we might want to surface the `incomplete_details` (e.g. `max_prompt_tokens`) just like we could surface the `last_error`.