### PR TITLE
fix(next-gen)/ Pass assistant instructions on first run

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -4132,7 +4132,6 @@ async def create_run(
                     await request.state.db.flush()
                     await request.state.db.refresh(thread)
 
-                print("Creating new run with instructions:", thread.instructions)
                 run_to_complete = models.Run(
                     status=schemas.RunStatus.PENDING,
                     thread_id=thread.id,
@@ -4488,8 +4487,6 @@ async def send_message(
             if thread.vector_store_id
             else None
         )
-
-        print("Thread Instructions:", thread.instructions)
 
         if thread.version <= 2:
             metadata: dict[str, str | int] = {


### PR DESCRIPTION
## Threads
### Resolved Issues
- Fixed: Next-Gen Assistants may have unexpected behavior in the first conversation turn because they do not receive their instructions when generating the first response.