### PR TITLE
Fix, Docker Dev Compose: `fastapi dev` doesn't support `workers`

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,15 +8,18 @@ services:
         node_env: development
 
   srv:
-    command: ["fastapi", "dev", "pingpong", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+    restart: no
+    command: ["fastapi", "run", "pingpong", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
     deploy:
       replicas: 1
 
   authz:
+    restart: always
     deploy:
       replicas: 1
 
   db:
+    restart: always
     platform: linux/amd64
     image: postgres:15.5
     container_name: pingpong-db


### PR DESCRIPTION
Uses `fastapi run` for `--workers` support. Also edits the `restart` policy for all containers when using the dev compose script to only restart `auth` and `db` containers, which should follow the most common development case of running the server outside Docker with a auto-reload option.