### PR TITLE
CLI for Thread Exports with User Emails

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -39,7 +39,7 @@ from .time import convert_seconds
 from .saml import get_saml2_client, get_saml2_settings, get_saml2_attrs
 
 from .ai import (
-    export_class_threads,
+    export_class_threads_anonymized,
     format_instructions,
     get_thread_conversation_name,
     get_initial_thread_conversation_name,
@@ -1957,7 +1957,7 @@ async def export_class(
             detail="Cannot export private classes",
         )
     tasks.add_task(
-        export_class_threads,
+        export_class_threads_anonymized,
         openai_client,
         class_id,
         request.state.session.user.id,


### PR DESCRIPTION
This pull request introduces a new functionality to export class threads with user emails and includes some refactoring to support this feature.

### New functionality for exporting class threads:

* [`pingpong/__main__.py`](diffhunk://#diff-79e530e369f73848d59c57d2a11153d4e681a1cd5bcfc771319926e74c6cc40bR61-R65): Added a new command group `export` and a command `export_threads_with_emails` to export class threads along with user emails. [[1]](diffhunk://#diff-79e530e369f73848d59c57d2a11153d4e681a1cd5bcfc771319926e74c6cc40bR61-R65) [[2]](diffhunk://#diff-79e530e369f73848d59c57d2a11153d4e681a1cd5bcfc771319926e74c6cc40bR449-R488)
* [`pingpong/ai.py`](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96R489-R524): Introduced new methods `export_class_threads_with_emails` and `export_class_threads_anonymized` to handle exporting threads with and without user emails. [[1]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96R489-R524) [[2]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96L506-R550)

### Refactoring to support the new functionality:

* [`pingpong/ai.py`](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96L506-R550): Modified the `export_class_threads` method to include an optional parameter `include_user_emails` and updated the CSV export logic to conditionally include user emails. [[1]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96L506-R550) [[2]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96L530-R575) [[3]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96R587) [[4]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96L554-R605) [[5]](diffhunk://#diff-731b9246557c6fda4efa604e5ccbd105a5ae4d71e2f7defea24b2afbb2074c96R615)
* [`pingpong/server.py`](diffhunk://#diff-00ab1e9013d6347c440ad972a6c85a4b38a9b2e7d615f0f81c7932b209ffc14aL42-R42): Updated references to use the new `export_class_threads_anonymized` method instead of the old `export_class_threads` method. [[1]](diffhunk://#diff-00ab1e9013d6347c440ad972a6c85a4b38a9b2e7d615f0f81c7932b209ffc14aL42-R42) [[2]](diffhunk://#diff-00ab1e9013d6347c440ad972a6c85a4b38a9b2e7d615f0f81c7932b209ffc14aL1960-R1960)