### PR TITLE
fix/ Canvas API may return empty final pages

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -524,7 +524,7 @@ class CanvasCourseClient(ABC):
         page_num = 0
         async for result in self._request_all_pages(request_url, params=params):
             if not result:
-                return page_num == 0
+                return page_num > 0
             page_num += 1
             for user in result:
                 if (


### PR DESCRIPTION
## Canvas Sync
### Resolved Issues
- Fixed: Users may incorrectly see the error message _"You are not an authorized teacher or TA in the Canvas class you are trying to access."_ when trying to sync a class with PingPong because the Canvas API might return an empty final page in paginated responses.
