### PR TITLE
fix/ Cannot copy Next-Gen Assistants

### DIFF
--- a/pingpong/copy.py
+++ b/pingpong/copy.py
@@ -384,7 +384,7 @@ async def copy_moderator_published_assistants(
     )
 
     async for assistant in models.Assistant.async_get_published(
-        session, source_class_id, supervisor_ids
+        session, source_class_id, supervisor_ids, version=2
     ):
         await copy_assistant(
             session,
@@ -403,7 +403,7 @@ async def copy_all_published_assistants(
     target_class_id: int,
 ):
     async for assistant in models.Assistant.async_get_published(
-        session, source_class_id
+        session, source_class_id, version=2
     ):
         await copy_assistant(
             session,

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -2401,11 +2401,17 @@ class Assistant(Base):
 
     @classmethod
     async def async_get_published(
-        cls, session: AsyncSession, class_id: int, user_ids: list[int] | None = None
+        cls,
+        session: AsyncSession,
+        class_id: int,
+        user_ids: list[int] | None = None,
+        version: int | None = None,
     ) -> AsyncGenerator["Assistant", None]:
         condition = [Assistant.published.is_not(None)]
         if user_ids:
             condition.append(Assistant.creator_id.in_(user_ids))
+        if version:
+            condition.append(Assistant.version == version)
 
         stmt = select(Assistant).where(
             and_(


### PR DESCRIPTION
## Groups
### Resolved Issues
- Fixed: Copying a Group may fail because Next-Gen Assistants cannot be copied to another Group.
### Known Issues
- Next-Gen Assistants cannot be copied to another Group.