### PR TITLE
fix/ Unavailable models in Classic Assistants

### DIFF
--- a/pingpong/ai_models.py
+++ b/pingpong/ai_models.py
@@ -217,7 +217,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
         "supports_expanded_reasoning_effort": False,
         "supports_verbosity": False,
         "supports_web_search": True,
-        "description": "Fast, cost-efficient reasoning model, succeeded by GPT-5 mini",
+        "description": "Fast, cost-efficient reasoning model, succeeded by GPT-5 mini.",
     },
     "o3": {
         "name": "o3",
@@ -236,7 +236,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
         "supports_expanded_reasoning_effort": False,
         "supports_verbosity": False,
         "supports_web_search": True,
-        "description": "Reasoning model for complex tasks, succeeded by GPT-5",
+        "description": "Reasoning model for complex tasks, succeeded by GPT-5.",
     },
     "o3-pro": {
         "name": "o3-pro",
@@ -255,7 +255,7 @@ KNOWN_MODELS: dict[str, schemas.AssistantModelDict] = {
         "supports_expanded_reasoning_effort": False,
         "supports_verbosity": False,
         "supports_web_search": True,
-        "description": "Version of o3 with more compute for better responses",
+        "description": "Version of o3 with more compute for better responses.",
     },
     "o1": {
         "name": "o1",

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -187,7 +187,8 @@
       (model) =>
         model.is_latest &&
         !(model.hide_in_model_selector ?? false) &&
-        (createClassicAssistant
+        ((data.isCreating && createClassicAssistant) ||
+        (!data.isCreating && assistant?.version !== 3)
           ? model.supports_classic_assistants
           : model.supports_next_gen_assistants) &&
         model.type === interactionMode
@@ -237,6 +238,10 @@
       (model) =>
         !model.is_latest &&
         !(model.hide_in_model_selector ?? false) &&
+        ((data.isCreating && createClassicAssistant) ||
+        (!data.isCreating && assistant?.version !== 3)
+          ? model.supports_classic_assistants
+          : model.supports_next_gen_assistants) &&
         model.type === interactionMode
     ) || []
   ).map((model) => ({


### PR DESCRIPTION
- Fixed: Latest Models unavailable in Classic Assistants may appear in the Model Selector when updating a Classic Assistant.
- Fixed: Pinned Models unavailable in Classic Assistants may appear in the Model Selector when creating or updating a Classic Assistant.