### PR TITLE
New merge endpoint and `merge_external_logins` logic fix

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -19,6 +19,7 @@ from fastapi import (
     Header,
 )
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+from pydantic import PositiveInt
 
 from pingpong.artifacts import ArtifactStoreError
 from pingpong.emails import (
@@ -535,6 +536,18 @@ async def delete_email_from_user(user_id: str, email: str, request: Request):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
+    return {"status": "ok"}
+
+
+@v1.post(
+    "/user/merge",
+    dependencies=[Depends(Authz("admin"))],
+    response_model=schemas.GenericStatus,
+)
+async def merge_users(
+    old_user_id: PositiveInt, new_user_id: PositiveInt, request: Request
+):
+    await merge(request.state.db, request.state.authz, new_user_id, old_user_id)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
Adds a new `/user/merge` endpoint so that we don't have to use a CLI command every time we need to merge two users, which is increasingly common in the RCT.

Also fixes a logical error in the `merge_external_logins` function. Previously, ExternalLogins with uniqueness constraints across all users (for instance, an email can only be used as an ExternalLogin for a single user) would raise an error. This was because the old function first created the new ExternalLogin record and then deleted the old one.