### PR TITLE
feat/ Set custom log levels to default when not set

### DIFF
--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -246,8 +246,10 @@ class Config(BaseSettings):
     """Stats Chat Bot config."""
 
     log_level: str = Field("INFO", env="LOG_LEVEL")
-    realtime_log_level: str = Field("INFO", env="REALTIME_LOG_LEVEL")
-    prompt_randomizer_log_level: str = Field("INFO", env="PROMPT_RANDOMIZER_LOG_LEVEL")
+    realtime_log_level: str | None = Field(None, env="REALTIME_LOG_LEVEL")
+    prompt_randomizer_log_level: str | None = Field(
+        None, env="PROMPT_RANDOMIZER_LOG_LEVEL"
+    )
 
     reload: int = Field(0)
     public_url: str = Field("http://localhost:8000")
@@ -318,8 +320,14 @@ logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
     logging.WARNING
 )
 logging.getLogger("uvicorn.access").addFilter(IgnoreHealthEndpoint())
-logging.getLogger("realtime_browser").setLevel(config.realtime_log_level)
-logging.getLogger("realtime_openai").setLevel(config.realtime_log_level)
-logging.getLogger("prompt_randomizer").setLevel(config.prompt_randomizer_log_level)
+logging.getLogger("realtime_browser").setLevel(
+    config.realtime_log_level or config.log_level
+)
+logging.getLogger("realtime_openai").setLevel(
+    config.realtime_log_level or config.log_level
+)
+logging.getLogger("prompt_randomizer").setLevel(
+    config.prompt_randomizer_log_level or config.log_level
+)
 if config.log_level != "DEBUG":
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)


### PR DESCRIPTION
Custom log levels for realtime_browser, realtime_openai, and prompt_randomizer loggers will default to `config.log_level` when their respective log level parameters are not set in the config file.