### PR TITLE
Model Stats: Add latest user activity timestamp

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -44,8 +44,11 @@ class ModelStatisticsResponse(BaseModel):
 
 class AssistantModelInfo(BaseModel):
     class_id: int
+    class_name: str
     assistant_id: int
-    last_edited_at: datetime
+    assistant_name: str
+    last_edited: datetime
+    last_user_activity: datetime | None
 
 
 class AssistantModelInfoResponse(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -940,8 +940,11 @@ async def get_model_assistants(model_name: str, request: Request):
     stats = [
         {
             "assistant_id": a.id,
+            "assistant_name": a.name,
             "class_id": a.class_id,
-            "last_edited_at": a.updated or a.created,
+            "class_name": a.class_name,
+            "last_edited": a.updated or a.created,
+            "last_user_activity": a.last_activity,
         }
         for a in assistants
     ]


### PR DESCRIPTION
Adds the max last_activity timestamp from all threads associated with each assistant in the `/api/v1/stats/models/{model_name}/assistants` endpoint. Also adds the class and assistant name in the response.