### PR TITLE
Patch: Show Export threads option to Moderators in the UI

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
@@ -191,7 +191,7 @@
     }) as FileUploadInfo[];
 
   $: hasApiKey = !!data?.class?.api_key;
-  $: isAdmin = !!data?.grants?.isAdmin;
+  $: canExportThreads = !!data?.grants?.isAdmin || !!data?.grants?.isTeacher;
   $: canEditClassInfo = !!data?.grants?.canEditInfo;
   $: canManageClassUsers = !!data?.grants?.canManageUsers;
   $: canUploadClassFiles = !!data?.grants?.canUploadClassFiles;
@@ -607,7 +607,7 @@
         >More options <ChevronDownOutline /></Button
       >
       <Dropdown class="overflow-y-auto">
-        {#if isAdmin}
+        {#if canExportThreads}
           <DropdownItem
             on:touchstart={() => (exportThreadsModal = true)}
             on:click={() => (exportThreadsModal = true)}


### PR DESCRIPTION
Even through we allowed Moderators to access the Export Threads API endpoint in #535, we still need to show the Export Threads option in the UI for Moderators.