### PR TITLE
fix(ui): No Role Canvas Connect page inaccessible

### DIFF
--- a/web/pingpong/src/routes/+layout.ts
+++ b/web/pingpong/src/routes/+layout.ts
@@ -12,6 +12,7 @@ const EDU = '/eduaccess';
 const LOGOUT = '/logout';
 const LTI_REGISTER = '/lti/register';
 const LTI_INACTIVE = '/lti/inactive';
+const LTI_NO_ROLE = '/lti/no-role';
 const NO_GROUP = '/lti/no-group';
 const SETUP = '/lti/setup';
 
@@ -88,7 +89,11 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
 			redirect(302, destination);
 		}
 	} else {
-		if (url.pathname === LTI_REGISTER || url.pathname === LTI_INACTIVE) {
+		if (
+			url.pathname === LTI_REGISTER ||
+			url.pathname === LTI_INACTIVE ||
+			url.pathname === LTI_NO_ROLE
+		) {
 			isPublicPage = true;
 			openAllLinksInNewTab = true;
 			logoIsClickable = false;


### PR DESCRIPTION
## Canvas Connect
### Resolved Issues
- Fixed: Users without a Teacher or Student role accessing PingPong through Canvas may see a login prompt instead of the No Role page.