### PR TITLE
fix/ Do not display extra prompt parts not part of the instructions

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -380,8 +380,6 @@ class CreateAssistant(BaseModel):
 
 class AssistantInstructionsPreviewRequest(BaseModel):
     instructions: str
-    use_latex: bool = False
-    use_image_descriptions: bool = False
 
 
 class AssistantInstructionsPreviewResponse(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -3674,8 +3674,8 @@ async def preview_assistant_instructions(
     return {
         "instructions_preview": format_instructions(
             req.instructions,
-            use_latex=req.use_latex,
-            use_image_descriptions=req.use_image_descriptions,
+            use_latex=False,
+            use_image_descriptions=False,
             user_id=request.state.session.user.id,
             thread_id=f"preview_{uuid.uuid4()}",
         )

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1276,8 +1276,6 @@ export type AssistantInstructionsPreviewResponse = {
 
 export type AssistantInstructionsPreviewRequest = {
   instructions: string;
-  use_latex: boolean;
-  use_image_descriptions: boolean;
 };
 
 /**

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -678,9 +678,7 @@
     instructionsPreview = '';
 
     const result = await api.previewAssistantInstructions(fetch, data.class.id, {
-      instructions,
-      use_latex: useLatex,
-      use_image_descriptions: useImageDescriptions
+      instructions
     });
     const expanded = api.expandResponse(result);
 


### PR DESCRIPTION
Focuses the instructions preview function on the instructions entered by the user only.