### PR TITLE
Allow self-signed certs srv<->authz

### DIFF
--- a/pingpong/authz/openfga.py
+++ b/pingpong/authz/openfga.py
@@ -271,6 +271,7 @@ class OpenFgaAuthzDriver(AuthzDriver):
         store: str,
         model_config: str,
         key: str | None = None,
+        verify_ssl: bool = True,
     ):
         cred: Credentials | None = None
         if key:
@@ -286,6 +287,10 @@ class OpenFgaAuthzDriver(AuthzDriver):
             api_host=host,
             credentials=cred,
         )
+        # NOTE(jnu): there is an undocumented parameter that allows self-signed certs. See:
+        # https://github.com/openfga/python-sdk/blob/13b1b0b6eb7e16b95abc6661c326796faba08f5c/openfga_sdk/rest.py#L67
+        self.config.verify_ssl = verify_ssl
+
         self.store = store
         self.model_config = model_config
 

--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -28,6 +28,7 @@ class OpenFgaAuthzSettings(BaseSettings):
     store: str = Field("pingpong")
     cfg: str = Field("authz.json")
     key: str | None = Field(None)
+    verify_ssl: bool = Field(True)
 
     @cached_property
     def driver(self):
@@ -37,6 +38,7 @@ class OpenFgaAuthzSettings(BaseSettings):
             store=self.store,
             key=self.key,
             model_config=self.cfg,
+            verify_ssl=self.verify_ssl,
         )
 
 


### PR DESCRIPTION
Adds a config option to disable strict ssl hostname verification on the client used to communicate with the OpenFGA server.

This uses an undocumented feature of the OpenFGA client config: https://github.com/openfga/python-sdk/blob/13b1b0b6eb7e16b95abc6661c326796faba08f5c/openfga_sdk/rest.py#L67

The alternative of setting up a private CA to share between the service containers is too much trouble compared to the modest benefit it would add.