### PR TITLE
fix/ Cannot display all threads

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -4625,6 +4625,7 @@ class Thread(Base):
                     User.first_name,
                     User.last_name,
                     User.anonymous_link_id,
+                    User.created,
                 )
             )
             .options(


### PR DESCRIPTION
## Thread Archive
### Resolved Issues
- Fixed: Loading the threads archive may fail because of lazy loading code changes introduced.