### PR TITLE
Log messages that trigger Azure content filtering

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -134,6 +134,12 @@ async def generate_name(
         return response.choices[0].message.parsed
     except openai.RateLimitError as e:
         raise e
+    except openai.BadRequestError:
+        # We are typically seeing this error when the Azure content filter
+        # is triggered. We should print the message that triggered the error
+        # and return None.
+        logger.exception(f"Error generating thread name. Message: {transcript}")
+        return None
     except openai.APIError:
         logger.exception("Error generating thread name.")
         return None


### PR DESCRIPTION
We are seeing `BadRequestError`s being raised when Azure content filters do not allow the model to return a response. Logs the messages transcript for us to understand what messages are triggering the filters (falls under the following clause in the Privacy Policy):

> The Harvard technical team developing and managing PingPong does have access to identifiable information for purposes of system administration, including system protection, maintenance, improvement, and management as well as **abuse prevention**, to track user trends to improve the quality of PingPong and the learning experience, and for the other purposes described in this notice and other relevant policies.