### PR TITLE
fix/ Maintain white space within Prompt modal

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/thread/[threadId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/thread/[threadId]/+page.svelte
@@ -833,7 +833,7 @@
     ><ModeratorsTable moderators={teachers} /></Modal
   >
   <Modal title="Assistant Prompt" size="lg" bind:open={showAssistantPrompt} autoclose outsideclose
-    ><span class="whitespace-pre-line text-gray-700">{$threadInstructions}</span></Modal
+    ><span class="whitespace-pre-wrap text-gray-700">{$threadInstructions}</span></Modal
   >
   {#if !$loading}
     {#if data.threadInteractionMode === 'voice' && !microphoneAccess && $messages.length === 0 && assistantInteractionMode === 'voice'}


### PR DESCRIPTION
Fixes an issue in the Assistant Prompt modal where whitespace within the assistant prompt may not be rendered as intended.