### PR TITLE
Fix: `generate_name` might be rate-limited

### DIFF
--- a/pingpong/artifacts.py
+++ b/pingpong/artifacts.py
@@ -30,7 +30,15 @@ class S3ArtifactStore(BaseArtifactStore):
                 ContentType=content_type,
                 ContentDisposition=f'attachment; filename="{name}"',
             )
-            return name
+            return await s3.generate_presigned_url(
+                "get_object",
+                Params={
+                    "Bucket": self._bucket,
+                    "Key": name,
+                    "ResponseContentDisposition": f'attachment; "filename={name}"',
+                },
+                ExpiresIn=self._expiry,
+            )
 
 
 class LocalArtifactStore(BaseArtifactStore):


### PR DESCRIPTION
Fixes an error where OAI might return a `RateLimitExceeded` error. In that case, we simply return `None` and defer the name generation to the next message sent by the user.