### PR TITLE
internal/ Upload files with `user_data` purpose for OAI Clients

### DIFF
--- a/pingpong/files.py
+++ b/pingpong/files.py
@@ -323,6 +323,9 @@ async def handle_create_single_purpose_file(
 
     await upload.seek(0)
     try:
+        openai_file_purpose = (
+            "user_data" if purpose == "assistants" and is_azure_client else purpose
+        )
         new_f = await oai_client.files.create(
             # NOTE(jnu): the client tries to infer the filename, which doesn't
             # work on this file that exists as bytes in memory. There's an
@@ -330,7 +333,7 @@ async def handle_create_single_purpose_file(
             # we use here to force correctness.
             # https://github.com/stanford-policylab/pingpong/issues/147
             file=(upload.filename.lower(), upload.file, upload.content_type),
-            purpose=purpose,
+            purpose=openai_file_purpose,
         )
     except openai.BadRequestError as e:
         raise HTTPException(


### PR DESCRIPTION
Moving to newly available `user_data` file purpose, which is a "[f]lexible file type for any purpose". Files uploaded under the `assistant` file purpose can be used with the new Responses API.

Azure OpenAI Service does not support the new `user_data` file purpose and is excluded from this change: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-secure#model-support