### PR TITLE
Fix: Manually-added users always invited as Members

### DIFF
--- a/web/pingpong/src/lib/components/BulkAddUsers.svelte
+++ b/web/pingpong/src/lib/components/BulkAddUsers.svelte
@@ -121,9 +121,9 @@
         email: e.email,
         display_name: e.name,
         roles: {
-          admin: role === 'admin',
-          teacher: role === 'teacher',
-          student: role === 'student'
+          admin: selectedRole === 'admin',
+          teacher: selectedRole === 'teacher',
+          student: selectedRole === 'student'
         }
       })),
       silent: silentAdd


### PR DESCRIPTION
Fixes an issue where users added manually through the "Invite new users" would always be assigned to the default (Member) permissions role.