### PR TITLE
fix/ Class Thread Export options may not be respected

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1339,7 +1339,10 @@ class User(Base):
         stmt = (
             select(User.id)
             .outerjoin(ExternalLogin)
-            .join(ExternalLoginProvider)
+            .outerjoin(
+                ExternalLoginProvider,
+                ExternalLogin.provider_id == ExternalLoginProvider.id,
+            )
             .where(
                 or_(
                     func.lower(User.email).in_(lower_emails),
@@ -4478,7 +4481,9 @@ class Thread(Base):
         include_only_user_ids: list[int] | None = None,
     ) -> AsyncGenerator["Thread", None]:
         condition = Thread.class_id == int(class_id)
-        if include_only_user_ids:
+        if include_only_user_ids is not None:
+            if not include_only_user_ids:
+                return
             condition = and_(
                 condition, Thread.users.any(User.id.in_(include_only_user_ids))
             )


### PR DESCRIPTION
## Thread Exports
### Resolved Issues
- Fixed: When user emails are provided in the export request to restrict which users are included in the export, only users with at least one External Login are included.
- Fixed: When no user account matches are found from the provided user emails, the export will include threads from all users.