### PR TITLE
fix(authz): add correlation_id to batch check and ensure ordered results

### DIFF
--- a/pingpong/authz/openfga.py
+++ b/pingpong/authz/openfga.py
@@ -224,11 +224,14 @@ class OpenFgaAuthzClient(AuthzClient):
                 user=entity,
                 relation=relation,
                 object=target,
+                correlation_id=str(index),
             )
-            for entity, relation, target in checks
+            for index, (entity, relation, target) in enumerate(checks)
         ]
         response = await self._cli.batch_check(ClientBatchCheckRequest(checks=query))
-        return [c.allowed for c in response.result]
+        ordered = {item.correlation_id: item for item in response.result}
+        results = [ordered[str(index)] for index in range(len(query))]
+        return [c.allowed for c in results]
 
     async def write(
         self,


### PR DESCRIPTION
Resolves an issue where the server may infer incorrect permissions based on the responses from the authentication server.

Starting in `openfga-sdk v0.9.0`, a breaking change was introduced to accommodate the new OpenFGA server based batch check. The side effect is that our client can no longer rely on the order of the results returned to construct the checks passed.

Adds an index-based `correlation_id` and uses it to order the results before returning to the caller.

> #### "I want to migrate to the new server based batch check"
> If you wish to migrate to the new method, whilst the method name remains the same. You will need to alter the way you construct the checks passed.
> 
> * Previously a list of `ClientCheckRequest` was constructed and passed directly to `batch_check`, now you should construct a list of `ClientBatchCheckItem` and pass a `ClientBatchCheckRequest` to `batch_check` with that list as the `checks` property
>   
>   * The `correlation_id` on a `ClientBatchCheckItem` is set for you if you do not provide it.
> * The `result` now contains a `correlation_id` property in addition to the `error` and `request` types and has removed the `response` property. Additionally, the `error` property is now of a `CheckError` type, rather than an `Exception` type.
> 
> ```diff
> checks = [
> -  ClientCheckRequest(
> +  ClientBatchCheckItem(
>         user="user:1",
>         relation="owner",
>         object="document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
>         contextual_tuples=[
>             ClientTuple(
>                 user="user:1",
>                 relation="owner",
>                 object="document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
>             )
>         ]
>     ),
> -  ClientCheckRequest(
> +  ClientBatchCheckItem(
>         user="use:2",
>         relation="owner",
>         object="document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"
>     )
> ]
> 
> - result = fga_client.client_batch_check(checks)
> + result = fga_client.batch_check(ClientBatchCheckRequest(checks=checks))
> 
> # response.result = [{
> #   allowed: true,
> #   correlation_id: "de3630c2-f9be-4ee5-9441-cb1fbd82ce75", # generated by the SDK
> #   tuple: {
> #     user: "user:1",
> #     relation: "viewer",
> #     object: "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
> #     contextual_tuples: [{
> #       user: "user:1",
> #       relation: "editor",
> #       object: "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"
> #     }]
> #   }
> # }, {
> #   allowed: false,
> #   correlation_id: "6d7c7129-9607-480e-bfd0-17c16e46b9ec",
> #   tuple: {
> #     user="user:2",
> #     relation="own",
> #     object="document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"
> #   },
> #   error: {
> #     input_error: "validation_error",
> #     message: "type 'doc' not found"
> #   }
> # }] 
> ```
> 
## References
* [openfga/python-sdk#154](https://github.com/openfga/python-sdk/pull/154)
* [openfga docs: Calling Batch Check API](https://openfga.dev/docs/getting-started/perform-check#03-calling-batch-check-api)