### PR TITLE
Fix: Do not show admin information in Group Moderators table for users who are not members of a group

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -413,6 +413,25 @@ class User(Base):
         return [row.User for row in result]
 
     @classmethod
+    async def get_all_by_id_if_in_class(
+        cls, session: AsyncSession, ids: List[int], class_id: int
+    ) -> List["User"]:
+        if not ids:
+            return []
+
+        stmt = (
+            select(User)
+            .join(UserClassRole)
+            .where(
+                User.id.in_([int(id_) for id_ in ids]),
+                UserClassRole.class_id == class_id,
+            )
+        )
+
+        result = await session.execute(stmt)
+        return [row.User for row in result]
+
+    @classmethod
     async def get_display_name(cls, session: AsyncSession, id_: int) -> str | None:
         stmt = select(User.display_name, User.first_name, User.last_name).where(
             User.id == int(id_)

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -1123,7 +1123,9 @@ async def list_class_supervisors(class_id: str, request: Request):
         "supervisor",
         "user",
     )
-    supervisors = await models.User.get_all_by_id(request.state.db, supervisor_ids)
+    supervisors = await models.User.get_all_by_id_if_in_class(
+        request.state.db, supervisor_ids, int(class_id)
+    )
     supervisors_users = []
     for supervisor in supervisors:
         supervisors_users.append(


### PR DESCRIPTION
Closes #588 by filtering out users who are Moderators in a group, but are not members of the group. These users technically have access to the group, but they are not active members of a group, and their inclusion in the Group Moderators table will cause confusion to members.