### PR TITLE
fix/ View All button disabled when no personal threads are available

### DIFF
--- a/web/pingpong/src/lib/components/Sidebar.svelte
+++ b/web/pingpong/src/lib/components/Sidebar.svelte
@@ -293,7 +293,6 @@
           <Button
             href={`/threads`}
             class="text-white hover:bg-blue-dark-40 p-2 rounded flex flex-wrap justify-between gap-2 items-center"
-            disabled={threads.length === 0}
           >
             <span class="text-xs">View All</span><ArrowRightOutline
               size="md"


### PR DESCRIPTION
## Thread Archive
### Resolved Issues
- Fixed: Accessing the Thread Archive through the View All button on the Sidebar is unavailable when the user has no threads of their own.