### PR TITLE
Update `uvicorn` dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN poetry install --only main --no-interaction --no-ansi
 
 COPY . /code
 
-CMD ["gunicorn", "pingpong:server", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:8000", "--workers", "4"]
+CMD ["gunicorn", "pingpong:server", "-k", "uvicorn_worker.UvicornWorker", "-b", "0.0.0.0:8000", "--workers", "4"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
         node_env: development
 
   srv:
-    command: ["gunicorn", "pingpong:server", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:8000", "--workers", "4", "--log-level", "debug"]
+    command: ["gunicorn", "pingpong:server", "-k", "uvicorn_worker.UvicornWorker", "-b", "0.0.0.0:8000", "--workers", "4", "--log-level", "debug"]
     deploy:
       replicas: 1
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2233,6 +2233,8 @@ files = [
     {file = "orjson-3.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:960db0e31c4e52fa0fc3ecbaea5b2d3b58f379e32a95ae6b0ebeaa25b93dfd34"},
     {file = "orjson-3.10.6-cp312-none-win32.whl", hash = "sha256:a6ea7afb5b30b2317e0bee03c8d34c8181bc5a36f2afd4d0952f378972c4efd5"},
     {file = "orjson-3.10.6-cp312-none-win_amd64.whl", hash = "sha256:874ce88264b7e655dde4aeaacdc8fd772a7962faadfb41abe63e2a4861abc3dc"},
+    {file = "orjson-3.10.6-cp313-none-win32.whl", hash = "sha256:efdf2c5cde290ae6b83095f03119bdc00303d7a03b42b16c54517baa3c4ca3d0"},
+    {file = "orjson-3.10.6-cp313-none-win_amd64.whl", hash = "sha256:8e190fe7888e2e4392f52cafb9626113ba135ef53aacc65cd13109eb9746c43e"},
     {file = "orjson-3.10.6-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:66680eae4c4e7fc193d91cfc1353ad6d01b4801ae9b5314f17e11ba55e934183"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caff75b425db5ef8e8f23af93c80f072f97b4fb3afd4af44482905c9f588da28"},
     {file = "orjson-3.10.6-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3722fddb821b6036fd2a3c814f6bd9b57a89dc6337b9924ecd614ebce3271394"},
@@ -3393,13 +3395,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.28.0"
+version = "0.31.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uvicorn-0.28.0-py3-none-any.whl", hash = "sha256:6623abbbe6176204a4226e67607b4d52cc60ff62cda0ff177613645cefa2ece1"},
-    {file = "uvicorn-0.28.0.tar.gz", hash = "sha256:cab4473b5d1eaeb5a0f6375ac4bc85007ffc75c3cc1768816d9e5d589857b067"},
+    {file = "uvicorn-0.31.0-py3-none-any.whl", hash = "sha256:cac7be4dd4d891c363cd942160a7b02e69150dcbc7a36be04d5f4af4b17c8ced"},
+    {file = "uvicorn-0.31.0.tar.gz", hash = "sha256:13bc21373d103859f68fe739608e2eb054a816dea79189bc3ca08ea89a275906"},
 ]
 
 [package.dependencies]
@@ -3409,6 +3411,21 @@ typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.2.0"
+description = "Uvicorn worker for Gunicorn! ✨"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "uvicorn_worker-0.2.0-py3-none-any.whl", hash = "sha256:65dcef25ab80a62e0919640f9582216ee05b3bb1dc2f0e58b354ca0511c398fb"},
+    {file = "uvicorn_worker-0.2.0.tar.gz", hash = "sha256:f6894544391796be6eeed37d48cae9d7739e5a105f7e37061eccef2eac5a0295"},
+]
+
+[package.dependencies]
+gunicorn = ">=20.1.0"
+uvicorn = ">=0.14.0"
 
 [[package]]
 name = "uvloop"
@@ -3913,4 +3930,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "eee20539dd6aa320cd90223ea5b389d4a2b4dd40a7ff9c73c907522ea2670897"
+content-hash = "e860c38b3904bf4591067a9a45d1f5e3e333db1256f802848d95722d56e9c529"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ async-throttle = "1.0.0"
 opentelemetry-api = "^1.20.0"
 requests = "^2.32.2"
 fastapi = "0.110.0"
-uvicorn = "0.28.0"
+uvicorn = "0.31.0"
 aiohttp = "^3.10.2"
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.23"}
 pyjwt = "^2.8.0"
@@ -47,6 +47,7 @@ arrow = "^1.3.0"
 humanize = "^4.10.0"
 croniter = "^3.0.3"
 aioboto3 = "^13.1.1"
+uvicorn-worker = "^0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files, upgrading the `uvicorn` package, the current version of which was causing excessive `ClientDisconnected` errors (see [here](https://github.com/encode/uvicorn/issues/2271)).

Dependency updates:

* `pyproject.toml`: Upgraded `uvicorn` from `0.28.0` to `0.31.0`. 
* Added `uvicorn-worker` version `0.2.0` as a new dependency.

Configuration updates:

* `Dockerfile`: Updated the `CMD` instruction to use `uvicorn_worker.UvicornWorker` instead of `uvicorn.workers.UvicornWorker`, which is [deprecated](https://www.uvicorn.org/deployment/#gunicorn) starting in `uvicorn` version [`0.30.0`](https://github.com/encode/uvicorn/releases/tag/0.30.0).
* `docker-compose.dev.yml`: Modified the `command` for the `srv` service to use `uvicorn_worker.UvicornWorker` to match the updated worker dependency.

Breaking changes:
* Because of the deprecated `uvicorn.workers` module, the server task definitions need to be updated on ECS before deployment.