### PR TITLE
New endpoints for Assistant/Model Statistics

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1472,7 +1472,9 @@ class Assistant(Base):
 
     @classmethod
     async def get_by_model(cls, session: AsyncSession, model: str) -> List["Assistant"]:
-        stmt = select(Assistant.id, Assistant.class_id).where(Assistant.model == model)
+        stmt = select(
+            Assistant.id, Assistant.class_id, Assistant.updated, Assistant.created
+        ).where(Assistant.model == model)
         result = await session.execute(stmt)
         return result.all()
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -45,6 +45,7 @@ class ModelStatisticsResponse(BaseModel):
 class AssistantModelInfo(BaseModel):
     class_id: int
     assistant_id: int
+    last_edited_at: datetime
 
 
 class AssistantModelInfoResponse(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -937,7 +937,14 @@ async def get_models_stats(request: Request):
 )
 async def get_model_assistants(model_name: str, request: Request):
     assistants = await models.Assistant.get_by_model(request.state.db, model_name)
-    stats = [{"assistant_id": a.id, "class_id": a.class_id} for a in assistants]
+    stats = [
+        {
+            "assistant_id": a.id,
+            "class_id": a.class_id,
+            "last_edited_at": a.updated or a.created,
+        }
+        for a in assistants
+    ]
     return schemas.AssistantModelInfoResponse(assistants=stats, model=model_name)
 
 


### PR DESCRIPTION
Adding new endpoints so we can monitor use of models we might want to retire.
- `/api/v1/stats/models`: Returns an array of models in use and the count of assistants using said model.
- `/api/v1/stats/models/{model_name}/assistants`: Returns an array of the assistant id, class_id and last edited timestamp of assistants using `model_name`.