### PR TITLE
Patch: `merge_external_logins` with new constraints

### DIFF
--- a/pingpong/merge.py
+++ b/pingpong/merge.py
@@ -176,19 +176,19 @@ async def merge_lms_users(
 async def merge_external_logins(
     session: AsyncSession, new_user_id: int, old_user_id: int
 ) -> None:
-    upsert_stmt = text("""
-    INSERT INTO external_logins (user_id, provider, identifier)
-    SELECT :new_user_id, provider, identifier
-    FROM external_logins
-    WHERE user_id = :old_user_id
-    ON CONFLICT (user_id, provider) DO NOTHING
-    """)
+    stmt = select(ExternalLogin).where(ExternalLogin.user_id == old_user_id)
+    old_logins = await session.scalars(stmt)
 
-    await session.execute(
-        upsert_stmt, {"new_user_id": new_user_id, "old_user_id": old_user_id}
-    )
+    for old_login in old_logins:
+        # Use the create_or_update method to migrate each login to the new user
+        await ExternalLogin.create_or_update(
+            session,
+            user_id=new_user_id,
+            provider=old_login.provider,
+            identifier=old_login.identifier,
+        )
 
-    # Remove the old user from all external logins
+    # Remove all external logins associated with the old user
     delete_stmt = delete(ExternalLogin).where(ExternalLogin.user_id == old_user_id)
     await session.execute(delete_stmt)
 


### PR DESCRIPTION
As in #675, #667 removed a previous unique constraint in ExternalLogin. We can now simply use ExternalLogin.create_or_update that encapsulates the conflict-handling logic.