### PR TITLE
fix/ Only set hidePrompt/useLatex when isCreating

### DIFF
--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -107,7 +107,7 @@
     instructions = assistant.instructions;
     hasSetInstructions = true;
   }
-  let hidePrompt = true;
+  let hidePrompt = data.isCreating;
   let hasSetHidePrompt = false;
   $: if (
     assistant?.hide_prompt !== undefined &&
@@ -117,7 +117,7 @@
     hidePrompt = assistant?.hide_prompt;
     hasSetHidePrompt = true;
   }
-  let useLatex = true;
+  let useLatex = data.isCreating;
   let hasSetUseLatex = false;
   $: if (assistant?.use_latex !== undefined && assistant?.use_latex !== null && !hasSetUseLatex) {
     useLatex = assistant?.use_latex;


### PR DESCRIPTION
## Assistants
### Updates & Improvements
- Hide Prompt and Use LaTeX are now selected by default when creating a new Assistant.