### PR TITLE
[CanvasSync] Keep the latest active profile when there are duplicates

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -653,7 +653,7 @@ class CanvasCourseClient(ABC):
                     teacher=is_teacher,
                     student=not is_teacher,
                 ),
-                sso_last_activity=latest_activity,
+                last_active=latest_activity,
             )
 
     async def _get_course_users(self, course_id: str) -> list[CreateUserClassRole]:
@@ -692,11 +692,11 @@ class CanvasCourseClient(ABC):
             if user.email not in unique_users:
                 unique_users[user.email] = user
             else:
-                if user.sso_last_activity is None:
+                if user.last_active is None:
                     continue
 
-                current_last = unique_users[user.email].sso_last_activity
-                if current_last is None or user.sso_last_activity > current_last:
+                current_last = unique_users[user.email].last_active
+                if current_last is None or user.last_active > current_last:
                     unique_users[user.email] = user
 
         return list(unique_users.values())

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -567,7 +567,7 @@ class CreateUserClassRole(BaseModel):
     email: str = Field(..., min_length=3, max_length=100)
     display_name: str | None = None
     sso_id: str | None = None
-    sso_last_activity: datetime | None = None
+    last_active: datetime | None = None
     roles: ClassUserRoles
 
 


### PR DESCRIPTION
Adds a new `last_active` parameter in `CreateUserClassRole` to track when each Canvas profile was last active. This is an improvement over #791, where the student profile that appeared latest in the list would be the one to persist the SSO information.

As a reminder, duplicate profiles are defined as ones that use the same email address in Canvas. In this approach, we check which of the duplicates was used most recently and save the SSO identifier of that profile.