### PR TITLE
Remove GPT4 mention from invite email

### DIFF
--- a/pingpong/invite.py
+++ b/pingpong/invite.py
@@ -30,7 +30,7 @@ async def send_invite(
             + " invitation.",
             "type": "invitation",
             "cta": f"Join {invite.class_name} on PingPong",
-            "underline": "PingPong is a tool for using large language models in a group setting. It&#8217;s built on top of GPT-4, a large language model developed by OpenAI.",
+            "underline": "PingPong is a tool for using large language models in a group setting. It&#8217;s built on top of models developed by OpenAI.",
             "expires": convert_seconds(expires),
             "link": link,
             "email": invite.email,


### PR DESCRIPTION
A very small edit to update a sentence in the invite email from:
> PingPong is a tool for using large language models in a group setting. It’s built on top of GPT-4, a large language model developed by OpenAI.

to
> PingPong is a tool for using large language models in a group setting. It’s built on top of models developed by OpenAI.

