### PR TITLE
[CanvasSync] Log whenever we have permission duplicates

### DIFF
--- a/pingpong/users.py
+++ b/pingpong/users.py
@@ -437,6 +437,9 @@ class AddNewUsers(ABC):
             await self._remove_deleted_users()
             await self._merge_accounts()
 
+        if len(grants) > len(list(set(grants))):
+            logger.exception("Duplicate grants detected.")
+
         await self.client.write_safe(
             grant=list(set(grants)), revoke=list(set(self.revokes))
         )


### PR DESCRIPTION
After #791, we are explicitly removing duplicates from grant and revoke permissions sets in `add_new_users`. While this helps avoid situations where a group cannot be synced with Canvas at all, there is the possibility that a new issue is never identified because we are silently resolving the duplicate permission tuples issue.

In #794, we resolved the only known edge case causing duplicate permission tuples, which was a case were multiple `CreateUserClassRole` records had the same email address.

This PR adds an exception log whenever we are explicitly removing duplicates from grant and revoke permissions sets in `add_new_users`. This should help flag any new edge cases causing this issue.