### PR TITLE
Fix: Reasoning Selector might not allow 'low' value to be selected

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -3453,11 +3453,13 @@ async def create_assistant(
 
         reasoning_effort = (
             REASONING_EFFORT_MAP.get(req.reasoning_effort)
-            if req.reasoning_effort
+            if req.reasoning_effort is not None
             else None
         )
         reasoning_extra_body = (
-            {"reasoning_effort": reasoning_effort} if reasoning_effort else {}
+            {"reasoning_effort": reasoning_effort}
+            if reasoning_effort is not None
+            else {}
         )
 
         new_asst = await openai_client.beta.assistants.create(
@@ -3660,7 +3662,7 @@ async def update_assistant(
     if "reasoning_effort" in req.model_fields_set:
         reasoning_effort = (
             REASONING_EFFORT_MAP.get(req.reasoning_effort)
-            if req.reasoning_effort
+            if req.reasoning_effort is not None
             else None
         )
         reasoning_extra_body: dict[str, Optional[str]] = (

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -184,7 +184,7 @@
   let temperatureValue: number;
   $: if (
     assistant?.temperature !== undefined &&
-    assistant?.temperature &&
+    assistant?.temperature !== null &&
     temperatureValue === undefined
   ) {
     temperatureValue = assistant.temperature;
@@ -192,20 +192,22 @@
   let reasoningEffortValue: number;
   $: if (
     assistant?.reasoning_effort !== undefined &&
-    assistant?.reasoning_effort &&
+    assistant?.reasoning_effort !== null &&
     reasoningEffortValue === undefined
   ) {
     reasoningEffortValue = assistant.reasoning_effort;
   }
   $: if (
     temperatureValue === undefined &&
-    (data.isCreating || assistant?.temperature === undefined || !assistant?.temperature)
+    (data.isCreating || assistant?.temperature === undefined || assistant?.temperature === null)
   ) {
     temperatureValue = 1;
   }
   $: if (
     reasoningEffortValue === undefined &&
-    (data.isCreating || assistant?.reasoning_effort === undefined || !assistant?.reasoning_effort)
+    (data.isCreating ||
+      assistant?.reasoning_effort === undefined ||
+      assistant?.reasoning_effort === null)
   ) {
     reasoningEffortValue = 1;
   }
@@ -956,7 +958,7 @@
             />
             <div class="mt-2 flex flex-row justify-between">
               <p class="text-sm">low</p>
-              <p class="text-sm">medium {reasoningEffortValue}</p>
+              <p class="text-sm">medium</p>
               <p class="text-sm">high</p>
             </div>
           {/if}


### PR DESCRIPTION
Fixes an issue where the Reasoning Selector might not display the assigned reasoning effort for an Assistant. Fixes an issue where users might be unable to set 'low' as the reasoning effort value for an Assistant.