### PR TITLE
fix/ Can’t delete Group when Canvas Sync is dismissed

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -1774,7 +1774,10 @@ async def delete_class(class_id: str, request: Request):
 
     # All private and class files associated with the class_id
     # are deleted by the database cascade
-    if class_.lms_status and class_.lms_status != schemas.LMSStatus.NONE:
+    if class_.lms_status and class_.lms_status not in {
+        schemas.LMSStatus.DISMISSED,
+        schemas.LMSStatus.NONE,
+    }:
         await remove_canvas_connection(request.state.db, class_.id, request=request)
 
     stmt = delete(models.UserClassRole).where(


### PR DESCRIPTION
## Canvas Sync
### Resolved Issues
- Fixed: A Group may fail to delete when Canvas Sync is dismissed in the Manage Group page. 

Closes #915