### PR TITLE
fix/ Clean up anonymous link file permissions after thread creation

### DIFF
--- a/pingpong/authz/mock.py
+++ b/pingpong/authz/mock.py
@@ -3,6 +3,7 @@ import json
 import logging
 import multiprocessing
 import time
+from datetime import datetime, timezone
 from typing import Tuple
 
 import aiohttp
@@ -137,6 +138,7 @@ class _MockFgaAuthzServer:
             raise ValueError("Missing relation or object")
 
         tuples = []
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         for u, rel, o in self._all_grants:
             if rel != relation or o != obj:
                 continue
@@ -148,7 +150,8 @@ class _MockFgaAuthzServer:
                         "user": u,
                         "relation": rel,
                         "object": o,
-                    }
+                    },
+                    "timestamp": now,
                 }
             )
 

--- a/pingpong/files.py
+++ b/pingpong/files.py
@@ -72,7 +72,11 @@ def _file_grants_revoke(
         )
     if file.anonymous_link:
         grants.append(
-            (f"anonymous_link:{file.anonymous_link.id}", "can_delete", target)
+            (
+                f"anonymous_link:{file.anonymous_link.share_token}",
+                "can_delete",
+                target,
+            )
         )
 
     grants.append((f"user:{file.uploader_id}", "owner", target))

--- a/pingpong/test_anonymous_file_permissions.py
+++ b/pingpong/test_anonymous_file_permissions.py
@@ -1,0 +1,98 @@
+from pingpong.files import _file_grants
+import pingpong.schemas as schemas
+from pingpong import models
+
+from .testutil import with_authz
+
+
+@with_authz(grants=[])
+async def test_anonymous_share_file_delete_permission_revoked_on_thread_create(
+    api, authz, config, db, monkeypatch
+):
+    async def fake_generate_name(*_args, **_kwargs):
+        return schemas.ThreadName(name="Test Thread", can_generate=True)
+
+    monkeypatch.setattr("pingpong.ai.generate_name", fake_generate_name)
+
+    share_token = "share-token-123"
+    async with db.async_session() as session:
+        creator = models.User(email="creator@test.org")
+        session.add(creator)
+        await session.flush()
+
+        class_ = models.Class(name="Test Class", api_key="test-key")
+        session.add(class_)
+        await session.flush()
+
+        assistant = models.Assistant(
+            name="Test Assistant",
+            instructions="Test instructions",
+            model="gpt-4o-mini",
+            class_id=class_.id,
+            creator_id=creator.id,
+            assistant_should_message_first=False,
+            version=3,
+            interaction_mode=schemas.InteractionMode.CHAT,
+        )
+        session.add(assistant)
+        await session.flush()
+
+        share_link = await models.AnonymousLink.create(
+            session,
+            share_token=share_token,
+            assistant_id=assistant.id,
+        )
+        anonymous_user = await models.User.create_anonymous_user(
+            session, anonymous_link_id=share_link.id
+        )
+
+        file = await models.File.create(
+            session,
+            data={
+                "file_id": "file_abc123",
+                "private": True,
+                "uploader_id": anonymous_user.id,
+                "name": "notes.txt",
+                "content_type": "text/plain",
+                "class_id": class_.id,
+                "anonymous_link_id": share_link.id,
+            },
+            class_id=class_.id,
+        )
+        await session.commit()
+
+    async with config.authz.driver.get_client() as authz_client:
+        await authz_client.write_safe(
+            grant=_file_grants(
+                file, class_.id, None, f"anonymous_link:{share_token}", None
+            )
+        )
+
+        await authz_client.write_safe(
+            grant=[
+                (
+                    f"anonymous_link:{share_token}",
+                    "can_create_thread",
+                    f"class:{class_.id}",
+                )
+            ]
+        )
+
+    response = api.post(
+        f"/api/v1/class/{class_.id}/thread",
+        json={
+            "message": "hello",
+            "assistant_id": assistant.id,
+            "code_interpreter_file_ids": [file.file_id],
+        },
+        headers={"X-Anonymous-Link-Share": share_token},
+    )
+    assert response.status_code == 200
+
+    calls = await authz.get_all_calls()
+    assert (
+        "revoke",
+        f"anonymous_link:{share_token}",
+        "can_delete",
+        f"user_file:{file.id}",
+    ) in calls


### PR DESCRIPTION
## Anonymous Sessions
### Resolved Issues
- Fixed: The permission to delete a user file for the associated meta user of the shared link is not removed after the thread and Anonymous Session token are created. The associated meta user of the shared link does not have permissions to view the file.

## Threads
### Resolved Issues
- Fixed: When creating a thread, the server might not raise an error because disconnecting user records from the thread database record could fail.

## Internal
### Resolved Issues
- Fixed: The mock authentication server may fail OpenFGA's `read` checks because responses do not include a `timestamp`.

Closes #925