### PR TITLE
fix(canvas)/ Ignore classes with missing data

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -406,7 +406,7 @@ class CanvasCourseClient(ABC):
                 yield self._process_course(course)
             except (KeyError, TypeError) as e:
                 logger.warning(
-                    f"Error processing course data: {course} for {self.class_id}. Missing required field: {e}"
+                    f"Error processing course data: {course} for {self.class_id}. Missing required fields: {e}"
                 )
                 continue
 


### PR DESCRIPTION
Fixes an issue were classes with missing data would not allow any classes available through a Canvas Sync connection to be displayed.