### PR TITLE
workflows/ Change Sentry release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,6 @@ jobs:
             exit 1
           fi
 
-          # Require: v<major>.<minor>[.<patch>][-<prerelease>]
-          # Examples: v1.0, v2.5.1, v3.2.0-beta.1
           if [[ ! "$RELEASE_NAME" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "Error: release.name must follow v<major>.<minor>[.<patch>][-<prerelease>]"
             echo "Found: $RELEASE_NAME"
@@ -70,7 +68,6 @@ jobs:
             exit 1
           fi
 
-          # Extract the build version - everything before first '-'
           BUILD="${RELEASE_TAG%%-*}"
 
           if [[ ! "$BUILD" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Sentry Release tags follows Sentry's preferred SemVer Version formatting, e.g. `pingpong@6.0+800`.
- The auto-incrementing commit number in the commit tag is used as the build number, e.g. build `809` from tag `809-srv383-web238`.
- The release workflow will fail if the release name does not follow PingPong's SemVer Version formatting (`v<major>.<minor>.<patch?>-<prerelease?>`). This change prevents issues where the commit tag name is used as a release name, which is GitHub's default.
- Sentry releases are correctly tagged with "staging" or "production" environments.