### PR TITLE
feat/ Allow users to create a Classic Assistant

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -407,6 +407,7 @@ class CreateAssistant(BaseModel):
     assistant_should_message_first: bool = False
     should_record_user_information: bool = False
     deleted_private_files: list[int] = []
+    create_classic_assistant: bool = False
 
     _temperature_check = model_validator(mode="after")(temperature_validator)
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -5072,12 +5072,21 @@ async def create_assistant(
         # Voice mode assistants are only supported in version 2
         assistant_version = 2
     else:
-        if class_.api_key_obj and class_.api_key_obj.provider == "openai":
+        if (
+            class_.api_key_obj
+            and class_.api_key_obj.provider == "openai"
+            and not req.create_classic_assistant
+        ):
             assistant_version = 3
-        elif not class_.api_key_obj and class_.api_key:
+        elif (
+            not class_.api_key_obj
+            and class_.api_key
+            and not req.create_classic_assistant
+        ):
             assistant_version = 3
         else:
             assistant_version = 2
+    del req.create_classic_assistant
 
     # Check that the class is not private if user information should be recorded
     if class_.private and (
@@ -5423,6 +5432,7 @@ async def update_assistant(
     request: Request,
     openai_client: OpenAIClient,
 ):
+    print(req.model_dump())
     # Get the existing assistant.
     asst = await models.Assistant.get_by_id(request.state.db, int(assistant_id))
     grants = list[Relation]()

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1343,6 +1343,7 @@ export type CreateAssistantRequest = {
   instructions: string;
   model: string;
   interaction_mode: 'chat' | 'voice';
+  create_classic_assistant?: boolean;
   temperature: number | null;
   reasoning_effort: number | null;
   tools: Tool[];
@@ -1366,6 +1367,7 @@ export type UpdateAssistantRequest = {
   instructions?: string;
   model?: string;
   interaction_mode?: 'chat' | 'voice';
+  create_classic_assistant?: boolean;
   temperature?: number | null;
   reasoning_effort?: number | null;
   tools?: Tool[];
@@ -1401,6 +1403,7 @@ export const updateAssistant = async (
   assistantId: number,
   data: UpdateAssistantRequest
 ) => {
+  console.log('Updating assistant', data);
   const url = `class/${classId}/assistant/${assistantId}`;
   return await PUT<UpdateAssistantRequest, Assistant>(f, url, data);
 };

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -318,6 +318,7 @@
     useImageDescriptions = assistant?.use_image_descriptions;
     hasSetImageDescriptions = true;
   }
+  let createClassicAssistant = false;
   let assistantShouldMessageFirst = false;
   let hasSetAssistantShouldMessageFirst = false;
   $: if (
@@ -660,6 +661,7 @@
       use_image_descriptions: body.use_image_descriptions?.toString() === 'on',
       hide_prompt: body.hide_prompt?.toString() === 'on',
       assistant_should_message_first: assistantShouldMessageFirst,
+      create_classic_assistant: createClassicAssistant,
       deleted_private_files: [...$trashPrivateFileIds, ...fileSearchCodeInterpreterUnusedFiles],
       should_record_user_information: shouldRecordNameOrVoice
     };
@@ -1550,6 +1552,24 @@
                   automatically use this Next-Gen version. Existing Classic Assistants will continue
                   to work just as expected and will be upgraded to Next-Gen in the future so you can
                   take advantage of the latest improvements.</Helper
+                >
+              </div>
+            {:else}
+              <div class="col-span-2 mb-1">
+                <Checkbox
+                  id="create_classic_assistant"
+                  name="create_classic_assistant"
+                  disabled={preventEdits}
+                  bind:checked={createClassicAssistant}>Create Classic Assistant</Checkbox
+                >
+                <Helper
+                  >Control whether to use the previous generation of Assistants. When checked,
+                  you'll create a Classic Assistant instead of a Next-Gen Assistant.<br /><br
+                  />Next-Gen Assistants are the next generation of PingPong Assistants. They're
+                  designed to enable additional capabilities and improve reliability. Most new
+                  Assistants you create will automatically use this Next-Gen version. Existing
+                  Classic Assistants will continue to work just as expected and will be upgraded to
+                  Next-Gen in the future so you can take advantage of the latest improvements.</Helper
                 >
               </div>
             {/if}


### PR DESCRIPTION
## Assistants
### New Features
- Adds new “Create Classic Assistant” checkbox under Advanced Options to allow users to control whether to use the previous generation of Assistants. When checked, PingPong will create a Classic Assistant instead of a Next-Gen Assistant.