### PR TITLE
[Canvas Sync]: Save changes at the end of canvas_sync_all (#723)

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -836,3 +836,6 @@ async def canvas_sync_all(
             except Exception as e:
                 logger.exception(f"Error syncing class {class_.id}: {e}")
                 await session_.rollback()
+
+    # Finally, commit all changes
+    await session.commit()


### PR DESCRIPTION
Because we are no longer using `session.commit()` after every class sync, we need to save all changes at the end of a run.