### PR TITLE
Allow Moderators edit any assistant they have access to

### DIFF
--- a/pingpong/authz/authz.fga
+++ b/pingpong/authz/authz.fga
@@ -54,10 +54,10 @@ type assistant
     define parent: [class]
     define owner: [user]
     define can_edit: owner or can_manage_assistants from parent or (can_view and supervisor from parent)
-    define can_delete: owner or can_manage_assistants from parent
+    define can_delete: owner or can_manage_assistants from parent or (can_view and supervisor from parent)
     define can_view: [class#member] or owner or can_manage_assistants from parent
     define can_interact_with: can_view
-    define can_publish: (owner and can_publish_assistants from parent) or (can_manage_assistants from parent and can_publish_assistants from parent)
+    define can_publish: (owner and can_publish_assistants from parent) or (can_manage_assistants from parent and can_publish_assistants from parent) or (can_view and supervisor from parent)
 
 type user_file
   relations

--- a/pingpong/authz/authz.fga.json
+++ b/pingpong/authz/authz.fga.json
@@ -682,6 +682,27 @@
                     "relation": "parent"
                   }
                 }
+              },
+              {
+                "intersection": {
+                  "child": [
+                    {
+                      "computedUserset": {
+                        "relation": "can_view"
+                      }
+                    },
+                    {
+                      "tupleToUserset": {
+                        "computedUserset": {
+                          "relation": "supervisor"
+                        },
+                        "tupleset": {
+                          "relation": "parent"
+                        }
+                      }
+                    }
+                  ]
+                }
               }
             ]
           }
@@ -756,6 +777,27 @@
                       "tupleToUserset": {
                         "computedUserset": {
                           "relation": "can_publish_assistants"
+                        },
+                        "tupleset": {
+                          "relation": "parent"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "intersection": {
+                  "child": [
+                    {
+                      "computedUserset": {
+                        "relation": "can_view"
+                      }
+                    },
+                    {
+                      "tupleToUserset": {
+                        "computedUserset": {
+                          "relation": "supervisor"
                         },
                         "tupleset": {
                           "relation": "parent"


### PR DESCRIPTION
Fixes #496 by changing the assistant `can_edit`, `can_delete` and `can_publish` permissions.