### PR TITLE
Fix: Main Page Assistant won't run URL-dependent code after navigation from Group Selector

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
   import { navigating, page } from '$app/stores';
   import ChatInput, { type ChatInputMessage } from '$lib/components/ChatInput.svelte';
   import {
@@ -22,7 +22,6 @@
   import * as api from '$lib/api';
   import { errorMessage } from '$lib/errors';
   import type { Assistant, FileUploadPurpose } from '$lib/api';
-  import { onMount } from 'svelte';
   import { loading } from '$lib/stores/general';
   import ModeratorsTable from '$lib/components/ModeratorsTable.svelte';
 
@@ -42,7 +41,7 @@
     );
   }
 
-  onMount(async () => {
+  afterNavigate(async () => {
     const errorCode = $page.url.searchParams.get('error_code');
     if (errorCode) {
       const errorMessage = getErrorMessage(parseInt(errorCode) || 0);


### PR DESCRIPTION
Fixes an issue where after navigating to a new Group page using the Select Group dropdown, the code ensuring that an assistant is linked in the URL wouldn't run. Fixed by switching `onMount` to `afterNavigate`, so that the code doesn't only run on the first load.