### PR TITLE
Fix: Activity Summaries Panel Visibility

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/manage/+page.svelte
@@ -911,7 +911,7 @@
     </form>
   {/if}
 
-  {#if subscriptionInfo && hasApiKey}
+  {#if subscriptionInfo && data?.hasAPIKey}
     <div bind:this={summaryElement} class="grid md:grid-cols-3 gap-x-6 gap-y-8 pt-6">
       <div>
         <Heading customSize="text-xl font-bold" tag="h3"


### PR DESCRIPTION
Fixes an issue where Moderators who do not have permissions to view API keys may not be able to view the Activity Summaries panel under Manage Group.