### PR TITLE
Add UI support for web search streaming data

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1410,6 +1410,36 @@ class FileSearchMessage(BaseModel):
     output_index: int | None = None
 
 
+class WebSearchSource(BaseModel):
+    url: str | None = None
+    name: str | None = None
+
+
+class WebSearchCall(BaseModel):
+    step_id: str
+    type: Literal["web_search_call"]
+    action_type: WebSearchActionType | None = None
+    query: str | None = None
+    url: str | None = None
+    pattern: str | None = None
+    sources: list[WebSearchSource] | None = None
+    status: Literal["in_progress", "searching", "completed", "incomplete", "failed"]
+
+
+class WebSearchMessage(BaseModel):
+    id: str
+    assistant_id: str
+    created_at: float
+    content: list[WebSearchCall]
+    metadata: dict[str, str]
+    object: Literal["thread.message"]
+    message_type: Literal["web_search_call"]
+    role: Literal["assistant"]
+    run_id: str
+    thread_id: str
+    output_index: int | None = None
+
+
 class CodeInterpreterMessage(BaseModel):
     id: str
     assistant_id: str

--- a/web/pingpong/package.json
+++ b/web/pingpong/package.json
@@ -54,7 +54,8 @@
     "katex": "^0.16.21",
     "marked": "^11.2.0",
     "marked-highlight": "^2.1.4",
-    "svelte-copy": "^1.4.2"
+    "svelte-copy": "^1.4.2",
+    "tldts": "^7.0.18"
   },
   "pnpm": {
     "overrides": {

--- a/web/pingpong/pnpm-lock.yaml
+++ b/web/pingpong/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       svelte-copy:
         specifier: ^1.4.2
         version: 1.4.2(svelte@4.2.19)
+      tldts:
+        specifier: ^7.0.18
+        version: 7.0.18
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.2.4
@@ -2211,6 +2214,13 @@ packages:
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.18:
+    resolution: {integrity: sha512-jqJC13oP4FFAahv4JT/0WTDrCF9Okv7lpKtOZUGPLiAnNbACcSg8Y8T+Z9xthOmRBqi/Sob4yi0TE0miRCvF7Q==}
+
+  tldts@7.0.18:
+    resolution: {integrity: sha512-lCcgTAgMxQ1JKOWrVGo6E69Ukbnx4Gc1wiYLRf6J5NN4HRYJtCby1rPF8rkQ4a6qqoFBK5dvjJ1zJ0F7VfDSvw==}
+    hasBin: true
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -4505,6 +4515,12 @@ snapshots:
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
+
+  tldts-core@7.0.18: {}
+
+  tldts@7.0.18:
+    dependencies:
+      tldts-core: 7.0.18
 
   to-fast-properties@2.0.0: {}
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -2139,7 +2139,19 @@ export type TextAnnotationFileCitation = {
   type: 'file_citation';
 };
 
-export type TextAnnotation = TextAnnotationFilePath | TextAnnotationFileCitation;
+export type TextAnnotationURLCitation = {
+  end_index: number;
+  start_index: number;
+  text: string;
+  title?: string | null;
+  type: 'url_citation';
+  url: string;
+};
+
+export type TextAnnotation =
+  | TextAnnotationFilePath
+  | TextAnnotationFileCitation
+  | TextAnnotationURLCitation;
 
 export type Text = {
   annotations: TextAnnotation[];
@@ -2193,6 +2205,22 @@ export type FileSearchCallItem = {
   status?: 'in_progress' | 'searching' | 'completed' | 'incomplete' | 'failed';
 };
 
+export type WebSearchSource = {
+  url?: string | null;
+  name?: string | null;
+};
+
+export type WebSearchCallItem = {
+  step_id: string;
+  type: 'web_search_call';
+  status?: 'in_progress' | 'searching' | 'completed' | 'incomplete' | 'failed';
+  action_type?: 'search' | 'find' | 'open_page' | null;
+  query?: string | null;
+  url?: string | null;
+  pattern?: string | null;
+  sources?: WebSearchSource[];
+};
+
 export type ReasoningSummaryPart = {
   id?: number;
   part_index: number;
@@ -2216,6 +2244,7 @@ export type Content =
   | MessageContentCodeOutputLogs
   | CodeInterpreterCallPlaceholder
   | FileSearchCallItem
+  | WebSearchCallItem
   | ReasoningCallItem;
 
 export type OpenAIMessage = {
@@ -2229,7 +2258,12 @@ export type OpenAIMessage = {
   vision_file_ids?: string[];
   metadata: Record<string, unknown> | null;
   object: 'thread.message' | 'code_interpreter_call_placeholder';
-  message_type?: 'file_search_call' | 'code_interpreter_call' | 'reasoning' | null;
+  message_type?:
+    | 'file_search_call'
+    | 'web_search_call'
+    | 'code_interpreter_call'
+    | 'reasoning'
+    | null;
   role: 'user' | 'assistant';
   run_id: string | null;
   attachments: OpenAIAttachment[] | null;
@@ -2255,6 +2289,7 @@ export type ThreadWithMeta = {
   messages: OpenAIMessage[];
   ci_messages: OpenAIMessage[];
   fs_messages: OpenAIMessage[];
+  ws_messages: OpenAIMessage[];
   reasoning_messages: OpenAIMessage[];
   attachments: Record<string, ServerFile>;
   instructions: string | null;
@@ -2325,6 +2360,7 @@ export type ThreadMessages = {
   messages: OpenAIMessage[];
   ci_messages: OpenAIMessage[];
   fs_messages: OpenAIMessage[];
+  ws_messages: OpenAIMessage[];
   reasoning_messages: OpenAIMessage[];
   limit: number;
   has_more: boolean;
@@ -2347,6 +2383,7 @@ export const getThreadMessages = async (
       limit: null,
       messages: [],
       fs_messages: [],
+      ws_messages: [],
       ci_messages: [],
       reasoning_messages: [],
       has_more: false,
@@ -2360,6 +2397,7 @@ export const getThreadMessages = async (
     messages: expanded.data.messages,
     ci_messages: expanded.data.ci_messages,
     fs_messages: expanded.data.fs_messages,
+    ws_messages: expanded.data.ws_messages,
     reasoning_messages: expanded.data.reasoning_messages,
     limit: expanded.data.limit,
     has_more: hasMore,
@@ -2440,6 +2478,16 @@ export type FileSearchCall = {
   status: 'in_progress' | 'searching' | 'completed' | 'incomplete' | 'failed';
 };
 
+export type WebSearchCall = {
+  id: string;
+  index: number;
+  output_index?: number;
+  type: 'web_search';
+  run_id: string | null;
+  status: 'in_progress' | 'searching' | 'completed' | 'incomplete' | 'failed';
+  action?: WebSearchCallItem;
+};
+
 export type ReasoningStepSummaryPartChunk = {
   reasoning_step_id: number;
   part_index: number;
@@ -2458,7 +2506,7 @@ export type ReasoningCall = {
 };
 
 // TODO(jnu): support function calling, updates for v2
-export type ToolCallDelta = CodeInterpreterCall | FileSearchCall;
+export type ToolCallDelta = CodeInterpreterCall | FileSearchCall | WebSearchCall;
 
 export type ThreadStreamToolCallCreatedChunk = {
   type: 'tool_call_created';

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -58,7 +58,9 @@
   import FileCitation from './FileCitation.svelte';
   import StatusErrors from './StatusErrors.svelte';
   import FileSearchCallItem from './FileSearchCallItem.svelte';
+  import WebSearchCallItem from './WebSearchCallItem.svelte';
   import ReasoningCallItem from './ReasoningCallItem.svelte';
+  import WebSourceChip from './WebSourceChip.svelte';
   export let data;
 
   let userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -207,6 +209,9 @@
 
   function isFileCitation(a: api.TextAnnotation): a is api.TextAnnotationFileCitation {
     return a.type === 'file_citation' && a.text === 'responses_v3';
+  }
+  function isURLCitation(a: api.TextAnnotation): a is api.TextAnnotationURLCitation {
+    return a.type === 'url_citation';
   }
   const getShortMessageTimestamp = (timestamp: number) => {
     return new Intl.DateTimeFormat('en-US', {
@@ -942,6 +947,7 @@
               {@const { clean_string, images } = processString(content.text.value)}
               {@const imageInfo = convertImageProxyToInfo(images)}
               {@const quoteCitations = (content.text.annotations ?? []).filter(isFileCitation)}
+              {@const urlCitations = (content.text.annotations ?? []).filter(isURLCitation)}
 
               <div class="leading-6">
                 <Markdown
@@ -960,6 +966,18 @@
                     <FileCitation
                       name={citation.file_citation.file_name}
                       quote={citation.file_citation.quote}
+                    />
+                  {/each}
+                </div>
+              {/if}
+              {#if urlCitations.length > 0}
+                <div class="flex flex-wrap gap-2 mt-1">
+                  {#each urlCitations as citation}
+                    <WebSourceChip
+                      source={{
+                        url: citation.url,
+                        name: citation.title ?? undefined
+                      }}
                     />
                   {/each}
                 </div>
@@ -1016,6 +1034,8 @@
               >
             {:else if content.type === 'file_search_call'}
               <FileSearchCallItem {content} />
+            {:else if content.type === 'web_search_call'}
+              <WebSearchCallItem {content} />
             {:else if content.type === 'reasoning'}
               <ReasoningCallItem {content} />
             {:else if content.type === 'code_output_image_file'}

--- a/web/pingpong/src/lib/components/WebSearchCallItem.svelte
+++ b/web/pingpong/src/lib/components/WebSearchCallItem.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { slide } from 'svelte/transition';
+  import { ChevronDownOutline, GlobeOutline } from 'flowbite-svelte-icons';
+  import type { WebSearchCallItem } from '$lib/api';
+  import WebSourceChip from './WebSourceChip.svelte';
+
+  export let content: WebSearchCallItem;
+
+  let open = false;
+  const toggle = () => (open = !open);
+
+  const statusText = () => {
+    switch (content.status) {
+      case 'completed':
+        return 'Searched the web';
+      case 'failed':
+        return 'Web search failed';
+      case 'incomplete':
+        return 'Web search was canceled';
+      default:
+        return 'Searching the web...';
+    }
+  };
+</script>
+
+  <div class="my-3">
+    <div class="flex items-center gap-2">
+      <GlobeOutline class="h-4 w-4 text-gray-600" />
+    <button class="flex flex-row items-center gap-2" on:click={toggle}>
+      <span
+        class={`text-sm font-medium ${
+          content.status === 'failed'
+            ? 'text-red-600'
+            : content.status === 'incomplete'
+              ? 'text-yellow-600'
+              : 'text-gray-600'
+        } ${content.status === 'completed' ? '' : 'shimmer'}`}
+        >{statusText()}</span
+      >
+      <ChevronDownOutline class={`text-gray-600 transition ${open ? 'rotate-180' : ''}`} />
+    </button>
+  </div>
+  {#if open}
+    <div
+      class="ml-2 mt-1 border-l border-gray-200 pl-4 text-sm text-gray-600 font-light space-y-2"
+      transition:slide={{ duration: 250 }}
+    >
+      {#if content.action_type === 'search' && content.query}
+        <div class="leading-5">Query: {content.query}</div>
+      {/if}
+      {#if content.action_type === 'find'}
+        {#if content.pattern}
+          <div class="leading-5">Pattern: {content.pattern}</div>
+        {/if}
+        {#if content.url}
+          <div class="leading-5 break-all">Within: {content.url}</div>
+        {/if}
+      {/if}
+      {#if content.action_type === 'open_page' && content.url}
+        <div class="leading-5 break-all">Opened: {content.url}</div>
+      {/if}
+      {#if content.sources && content.sources.length > 0}
+        <div class="flex flex-wrap gap-2 pt-1">
+          {#each content.sources as source (source.url || source.name || Math.random())}
+            <WebSourceChip {source} />
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style lang="css">
+  .shimmer {
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    animation-delay: 0s;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    animation-name: shimmer;
+    background: #4b5563 -webkit-gradient(linear, 100% 0, 0 0, from(#5d5d5d), color-stop(0.4, #ffffffbf), to(#4b5563),
+        color-stop(0.6, #ffffffbf), to(#4b5563));
+    -webkit-background-clip: text;
+    background-clip: text;
+    background-position: -100% 0;
+    background-position: unset top;
+    background-repeat: no-repeat;
+    background-size: 50% 200%;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: -100% 0;
+    }
+    100% {
+      background-position: 250% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .shimmer {
+      animation: none;
+    }
+  }
+
+  .shimmer:hover {
+    -webkit-text-fill-color: #374151;
+    color: #374151;
+    background: 0 0;
+  }
+</style>

--- a/web/pingpong/src/lib/components/WebSourceChip.svelte
+++ b/web/pingpong/src/lib/components/WebSourceChip.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { WebSearchSource } from '$lib/api';
+  import { happyToast } from '$lib/toast';
+  import { parse } from 'tldts';
+
+  export let source: WebSearchSource;
+
+  const domainFromUrl = (url?: string | null) => {
+    if (!url) return '';
+    const parsed = parse(url);
+    if (parsed.domain) {
+      return parsed.domain;
+    }
+    try {
+      const parsedUrl = new URL(url);
+      return parsedUrl.hostname;
+    } catch (err) {
+      console.error('Invalid URL provided to WebSourceChip', err);
+      return url;
+    }
+  };
+
+  const domain = domainFromUrl(source?.url);
+  const faviconUrl = source?.url
+    ? `https://www.google.com/s2/favicons?domain_url=${encodeURIComponent(source.url)}&sz=64`
+    : undefined;
+
+  const label = source?.name || domain || source?.url || 'Source';
+
+  const showToast = () => {
+    const namePart = source?.name ? `${source.name}\n` : '';
+    const urlPart = source?.url || 'No URL provided';
+    happyToast(`${namePart}${urlPart}`, 5000);
+  };
+</script>
+
+<button
+  type="button"
+  class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100"
+  on:click|stopPropagation={showToast}
+>
+  {#if faviconUrl}
+    <img alt="Favicon" src={faviconUrl} class="h-4 w-4 rounded-full" loading="lazy" />
+  {/if}
+  <span class="truncate max-w-[12rem]" title={source?.name || domain}>{label}</span>
+</button>

--- a/web/pingpong/src/lib/content.ts
+++ b/web/pingpong/src/lib/content.ts
@@ -26,6 +26,9 @@ export const parseTextContent = (text: Text, threadVersion: number = 2, baseUrl:
         const { start_index, end_index, file_citation } = annotation;
         const fileName = ` (${file_citation.file_name})`;
         replacements.push({ start: start_index, end: end_index, newValue: fileName });
+      } else if (annotation.type === 'url_citation') {
+        const { start_index, end_index } = annotation;
+        replacements.push({ start: start_index, end: end_index, newValue: '' });
       }
     }
   }


### PR DESCRIPTION
## Summary
- send web search tool call progress to the client and persist action details
- surface stored web search calls and URL citations in thread responses
- render web search activity and sources in the UI with domain chips and favicon toasts

## Testing
- pnpm check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbf123be88328973a1d69037fbb17)