### PR TITLE
fix(study)/ Incorrect determination of when to display alert

### DIFF
--- a/web/study/src/routes/preassessment/[courseId]/+page.svelte
+++ b/web/study/src/routes/preassessment/[courseId]/+page.svelte
@@ -35,7 +35,7 @@
 				>
 				<span>students</span>
 			</div>
-			{#if data.preAssessmentStudentCount && data.enrollmentCount && data.preAssessmentStudentCount < data.enrollmentCount}
+			{#if data.preAssessmentStudentCount && data.preAssessmentStudentCount < data.preAssessmentStudents.length}
 				<Alert.Root class="self-start">
 					<Info />
 					<Alert.Title class="line-clamp-none tracking-normal"


### PR DESCRIPTION
## Study Dashboard
### Resolved Issues
Fixed: Instructors may see the "Student count lower than submission count” alert even when not applicable for their course.