### PR TITLE
Fix: APIKey Radio Selector causes Viewport jump

### DIFF
--- a/web/pingpong/src/app.pcss
+++ b/web/pingpong/src/app.pcss
@@ -20,6 +20,10 @@
   color: theme('colors.blue-dark-40');
 }
 
+input[type='radio'] {
+  display: none !important;
+}
+
 .markdown {
   h1,
   h2,

--- a/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
@@ -1498,9 +1498,3 @@
     </div>
   {/if}
 </div>
-
-<style>
-  :global(input[type='radio']) {
-    display: none !important;
-  }
-</style>


### PR DESCRIPTION
Resolves #688 in Chromium browsers. This is expected Chromium behavior: https://issues.chromium.org/issues/40782006. Webkit does not behave in this way, so the issue doesn't affect Safari users.

Adapted from https://github.com/twbs/bootstrap/issues/39097#issuecomment-1867954762, but note that we don't have a prop to add this change to, so we have to use custom styles.

> [Radio styling](https://flowbite-svelte.com/docs/forms/radio#Radio_styling)
> Use the class prop to overwrite the label and input tag class.

Adding `hidden` to the `class` prop changes both the label and input tag classes, which hides the actual label.