### PR TITLE
Add PDF export option for next-gen thread pages

### DIFF
--- a/web/pingpong/src/lib/components/ReasoningCallItem.svelte
+++ b/web/pingpong/src/lib/components/ReasoningCallItem.svelte
@@ -5,10 +5,15 @@
   import Markdown from './Markdown.svelte';
 
   export let content: ReasoningCallItem;
+  export let forceOpen: boolean = false;
 
   let open = false;
 
   $: hasSummary = (content.summary && content.summary.length > 0) || false;
+
+  $: if (forceOpen && hasSummary) {
+    open = true;
+  }
 
   const toggle = () => {
     if (hasSummary) {


### PR DESCRIPTION
## Summary
- add a next-gen-only print/PDF action that loads all thread messages and prepares the UI for export
- expand reasoning accordions on demand and keep code/output accordions open during print preparation
- add print-friendly layout rules to keep thread content together on exported pages

## Testing
- pnpm test index.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b87f42c048328b3f54a163acaebc3)