### PR TITLE
Fix: Properly display callback errors

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -447,7 +447,7 @@ async def run_thread(
                 yield (
                     orjson.dumps(
                         {
-                            "type": "rate_limit_error",
+                            "type": "presend_error",
                             "detail": "OpenAI was unable to process your request. If the issue persists, check PingPong's status page for updates.",
                         }
                     )

--- a/web/pingpong/src/lib/components/ChatInput.svelte
+++ b/web/pingpong/src/lib/components/ChatInput.svelte
@@ -286,17 +286,13 @@
       code_interpreter_file_ids,
       vision_file_ids,
       message,
-      callback: (
-        success: boolean,
-        _errorMessage: string | null = null,
-        message_sent: boolean = true
-      ) => {
-        if (success) {
+      callback: (params: CallbackParams) => {
+        if (params.success) {
           return;
         }
-        if (!message_sent) {
+        if (!params.message_sent) {
           errorMessage =
-            _errorMessage ||
+            params.errorMessage ||
             'We faced an error while trying to send your message. Please try again.';
           $allFiles = tempFiles;
           ref.value = message;
@@ -304,7 +300,7 @@
           fixHeight(realRef);
         }
         errorMessage =
-          _errorMessage ||
+          params.errorMessage ||
           'We faced an error while generating a response to your message. Your message was successfully sent. Please try again by sending a new message.';
       }
     });


### PR DESCRIPTION
Fixes an error where an error message would not display above `ChatInput`. This was caused by `form.callback` accepting an `CallbackParams` object that was not properly unpacked.

### Other fixes:
- Removes an old `rate_limit_error` type that the current thread manager does not know how to handle and replaces it with the correct `presend_error` type that returns the typed message and input to ChatInput.
- Moves the catcher for `openai.APIError` to the right place to catch errors when creating a thread.
- Adds a second `openai.InternalServerError` with more information for the user.