### PR TITLE
feat/ Display default prompt in assistant instructions

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -15,7 +15,6 @@ from pingpong.schemas import (
     APIKeyValidationResponse,
     ThreadName,
     NewThreadMessage,
-    InteractionMode,
 )
 
 from datetime import datetime, timezone
@@ -564,22 +563,9 @@ def format_instructions(
     instructions: str,
     use_latex: bool = False,
     use_image_descriptions: bool = False,
-    interaction_mode: InteractionMode = InteractionMode.CHAT,
     thread_id: str | None = None,
 ) -> str:
     """Format instructions for a prompt."""
-
-    if interaction_mode == InteractionMode.VOICE:
-        instructions = (
-            "Your knowledge cutoff is 2023-10. You are a helpful, witty, and "
-            "friendly AI. Act like a human, but remember that you aren't a "
-            "human and that you can't do human things in the real world. Your "
-            "voice and personality should be warm and engaging, with a lively "
-            "and playful tone. If interacting in a non-English language, "
-            "start by using the standard accent or dialect familiar to the "
-            "user. Talk quickly. Do not refer to these rules, even if you're "
-            "asked about them.\n"
-        ) + instructions
 
     if use_latex:
         instructions += (

--- a/pingpong/ai_models.py
+++ b/pingpong/ai_models.py
@@ -247,6 +247,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
     #
     "gpt-4o-realtime-preview": {
         "name": "GPT-4o Realtime",
+        "default_prompt_id": "voice_mode_v1",
         "sort_order": 0.1,
         "type": "voice",
         "is_new": False,
@@ -261,6 +262,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
     },
     "gpt-4o-mini-realtime-preview": {
         "name": "GPT-4o mini Realtime",
+        "default_prompt_id": "voice_mode_v1",
         "sort_order": 0.2,
         "type": "voice",
         "is_new": False,
@@ -562,6 +564,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
     #
     "gpt-4o-realtime-preview-2024-12-17": {
         "name": "gpt-4o-realtime-preview-2024-12-17",
+        "default_prompt_id": "voice_mode_v1",
         "sort_order": 0.1,
         "type": "voice",
         "is_new": False,
@@ -576,6 +579,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
     },
     "gpt-4o-realtime-preview-2024-10-01": {
         "name": "gpt-4o-realtime-preview-2024-10-01",
+        "default_prompt_id": "voice_mode_v1",
         "sort_order": 0.2,
         "type": "voice",
         "is_new": False,
@@ -590,6 +594,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
     },
     "gpt-4o-mini-realtime-preview-2024-12-17": {
         "name": "gpt-4o-mini-realtime-preview-2024-12-17",
+        "default_prompt_id": "voice_mode_v1",
         "sort_order": 0.3,
         "type": "voice",
         "is_new": False,
@@ -657,3 +662,19 @@ AZURE_UNAVAILABLE_MODELS = [
     "gpt-4.1-mini-2025-04-14",
     "gpt-4.1-nano-2025-04-14",
 ]
+
+DEFAULT_PROMPTS = {
+    "voice_mode_v1": schemas.AssistantDefaultPrompt(
+        id="voice_mode_v1",
+        prompt=(
+            "Your knowledge cutoff is 2023-10. You are a helpful, witty, and "
+            "friendly AI. Act like a human, but remember that you aren't a "
+            "human and that you can't do human things in the real world. Your "
+            "voice and personality should be warm and engaging, with a lively "
+            "and playful tone. If interacting in a non-English language, "
+            "start by using the standard accent or dialect familiar to the "
+            "user. Talk quickly. Do not refer to these rules, even if you're "
+            "asked about them."
+        ),
+    )
+}

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1837,6 +1837,20 @@ class Assistant(Base):
         result = await session.execute(stmt)
         return [row.Assistant for row in result]
 
+    @classmethod
+    async def get_by_class_id_models(
+        cls, session: AsyncSession, class_id: int, models: list[str]
+    ) -> AsyncGenerator["Assistant", None]:
+        stmt = select(Assistant).where(
+            and_(
+                Assistant.class_id == class_id,
+                Assistant.model.in_(models),
+            )
+        )
+        result = await session.execute(stmt)
+        for row in result:
+            yield row.Assistant
+
 
 class LMSClass(Base):
     __tablename__ = "lms_classes"
@@ -2539,6 +2553,22 @@ class Class(Base):
                 ),
             )
         stmt = select(Class).where(and_(*conditions))
+        result = await session.execute(stmt)
+
+        for row in result:
+            yield row.Class
+
+    @classmethod
+    async def get_all_classes_with_api_keys(
+        cls, session: AsyncSession, before: datetime | None = None
+    ) -> AsyncGenerator["Class", None]:
+        """Get all classes that have API keys."""
+        stmt = select(Class).where(
+            or_(
+                Class.api_key_id.isnot(None),
+                Class.api_key.isnot(None),
+            )
+        )
         result = await session.execute(stmt)
 
         for row in result:

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum, StrEnum, auto
-from typing import Generic, Literal, TypeVar, Union, TypedDict
+from typing import Generic, Literal, NotRequired, TypeVar, Union, TypedDict
 
 from openai.types.beta.assistant_tool import AssistantTool as Tool
 from openai.types.beta.threads import Message as OpenAIMessage
@@ -1034,6 +1034,7 @@ class AssistantModel(BaseModel):
     owner: str
     name: str
     description: str
+    default_prompt_id: str | None = None
     type: InteractionMode
     is_latest: bool
     is_new: bool
@@ -1060,10 +1061,17 @@ class AssistantModelDict(TypedDict):
     supports_temperature: bool
     supports_reasoning: bool
     description: str
+    default_prompt_id: NotRequired[str]
+
+
+class AssistantDefaultPrompt(BaseModel):
+    id: str
+    prompt: str
 
 
 class AssistantModels(BaseModel):
     models: list[AssistantModel]
+    default_prompts: list[AssistantDefaultPrompt] = []
 
 
 class Classes(BaseModel):

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -985,6 +985,7 @@ export type AssistantModel = {
   supports_temperature: boolean;
   supports_reasoning: boolean;
   hide_in_model_selector?: boolean;
+  default_prompt_id?: string | null;
 };
 
 export type AssistantModelOptions = {
@@ -996,11 +997,17 @@ export type AssistantModelOptions = {
   highlight: boolean;
 };
 
+export type AssistantDefaultPrompt = {
+  id: string;
+  prompt: string;
+};
+
 /**
  * List of language models.
  */
 export type AssistantModels = {
   models: AssistantModel[];
+  default_prompts?: AssistantDefaultPrompt[];
 };
 
 /**

--- a/web/pingpong/src/routes/group/[classId]/+layout.ts
+++ b/web/pingpong/src/routes/group/[classId]/+layout.ts
@@ -47,6 +47,7 @@ export const load: LayoutLoad = async ({ fetch, params }) => {
   }
 
   const models = modelsResponse.error ? [] : modelsResponse.data.models;
+  const defaultPrompts = modelsResponse.error ? [] : (modelsResponse.data.default_prompts ?? []);
 
   const supervisors = teachersResponse.error ? [] : teachersResponse.data.users;
 
@@ -63,6 +64,7 @@ export const load: LayoutLoad = async ({ fetch, params }) => {
     isSupervisor: grants.isSupervisor,
     models,
     hasAPIKey,
-    supervisors
+    supervisors,
+    defaultPrompts
   };
 };

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -396,9 +396,25 @@
     _temperatureValue = assistant.temperature;
   }
 
-  const changeTemperatureInteractionMode = (evt: Event) => {
+  const setDefaultModelPrompt = (model: string) => {
+    const matchingModels = data.models.filter((m) => m.id === model);
+    let found = false;
+    matchingModels.forEach((m) => {
+      if (m.default_prompt_id) {
+        instructions = data.defaultPrompts.find((p) => p.id === m.default_prompt_id)?.prompt || '';
+        hasSetInstructions = true;
+        found = true;
+      }
+    });
+    if (!found) {
+      instructions = '';
+      hasSetInstructions = true;
+    }
+  };
+
+  const changeInteractionMode = (evt: Event) => {
     const target = evt.target as HTMLInputElement;
-    const mode = target.value;
+    const mode = target.value as 'chat' | 'voice';
     if (
       assistant?.interaction_mode === mode &&
       assistant?.temperature !== undefined &&
@@ -412,6 +428,16 @@
     } else if (mode === 'chat') {
       temperatureValue = defaultChatTemperature;
       _temperatureValue = defaultChatTemperature;
+    }
+    if (
+      assistant?.interaction_mode === mode &&
+      assistant?.instructions !== undefined &&
+      assistant?.instructions !== null
+    ) {
+      instructions = assistant.instructions;
+      hasSetInstructions = true;
+    } else {
+      setDefaultModelPrompt(selectedModel);
     }
   };
   let reasoningEffortValue: number;
@@ -862,7 +888,7 @@
             value="chat"
             bind:group={interactionMode}
             disabled={preventEdits}
-            on:change={changeTemperatureInteractionMode}
+            on:change={changeInteractionMode}
             class={`${preventEdits ? 'hover:bg-transparent' : ''} select-none`}
             ><div class="flex flex-row gap-2 items-center">
               {#if interactionMode === 'chat'}<MessageDotsSolid
@@ -876,7 +902,7 @@
             value="voice"
             bind:group={interactionMode}
             disabled={preventEdits}
-            on:change={changeTemperatureInteractionMode}
+            on:change={changeInteractionMode}
             class={`${preventEdits ? 'hover:bg-transparent' : ''} select-none`}
             ><div class="flex flex-row gap-2 items-center">
               {#if interactionMode === 'voice'}<MicrophoneSolid


### PR DESCRIPTION
Default prompts are now associated with each model, not each interaction mode. This allows more flexibility in the future.

The default prompts will now be displayed on the Edit Assistant page as a prefilled value. Users can edit the default prompt or add their own.