### PR TITLE
docs/ Replace SIS with SSO in missing information error message

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -537,7 +537,7 @@ class CanvasCourseClient(ABC):
                     )
                     raise CanvasException(
                         code=403,
-                        detail="You do not have permission to access SIS information for at least one user in this class. Please ask another privileged user to set up Canvas Sync. If you're still facing issues, contact your Canvas administrator.",
+                        detail="You do not have permission to access SSO information for at least one user in this class. Please ask another privileged user to set up Canvas Sync. If you're still facing issues, contact your Canvas administrator.",
                     )
                 if not user.get("email"):
                     if self.sync_with_incomplete_profiles:


### PR DESCRIPTION
## Canvas Integration
### Updates & Improvements
- Replace SIS with better known SSO terminology in missing information error message