### PR TITLE
Support for simple text help module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ load_test_results_*
 # Saml
 saml/**/*.key
 saml/**/*.crt
+
+# Local artifact store
+uploads/


### PR DESCRIPTION
 - Supports a simple custom text setting for the help/support module in the config
 - Refactor the discord/"none" support settings to be more customizable as well
 - Add smart default for artifact store to simplify local development. (By default artifacts will go into an ignored `./uploads` directory.)

When this is released we will need to change the prod `[support]` config block to the following:

```
[support]
type = "text"
text = "For any other questions about PingPong usage, including enrollment issues, please contact <a class='underline' href='mailto:pingpong-help@hks.harvard.edu?subject=%5BPingPong%5D%20App%20support%20request'>pingpong-help@hks.harvard.edu</a>."
```
