### PR TITLE
[Canvas Sync] Patch: Nested Session to handle Rollbacks

### DIFF
--- a/pingpong/__main__.py
+++ b/pingpong/__main__.py
@@ -626,7 +626,9 @@ def run_dynamic_tasks_with_args(host: str, port: int, tasks: list[str]) -> None:
                     f"Task '{task_name}' (calling {function_name}) completed successfully at {datetime.now()}"
                 )
             except Exception as e:
-                logger.error(f"Error in task '{task_name}' ({function_name}): {e}")
+                logger.error(
+                    f"Error in task '{task_name}' ({function_name}): {e}", exc_info=True
+                )
 
     async def _parse_tasks():
         task_coroutines = []

--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -784,20 +784,17 @@ async def canvas_sync_all(
         sync_classes_with_error_status=sync_classes_with_error_status,
     ):
         logger.info(f"Syncing class {class_.id}...")
-
-        try:
-            async with ScriptCanvasClient(
-                canvas_backend,
-                session,
-                authz_,
-                class_.id,
-                class_.lms_user_id,
-                sync_without_sso_ids=sync_without_sso_ids,
-            ) as client:
-                await client.sync_roster()
-                await session.commit()
-        except Exception as e:
-            logger.error(f"Error syncing class {class_.id}: {e}")
-
-            if session.in_transaction():
-                await session.rollback()
+        async with session.begin_nested() as session_:
+            try:
+                async with ScriptCanvasClient(
+                    canvas_backend,
+                    session,
+                    authz_,
+                    class_.id,
+                    class_.lms_user_id,
+                    sync_without_sso_ids=sync_without_sso_ids,
+                ) as client:
+                    await client.sync_roster()
+            except Exception as e:
+                logger.error(f"Error syncing class {class_.id}: {e}", exc_info=True)
+                await session_.rollback()


### PR DESCRIPTION
Creates new `session_` `AsyncSessionTransaction`s to handle rollbacks. Note that we need to pass `session` in the `ScriptCanvasClient` init.