### PR TITLE
Add some default ssl in the web container

### DIFF
--- a/web/pingpong/Dockerfile
+++ b/web/pingpong/Dockerfile
@@ -28,10 +28,22 @@ RUN pnpm build -d
 # Production image is just nginx with assets copied in
 FROM nginx:1.27.0
 
+RUN apt-get update && apt-get install ca-certificates -y && update-ca-certificates
+
 ARG host=0.0.0.0
 ARG port=3000
+ARG ssl_port=3001
+
+RUN openssl req -trustout -x509 -newkey rsa:4096 -sha256 -nodes \
+    -keyout /etc/ssl/private/pingpong-self-signed.key \
+    -out /etc/ssl/certs/pingpong-self-signed.crt \
+    -days 3650 \
+    -subj "/C=US/ST=MA/L=Cambridge/O=Harvard Kennedy School/OU=CPL/CN=pingpong-web.private"
 
 ENV NGINX_LISTEN=$host:$port
+ENV NGINX_LISTEN_SSL=$host:$ssl_port
+ENV NGINX_SSL_CERT=/etc/ssl/certs/pingpong-self-signed.crt
+ENV NGINX_SSL_CERT_KEY=/etc/ssl/private/pingpong-self-signed.key
 
 COPY default.conf.template /etc/nginx/templates/
 COPY --from=buildweb /app/build /usr/share/nginx/html

--- a/web/pingpong/default.conf.template
+++ b/web/pingpong/default.conf.template
@@ -1,5 +1,9 @@
 server {
     listen ${NGINX_LISTEN};
+    listen ${NGINX_LISTEN_SSL} ssl;
+
+    ssl_certificate ${NGINX_SSL_CERT};
+    ssl_certificate_key ${NGINX_SSL_CERT_KEY};
 
     http2 on;
 


### PR DESCRIPTION
Generate a self-signed certificate in the Dockerfile for the web service and add an SSL listener to the nginx template. This can be overridden by env variables to use a different certificate, but at least ensures we can always handle SSL requests in the web service.