### PR TITLE
Sync users with missing SSO IDs when using `sync_without_sso_ids`

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -582,7 +582,8 @@ class CanvasCourseClient(ABC):
                     f"User {user['email']} does not have an SSO ID in the Canvas response. Marking class as having a sync error."
                 )
                 self.missing_sso_ids = True
-                break
+                if not self.sync_without_sso_ids:
+                    break
             yield CreateUserClassRole(
                 email=user["email"],
                 sso_id=user.get(self.config.sso_target),


### PR DESCRIPTION
Complements #639 