### PR TITLE
fix(ui): restore sticky header tracking for dropdown scroll positioning

### DIFF
--- a/web/pingpong/src/lib/components/ModelDropdownOptions.svelte
+++ b/web/pingpong/src/lib/components/ModelDropdownOptions.svelte
@@ -7,6 +7,8 @@
 	interface Props {
 		modelOptions: AssistantModelOptions[];
 		modelNodes: { [key: string]: HTMLElement };
+		optionHeaders?: { [key: string]: string };
+		headerClass?: string;
 		selectedModel: string;
 		updateSelectedModel: (model: string) => void;
 		allowVisionUpload: boolean;
@@ -16,11 +18,22 @@
 	let {
 		modelOptions,
 		modelNodes = $bindable(),
+		optionHeaders = $bindable(),
+		headerClass,
 		selectedModel,
 		updateSelectedModel,
 		allowVisionUpload,
 		smallNameText = false
 	}: Props = $props();
+
+	$effect(() => {
+		if (!headerClass || !optionHeaders) {
+			return;
+		}
+		for (const { value } of modelOptions) {
+			optionHeaders[value] = headerClass;
+		}
+	});
 </script>
 
 <div class="relative">

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -959,6 +959,7 @@
 	};
 
 	let modelNodes: { [key: string]: HTMLElement } = $state({});
+	let modelHeaders: { [key: string]: string } = $state({});
 
 	/**
 	 * Determine if a specific field has changed in the form.
@@ -1548,6 +1549,7 @@
 					footer
 					placeholder={selectedModelName || 'Select a model...'}
 					optionNodes={modelNodes}
+					optionHeaders={modelHeaders}
 					disabled={preventEdits}
 					bind:selectedOption={selectedModel}
 					bind:dropdownOpen
@@ -1560,10 +1562,12 @@
 					>
 					<ModelDropdownOptions
 						modelOptions={latestModelOptions}
+						headerClass="latest-models"
 						{selectedModel}
 						{updateSelectedModel}
 						{allowVisionUpload}
 						bind:modelNodes
+						bind:optionHeaders={modelHeaders}
 					/>
 					<DropdownHeader
 						order={2}
@@ -1572,10 +1576,12 @@
 					>
 					<ModelDropdownOptions
 						modelOptions={versionedModelOptions}
+						headerClass="versioned-models"
 						{selectedModel}
 						{updateSelectedModel}
 						{allowVisionUpload}
 						bind:modelNodes
+						bind:optionHeaders={modelHeaders}
 						smallNameText
 					/>
 					<div slot="footer">


### PR DESCRIPTION
The Svelte 5 upgrade (9eb3194) removed the modelHeaders and headerClass props from ModelDropdownOptions, along with the loop that populated the header-to-model mappings. This caused DropdownContainer's $effect to always have an empty optionHeaders object, resulting in totalStickyHeight being 0 and the selected option being obscured by sticky headers.

Restore header tracking by re-adding optionHeaders and headerClass props to ModelDropdownOptions, using an $effect to populate the mappings reactively instead of the previous imperative for loop.