### PR TITLE
fix/ Cannot update assistant with CI files

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -5600,7 +5600,9 @@ async def update_assistant(
     openai_client: OpenAIClient,
 ):
     # Get the existing assistant.
-    asst = await models.Assistant.get_by_id_with_ci_files(request.state.db, int(assistant_id))
+    asst = await models.Assistant.get_by_id_with_ci_files(
+        request.state.db, int(assistant_id)
+    )
     grants = list[Relation]()
     revokes = list[Relation]()
 


### PR DESCRIPTION
Resolves an issue where the Update Assistant endpoint would fail because of lazy loading changes introduced in #1050 