### PR TITLE
Remove Unavailable Azure Models & Other Improvements

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -2307,9 +2307,7 @@ async def list_class_models(
         "o3-mini-2025-01-31",
     ]
 
-    if isinstance(openai_client, openai.AsyncAzureOpenAI) and any(
-        m.id == "gpt-4o-2024-08-06" for m in all_models.data
-    ):
+    if isinstance(openai_client, openai.AsyncAzureOpenAI):
         filtered = [m for m in filtered if m["id"] not in AZURE_UNAVAILABLE_MODELS]
 
     # Vision is not supported in Azure, set vision_support_override to False


### PR DESCRIPTION
- Filters out `o3-mini` and `o3-mini-2025-01-31` from Model Selectors in Azure Groups.
- Creates new `AZURE_UNAVAILABLE_MODELS` array for better handling of model availability filtering instead of individual checks.
- Updates user-facing `o3-mini` name to `o3 mini`.
- Removes the `new` tag from `gpt-4o-mini-2024-07-18`.