### PR TITLE
Allow Admins to remove themselves from Groups they create

### DIFF
--- a/pingpong/scripts/airtable/__main__.py
+++ b/pingpong/scripts/airtable/__main__.py
@@ -4,6 +4,7 @@ import logging
 
 from pingpong.scripts.airtable.helpers import (
     _process_airtable_class_requests,
+    _process_remove_self_from_classes,
     _process_students_to_add,
     _process_external_logins_to_add,
 )
@@ -21,7 +22,9 @@ def process_airtable_class_requests() -> None:
     """
     Process pending Airtable class creation requests.
     """
+    logger.info("Processing class creation requests...")
     asyncio.run(_process_airtable_class_requests())
+    logger.info("Finished processing class creation requests.")
 
 
 @cli.command("process_students_to_add")
@@ -29,7 +32,19 @@ def process_students_to_add() -> None:
     """
     Process pending Airtable student creation requests.
     """
+    logger.info("Processing student creation requests...")
     asyncio.run(_process_students_to_add())
+    logger.info("Finished processing student creation requests.")
+
+
+@cli.command("process_remove_self_from_classes")
+def process_remove_self_from_classes() -> None:
+    """
+    Process pending Airtable remove self from class requests.
+    """
+    logger.info("Processing remove self from class requests...")
+    asyncio.run(_process_remove_self_from_classes())
+    logger.info("Finished processing remove self from class requests.")
 
 
 @cli.command("process_external_logins_to_add")
@@ -37,7 +52,9 @@ def process_external_logins_to_add() -> None:
     """
     Process pending Airtable external login creation requests.
     """
+    logger.info("Processing external login creation requests...")
     asyncio.run(_process_external_logins_to_add())
+    logger.info("Finished processing external login creation requests.")
 
 
 if __name__ == "__main__":

--- a/pingpong/scripts/airtable/schemas.py
+++ b/pingpong/scripts/airtable/schemas.py
@@ -111,6 +111,7 @@ class PingPongClass(Model):
     billing_api_key = F.TextField("Billing API Selection")
     assistant_templates = F.LinkField("Assistant Templates", AssistantTemplate)
     pingpong_assistants = F.LinkField("PingPong Assistants", PingPongAssistant)
+    remove_admin = F.CheckboxField("Remove Admin")
 
     class Meta:
         table_name: str = "PingPong Classes"

--- a/pingpong/scripts/airtable/server_requests.py
+++ b/pingpong/scripts/airtable/server_requests.py
@@ -87,3 +87,23 @@ async def add_login_email(
     ) as resp:
         response = await resp.json()
         return schemas.GenericStatus(**response)
+
+
+async def delete_user_from_class(
+    session, class_id: int, user_id: int, url: str
+) -> schemas.GenericStatus:
+    async with session.delete(
+        f"{url}/api/v1/class/{class_id}/user/{user_id}",
+        raise_for_status=True,
+    ) as resp:
+        response = await resp.json()
+        return schemas.GenericStatus(**response)
+
+
+async def get_me(session, url: str) -> schemas.User:
+    async with session.get(
+        f"{url}/api/v1/me",
+        raise_for_status=True,
+    ) as resp:
+        response = await resp.json()
+        return schemas.User(**response["user"])

--- a/web/pingpong/src/lib/components/BulkAddUsers.svelte
+++ b/web/pingpong/src/lib/components/BulkAddUsers.svelte
@@ -458,7 +458,7 @@
 
             <TableBodyCell class="px-3 py-1">
               {#if tuple.error}
-                <span class="text-light text-red-700">{tuple.error}</span>
+                <span class="text-light text-red-700 text-wrap">{tuple.error}</span>
               {:else}
                 <CheckOutline class="w-6 h-6 text-green-600" />
               {/if}


### PR DESCRIPTION
Allows Administrators to remove themselves from Groups they have created given that there is another Moderator in the Group. Also adds checks that another Moderator is present before allowing Admins to change a Moderator's role.