### PR TITLE
internal/ Add `max_request_body_size` parameter to Sentry init

### DIFF
--- a/pingpong/errors.py
+++ b/pingpong/errors.py
@@ -16,5 +16,6 @@ def sentry():
             profiles_sample_rate=1.0,
             profile_lifecycle="trace",
             enable_logs=True,
+            max_request_body_size="always",
         )
     yield


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Adds the following configuration option to the Sentry backend integration:
    - <code><a href="https://docs.sentry.io/platforms/python/configuration/options/#max_request_body_size">max_request_body_size</a> = "always"</code>: This parameter controls whether integrations should capture HTTP request bodies. `always`: The SDK will always capture the request body as long as Sentry can make sense of it.