### PR TITLE
Fix: Vector Store files may not be processed before Thread Run

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -2349,6 +2349,13 @@ async def create_run(
         file_names = await models.Thread.get_file_search_files(
             request.state.db, thread.id
         )
+        vector_store_id = (
+            await models.VectorStore.get_vector_store_id_by_id(
+                request.state.db, thread.vector_store_id
+            )
+            if thread.vector_store_id
+            else None
+        )
         stream = run_thread(
             openai_client,
             class_id=class_id,
@@ -2356,6 +2363,7 @@ async def create_run(
             assistant_id=asst.assistant_id,
             message=[],
             file_names=file_names,
+            vector_store_id=vector_store_id,
         )
     except Exception as e:
         logger.exception("Error running thread")
@@ -2496,6 +2504,13 @@ async def send_message(
         file_names = await models.Thread.get_file_search_files(
             request.state.db, thread.id
         )
+        vector_store_id_ = (
+            await models.VectorStore.get_vector_store_id_by_id(
+                request.state.db, thread.vector_store_id
+            )
+            if thread.vector_store_id
+            else None
+        )
         # Create a generator that will stream chunks to the client.
         stream = run_thread(
             openai_client,
@@ -2507,6 +2522,7 @@ async def send_message(
             file_names=file_names,
             file_search_file_ids=data.file_search_file_ids,
             code_interpreter_file_ids=data.code_interpreter_file_ids,
+            vector_store_id=vector_store_id_,
         )
     except Exception:
         logger.exception("Error running thread")


### PR DESCRIPTION
Fixes #595 (and #317), where an assistant might not have visibility into a files uploaded in a Thread's Vector Store.

## Background
OpenAI's [technical notes](https://platform.openai.com/docs/assistants/tools/file-search#ensuring-vector-store-readiness-before-creating-runs) state:

> **Ensuring vector store readiness before creating runs**
> We highly recommend that you ensure all files in a vector_store are fully processed before you create a run. This will ensure that all the data in your vector_store is searchable. You can check for vector_store readiness by using the polling helpers in our SDKs, or by manually polling the vector_store object to ensure the [status](https://platform.openai.com/docs/api-reference/vector-stores/object#vector-stores/object-status) is completed.
> 
> As a fallback, we've built a 60 second maximum wait in the Run object when the thread’s vector store contains files that are still being processed. This is to ensure that any files your users upload in a thread a fully searchable before the run proceeds. This fallback wait does not apply to the assistant's vector store.

It sounds like we should be doing the same, even though we're using their helper `message` `attachments` parameter when creating a message.  However, as noted in #317, we no longer upload files ourselves at the thread level, so we cannot use `create_and_poll` or `upload_and_poll`. Instead, we have to call `poll` on every single file uploaded to the vector store in the current message run.