### PR TITLE
fix/ Recursion error when no `response_model` was given

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -105,7 +105,7 @@ class InspectAuthz(BaseModel):
 
 
 class InspectAuthzAllResult(BaseModel):
-    results: list[Relation]
+    result: list[Relation]
 
 
 class AddEmailToUserRequest(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -343,7 +343,7 @@ async def inspect_authz(request: Request, subj: str, obj: str, rel: str):
     response_model=schemas.InspectAuthzAllResult,
 )
 async def list_all_user_permissions(request: Request, user_id: str):
-    return {"results": await list_all_permissions(request.state.authz, int(user_id))}
+    return {"result": await list_all_permissions(request.state.authz, int(user_id))}
 
 
 @v1.post(


### PR DESCRIPTION
Fixes an error seen on the staging server, where a PUT request to the `/me` endpoint would result in 

```
RecursionError: maximum recursion depth exceeded while calling a Python object
```

when the endpoint didn’t specify the expected `User` response model. This might be related to #798.

To prevent future issues, adds expected response model to many more endpoints.