### PR TITLE
Fix: Thread-related Vector Stores are not attached to thread

### DIFF
--- a/pingpong/vector_stores.py
+++ b/pingpong/vector_stores.py
@@ -34,7 +34,6 @@ async def create_vector_store(
             metadata={
                 "class_id": class_id,
             },
-            expires_after={"anchor": "last_active_at", "days": 1460},
         )
 
     except openai.BadRequestError as e:


### PR DESCRIPTION
Fixes an issue where empty thread vector stores we created were not attached as tool resources to the relevant thread. This resulted in OAI creating a second vector store with a set (7 day) expiration date. A side effect of this issue is that we were keeping track of the wrong vector store, which might result in incomplete thread deletions.