### PR TITLE
fix/ Do not leak keys in `/config` endpoint

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -249,7 +249,7 @@ def get_config(request: Request):
     for instance in d.get("lms", {}).get("lms_instances", []):
         if "client_secret" in instance:
             instance["client_secret"] = "******"
-    if "airtable_api_key" in d.get("study", {}):
+    if d.get("study", {}) is not None and "airtable_api_key" in d.get("study", {}):
         d["study"]["airtable_api_key"] = "******"
     return {"config": d, "headers": dict(request.headers)}
 


### PR DESCRIPTION
Fixes an issue where the `/config` endpoint was inadvertently returning DB passwords and other sensitive keys because the dict with sensitive values stripped wasn’t used.

Also hides values for LMS client secrets and Airtable API keys for the study module.