### PR TITLE
Canvas Sync: More logs to diagnose missing SSO tenant or ID

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -561,6 +561,10 @@ class CanvasCourseClient(ABC):
                 if enrollment["type"] in ["TeacherEnrollment", "TaEnrollment"]:
                     is_teacher = True
                     break
+            if not user.get(self.config.sso_target):
+                logging.warning(
+                    f"User {user['email']} does not have an SSO ID in the Canvas response. Data provided:]\n{json.dumps(user, indent=2)}"
+                )
             yield CreateUserClassRole(
                 email=user["email"],
                 sso_id=user.get(self.config.sso_target),

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -383,6 +383,14 @@ class User(Base):
         initial_state: schemas.UserState = schemas.UserState.UNVERIFIED,
         display_name: str | None = None,
     ) -> "User":
+        if not provider:
+            logging.warning(
+                f"get_by_email_sso: Provider is missing, identifier is {identifier}"
+            )
+        if not identifier:
+            logging.warning(
+                f"get_by_email_sso: Identifier is missing, provider is {provider}"
+            )
         existing = await cls.get_by_email_sso(
             session, email, provider=provider, identifier=identifier
         )

--- a/pingpong/users.py
+++ b/pingpong/users.py
@@ -317,6 +317,14 @@ class AddNewUsers(ABC):
                     )
                 )
                 continue
+            if not self.new_ucr.sso_tenant:
+                logging.warning(
+                    f"add_users_to_class: Warning for User {ucr.email}, SSO ID: {ucr.sso_id}: No SSO tenant provided."
+                )
+            if not ucr.sso_id:
+                logging.warning(
+                    f"add_users_to_class: Warning for User {ucr.email}, SSO tenant: {self.new_ucr.sso_tenant}: No SSO ID provided."
+                )
             user = await models.User.get_or_create_by_email_sso(
                 self.session,
                 ucr.email,


### PR DESCRIPTION
Adds more logs to diagnose the issue of get_or_create_by_email_sso not receiving an SSO ID or tenant in some edge cases.