### PR TITLE
Rollback DB changes when raising HTTPExceptions or others in FastAPI

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -213,7 +213,8 @@ async def begin_db_session(request: Request, call_next):
         request.state.db = db
         try:
             result = await call_next(request)
-            if not result.status_code or result.status_code >= 400:
+            status_code = getattr(result, "status_code", 0)
+            if not status_code or status_code >= 400:
                 await db.rollback()
             await db.commit()
             return result


### PR DESCRIPTION
Currently, whenever an endpoint returns an HTTPException, we are not rolling back changes in the database. Inspects the `status_code` parameter of the return of `call_next` to determine if we should roll back DB changes before returning.