### PR TITLE
fix(ui): placeholder color

### DIFF
--- a/web/pingpong/src/app.css
+++ b/web/pingpong/src/app.css
@@ -186,7 +186,7 @@
 /* Override Flowbite's placeholder color */
 input::placeholder,
 textarea::placeholder {
-	color: theme('colors.gray.600');
+	color: var(--color-gray-500);
 }
 
 @layer base {


### PR DESCRIPTION
## UI
### Resolved Issues
- Fixed: Placeholder text in textboxes is the primary (black) color instead of secondary (grey). Resolves #1211.