### PR TITLE
fix/ Typo in `add_code_interpreter_files` call

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -4542,7 +4542,7 @@ class Thread(Base):
             yield row.Thread
 
     @classmethod
-    async def add_code_interpeter_files(
+    async def add_code_interpreter_files(
         cls, session: AsyncSession, thread_id: int, file_ids: list[str]
     ) -> None:
         if not file_ids:

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -4473,7 +4473,7 @@ async def send_message(
                 thread.updated = func.now()
 
         if data.code_interpreter_file_ids:
-            await models.Thread.add_code_interpeter_files(
+            await models.Thread.add_code_interpreter_files(
                 request.state.db, thread.id, data.code_interpreter_file_ids
             )
 


### PR DESCRIPTION
## Threads
### Resolved Issues
- Fixed: Files generated by a Code Interpreter call may not be accessible to Next-Gen Assistants in subsequent responses. (Closes #1038)