### PR TITLE
Canvas Sync: Do not update roster when `missing_sso_ids`

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -770,10 +770,17 @@ class ScriptCanvasClient(CanvasCourseClient):
 
 
 async def canvas_sync_all(
-    session: AsyncSession, authz_: OpenFgaAuthzClient, canvas_backend: CanvasSettings, sync_without_sso_ids: bool = False, sync_error_classes: bool = False
+    session: AsyncSession,
+    authz_: OpenFgaAuthzClient,
+    canvas_backend: CanvasSettings,
+    sync_without_sso_ids: bool = False,
+    sync_classes_with_error_status: bool = False,
 ) -> None:
     async for class_ in Class.get_all_to_sync(
-        session, canvas_backend.tenant, LMSType(canvas_backend.type), sync_error_classes
+        session,
+        canvas_backend.tenant,
+        LMSType(canvas_backend.type),
+        sync_classes_with_error_status=sync_classes_with_error_status,
     ):
         logger.info(f"Syncing class {class_.id}...")
         async with ScriptCanvasClient(

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1420,7 +1420,11 @@ class Class(Base):
 
     @classmethod
     async def get_all_to_sync(
-        cls, session: AsyncSession, lms_tenant: str, lms_type: schemas.LMSType, sync_error_classes: bool = False
+        cls,
+        session: AsyncSession,
+        lms_tenant: str,
+        lms_type: schemas.LMSType,
+        sync_classes_with_error_status: bool = False,
     ) -> AsyncGenerator["Class", None]:
         """
         For syncing CRON job: Get all classes with an active
@@ -1428,10 +1432,10 @@ class Class(Base):
         """
         lms_status_condition = (
             or_(
-            Class.lms_status == schemas.LMSStatus.LINKED,
-            Class.lms_status == schemas.LMSStatus.ERROR,
+                Class.lms_status == schemas.LMSStatus.LINKED,
+                Class.lms_status == schemas.LMSStatus.ERROR,
             )
-            if sync_error_classes
+            if sync_classes_with_error_status
             else Class.lms_status == schemas.LMSStatus.LINKED
         )
         stmt = (


### PR DESCRIPTION
Fixes #638. Also adds options to sync classes with Sync Errors and not skip students with missing SSO IDs.