### PR TITLE
fix/ OpenAI vector stores endpoint is out of beta

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -421,7 +421,7 @@ async def run_thread(
                     raise ValueError("Vector store ID is required for file search")
                 await asyncio.gather(
                     *[
-                        cli.beta.vector_stores.files.poll(
+                        cli.vector_stores.files.poll(
                             file_id=file_id, vector_store_id=vector_store_id
                         )
                         for file_id in file_search_file_ids


### PR DESCRIPTION
Fixes an issue where users may have been unable to send a message to a thread when it contained File Search attachments. 

The issue was caused by an `openai` package upgrade in #810 that moved the `vector_stores` endpoint out of beta.