### PR TITLE
Add status embed for incidents and maintenance

### DIFF
--- a/web/pingpong/src/routes/+layout.svelte
+++ b/web/pingpong/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
       </Main>
     </div>
   </div>
+  <script src="https://pingpong-hks.statuspage.io/embed/script.js"></script>
 {:else if data.isPublicPage}
   <div class=" w-full flex lg:gap-4 h-[calc(100vh-3rem)]">
     <div class="basis-[320px] shrink-0 grow-0 min-w-0">


### PR DESCRIPTION
Adds a status embed for the PingPong status page (https://pingpong-hks.statuspage.io). Whenever an incident is created, or maintenance is underway, users will get a banner in the bottom right corner of the page informing them of the current app status.

Notes:
- The status embed is set to only appear when the user is logged in and onboarded for now, but we can decide to add the status embed in additional places, e.g. the log-in page.
- With this addition, we can use the [StatusPage API](https://developer.statuspage.io) in the future to update our status page server-side, and the [Public Page API](https://pingpong-hks.statuspage.io/api) to inform users of any upcoming maintenance.
- We should be able to use the same Public Page API from OAI's page (https://status.openai.com/api) to programmatically monitor for incidents and update our Status Page accordingly.

<img width="360" alt="image" src="https://github.com/user-attachments/assets/b76e309e-69b9-474b-af32-91725332294c">

<img width="393" alt="image" src="https://github.com/user-attachments/assets/22f5bb76-756d-43e0-8208-987bd3dd1207">