### PR TITLE
Canvas Sync: Don't raise UI error when syncing through script

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -618,6 +618,11 @@ class CanvasCourseClient(ABC):
         """Update the user roles for the class."""
         pass
 
+    @abstractmethod
+    def _raise_sync_error_if_manual(self) -> None:
+        """Raise an error if the sync is manual."""
+        pass
+
     async def sync_roster(self) -> None:
         """Sync the roster for the class."""
 
@@ -634,10 +639,9 @@ class CanvasCourseClient(ABC):
             sso_tenant=self.config.sso_tenant,
         )
         if self.missing_sso_ids:
-            raise CanvasException(
-                code=403,
-                detail="Some users in the Canvas class do not have SIS information. Please ask another privileged user to set up Canvas Sync. If you're still facing issues, contact your Canvas administrator.",
-            )
+            await Class.mark_lms_sync_error(self.db, self.class_id)
+            self._raise_sync_error_if_manual()
+
         await self._update_user_roles()
         await Class.update_last_synced(self.db, self.class_id)
 
@@ -681,6 +685,12 @@ class ManualCanvasClient(CanvasCourseClient):
             str(self.class_id), self.new_ucr, self.request, self.tasks
         ).add_new_users()
 
+    def _raise_sync_error_if_manual(self):
+        raise CanvasException(
+            code=403,
+            detail="Some users in the Canvas class do not have SIS information. Please ask another privileged user to set up Canvas Sync. If you're still facing issues, contact your Canvas administrator.",
+        )
+
 
 class LightweightCanvasClient(CanvasCourseClient):
     """A lightweight version of the Canvas client that does not support syncing or updating user roles."""
@@ -711,6 +721,9 @@ class LightweightCanvasClient(CanvasCourseClient):
             "LightweightCanvasClient does not support updating user roles."
         )
 
+    def _raise_sync_error_if_manual(self):
+        raise NotImplementedError("LightweightCanvasClient does not support syncing.")
+
 
 class ScriptCanvasClient(CanvasCourseClient):
     def __init__(
@@ -739,6 +752,9 @@ class ScriptCanvasClient(CanvasCourseClient):
         await AddNewUsersScript(
             str(self.class_id), self.user_id, self.db, self.client, self.new_ucr
         ).add_new_users()
+
+    def _raise_sync_error_if_manual(self):
+        pass
 
 
 async def canvas_sync_all(


### PR DESCRIPTION
Fixes an issue where the Canvas Sync script would terminate after a class with missing netIDs was encountered. This was caused after a CanvasException was raised that is destined to provide an informative error when users manually sync classes. This issue was resolved by only raising the error when the Syncing module is called manually by a user.

This PR also resolves an issue where classes with missing netIDs were not marked as having a Canvas connection error.