### PR TITLE
feat/ Show error message when `fetchRecording` fails

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -853,6 +853,7 @@
 
     for await (const chunk of await res) {
       if ((chunk as { type: string }).type === 'error') {
+        sadToast(`Failed to load recording: ${(chunk as { detail: string }).detail}`);
         return;
       }
       chunks.push(chunk as Uint8Array);


### PR DESCRIPTION
## Voice Mode
### Updates & Improvements
- Users will now see an error toast message when the voice recording they are trying to access is not found or unavailable.