### PR TITLE
fix/ Allow copying thread link when embedded in an iframe

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -390,17 +390,26 @@
   let shareLink = '';
   let shareLinkInputEl: HTMLInputElement | null = null;
 
+  type PermissionsPolicyLike = {
+    allows?: (feature: string, origin?: string) => boolean;
+    allowsFeature?: (feature: string) => boolean;
+  };
+
   const canProgrammaticallyCopy = () => {
     try {
       // Check Permissions Policy if available to avoid triggering violations in iframes
-      const pol: any = (document as any).permissionsPolicy || (document as any).featurePolicy;
+      const d = document as unknown as {
+        permissionsPolicy?: PermissionsPolicyLike;
+        featurePolicy?: PermissionsPolicyLike;
+      };
+      const pol: PermissionsPolicyLike | undefined = d.permissionsPolicy ?? d.featurePolicy;
       if (pol) {
         if (typeof pol.allows === 'function' && !pol.allows('clipboard-write')) return false;
         if (typeof pol.allowsFeature === 'function' && !pol.allowsFeature('clipboard-write'))
           return false;
       }
       return !!navigator.clipboard && window.isSecureContext;
-    } catch (_) {
+    } catch {
       return false;
     }
   };
@@ -423,7 +432,7 @@
         await navigator.clipboard.writeText(url);
         happyToast('Link copied to clipboard', 3000);
         return;
-      } catch (_) {
+      } catch {
         // Fall through to manual copy
       }
     }


### PR DESCRIPTION
## Threads
### Resolved Issues
- Fixed: Users may be unable to copy the thread link when PingPong is embedded in an iframe due to Chromium browsers blocking websites from accessing the clipboard without explicit user permission at embed time. See [Deprecating Permissions in Cross-Origin Iframes (The Chromium Projects)](https://www.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes/) for more details.
    - PingPong will now display a modal dialog when it can't access the Clipboard API. Users will have to actively copy the link to their clipboard using Cmd+C / Ctrl+C.
    - To bypass this restriction on Chromium browsers and restore the previous copying behavior, add the `allow="clipboard-write"` attribute in your iframe definition, e.g.
    ```
    <iframe 
        style="border:0" 
        src="LINK_COPIED_FROM_PINGPONG" 
        height="1000px" 
        width="100%" 
        allow="clipboard-write"
    ></iframe> 
    ```