### PR TITLE
fix/ Tool calls may be displayed under a separate assistant message

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -1517,6 +1517,8 @@ class BufferedResponseStreamHandler:
                     "output_index": self.prev_output_index,
                     "type": "code_interpreter",
                     "code_interpreter": {"input": data.code or "", "outputs": None},
+                    "status": data.status,
+                    "run_id": str(self.run_id),
                 },
             }
         )


### PR DESCRIPTION
## Threads
### Resolved Issues
- Fixed: Web Search tool calls may be displayed under a separate assistant message when streaming.
- Fixed: Code Interpreter tool calls may be displayed under a separate assistant message when streaming.