### PR TITLE
fix/ Web Search may not be available

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -1289,7 +1289,7 @@
       {/if}
     </div>
     <div class="col-span-2 mb-4">
-      {#if (data.isCreating && createClassicAssistant) || assistant?.version !== 3}
+      {#if (data.isCreating && createClassicAssistant) || (!data.isCreating && assistant?.version !== 3)}
         <div class="col-span-2 mb-3">
           <div class="flex flex-col gap-y-1">
             <Badge


### PR DESCRIPTION
Fixed: Some users may see "No Web Search capabilities in Classic Assistants" when trying to enable the Web Search capability while creating a Next Gen Assistant.