### PR TITLE
Patch: In `on_tool_call_created`, `tool_call` is of type `Dict`, not the expected type `ToolCall`

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -466,7 +466,7 @@ async def run_thread(
     except openai.APIError as openai_error:
         if openai_error.type == "server_error":
             try:
-                logger.warning(f"Server error in thread run: {openai_error}")
+                logger.exception(f"Server error in thread run: {openai_error}")
                 yield (
                     orjson.dumps(
                         {


### PR DESCRIPTION
Fixes an issue where a File Search tool call creation stream may fail with error `'dict' object has no attribute 'model_dump'` while streaming a run because the OpenAI API is currently returning a Dict instead of a `ToolCall` class instance. For now, we check if the `tool_call` is a Dict and return it instead of trying to `model_dump()`.