### PR TITLE
ViewUsers Table: Allow Admins to Edit their Own Role

### DIFF
--- a/web/pingpong/src/lib/components/ViewUsers.svelte
+++ b/web/pingpong/src/lib/components/ViewUsers.svelte
@@ -358,7 +358,6 @@
           {@const roleInfo = getRoleInfoForUser(user)}
           {@const noPermissions = !checkUserEditPermissions(roleInfo.primary)}
           {@const currentUser = isCurrentUser(user)}
-          {@const userIsSupervisor = user.roles.teacher || user.roles.admin}
           {@const userIsAdmin = user.roles.admin}
           <TableBodyRow>
             <TableBodyCell {tdClass}


### PR DESCRIPTION
Fixes an issue where PingPong may incorrectly determine that there is only one Moderator left in a group and not allow an Admin to edit their role or that of another Moderator.