### PR TITLE
internal/ Remove scripts image from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,15 +81,6 @@ jobs:
           aws ecr put-image --repository-name ${{ vars.PINGPONG_SRV_REPO }} --registry-id ${{ env.REGISTRY_ID }} --image-tag ${{env.ENVIRONMENT}} --image-manifest "$MANIFEST"
           echo "Tagged existing Server Image (${{ env.SRV_VERSION }}) with ${{ env.ENVIRONMENT }} tag"
 
-      - name: Tag scripts image for release
-        env:
-          ENVIRONMENT: ${{ github.event.release.prerelease && 'stage' || 'prod' }}
-        if: ${{ env.SRV_IMAGE_STATUS == 'EXISTS_WITHOUT_ENV_TAG' }}
-        run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ vars.PINGPONG_SCRIPTS_REPO }} --registry-id ${{ env.REGISTRY_ID }} --image-ids imageTag=${{ env.SRV_VERSION }} --output text --query 'images[].imageManifest')
-          aws ecr put-image --repository-name ${{ vars.PINGPONG_SCRIPTS_REPO }} --registry-id ${{ env.REGISTRY_ID }} --image-tag ${{env.ENVIRONMENT}} --image-manifest "$MANIFEST"
-          echo "Tagged existing Scripts Image (${{ env.SRV_VERSION }}) with ${{ env.ENVIRONMENT }} tag"
-
       - name: Build server image for release
         env:
           ENVIRONMENT: ${{ github.event.release.prerelease && 'stage' || 'prod' }}
@@ -100,15 +91,6 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.prod.yml build \
             --build-arg SENTRY_RELEASE=${{ env.VERSION_STRIPPED }} \
             srv
-
-      - name: Build scripts image for release
-        env:
-          ENVIRONMENT: ${{ github.event.release.prerelease && 'stage' || 'prod' }}
-          SRV_VERSION: ${{ env.SRV_VERSION }}
-        if: ${{ env.SRV_IMAGE_STATUS == 'DOES_NOT_EXIST' }}
-        run: |
-          echo "Building Scripts Image with tag ${{ env.SRV_VERSION }}"
-          docker compose -f docker-compose.yml -f docker-compose.prod.yml build scripts
 
       - name: Push server image for release
         env:
@@ -121,18 +103,7 @@ jobs:
           docker push ${{ vars.PINGPONG_SRV_REGISTRY }}:${{ env.ENVIRONMENT }}
           echo "Built and pushed Server Image (${{ env.SRV_VERSION }}) with ${{ env.ENVIRONMENT }} tag"
 
-      - name: Push scripts image for release
-        env:
-          ENVIRONMENT: ${{ github.event.release.prerelease && 'stage' || 'prod' }}
-        if: ${{ env.SRV_IMAGE_STATUS == 'DOES_NOT_EXIST' }}
-        run: |
-          aws ecr get-login-password --region ${{ vars.AWS_REGION }} | docker login --username AWS --password-stdin ${{ vars.PINGPONG_REGISTRY_ENDPOINT }}
-          docker tag ${{ vars.PINGPONG_SCRIPTS_REGISTRY }}:${{ env.SRV_VERSION }} ${{ vars.PINGPONG_SCRIPTS_REGISTRY }}:${{ env.ENVIRONMENT }}
-          docker push ${{ vars.PINGPONG_SCRIPTS_REGISTRY }}:${{ env.SRV_VERSION }}
-          docker push ${{ vars.PINGPONG_SCRIPTS_REGISTRY }}:${{ env.ENVIRONMENT }}
-          echo "Built and pushed Scripts Image (${{ env.SRV_VERSION }}) with ${{ env.ENVIRONMENT }} tag"
-
-      - name: Send Server/Scripts Image tagged notification
+      - name: Send Server Image tagged notification
         if: ${{ env.SRV_IMAGE_STATUS != 'EXISTS_WITH_ENV_TAG' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -140,8 +111,8 @@ jobs:
           ENVIRONMENT: ${{ github.event.release.prerelease && 'stage' || 'prod' }}
         run: |
           GIF=$(curl "https://api.giphy.com/v1/gifs/random?api_key=$GIPHY_API_KEY&tag=dog&rating=g" | python -c "import sys,json; print (json.load(sys.stdin)['data']['images']['downsized']['url'])")
-          TAGGED_MSG=":pingpong: *Retagged* existing *Server/Scripts Image (${{ env.SRV_VERSION }})* with *${{ env.ENVIRONMENT }}* tag :tada:"
-          BUILT_MSG=":pingpong: *Built* and pushed *Server/Scripts Image (${{ env.SRV_VERSION }})* with *${{ env.ENVIRONMENT }}* tag :tada:"
+          TAGGED_MSG=":pingpong: *Retagged* existing *Server Image (${{ env.SRV_VERSION }})* with *${{ env.ENVIRONMENT }}* tag :tada:"
+          BUILT_MSG=":pingpong: *Built* and pushed *Server Image (${{ env.SRV_VERSION }})* with *${{ env.ENVIRONMENT }}* tag :tada:"
           if [[ ${{ env.SRV_IMAGE_STATUS }} == 'DOES_NOT_EXIST' ]]; then
             MSG=$BUILT_MSG
           else


### PR DESCRIPTION
We no longer need to support a separate container for scripts, as the `pyairtable` dependency is included in the main dependency group. This will speed up build times.