### PR TITLE
Patch: Correctly Encode `#` for forward url in SSO 

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -405,7 +405,7 @@ async def login_sso(provider: str, request: Request):
     if sso_config.protocol == "saml":
         saml_client = await get_saml2_client(sso_config, request)
         dest = request.query_params.get("redirect", "/")
-        dest_encoded = dest.replace("#", "%23")
+        dest_encoded = dest.replace("#", "%2523")
         return RedirectResponse(saml_client.login(dest_encoded))
     else:
         raise HTTPException(


### PR DESCRIPTION
Patches #767 