### PR TITLE
patch: read_latest_authorization_model no longer raises `IndexError`

### DIFF
--- a/pingpong/authz/openfga.py
+++ b/pingpong/authz/openfga.py
@@ -352,15 +352,13 @@ class OpenFgaAuthzDriver(AuthzDriver):
 
         async with self.get_client() as ac:
             c = ac._cli
-            try:
-                latest = await c.read_latest_authorization_model()
-                if not latest.authorization_model:
-                    raise IndexError()
+            latest = await c.read_latest_authorization_model()
+            if latest.authorization_model:
                 self.config.authorization_model_id = latest.authorization_model.id
                 logger.info(
                     f"Using existing model with id {self.config.authorization_model_id}"
                 )
-            except IndexError:
+            else:
                 with open(self.model_config) as f:
                     model = json.load(f)
                     resp = await c.write_authorization_model(model)


### PR DESCRIPTION
Resolves an issue where the authorization server will not copy the model configuration in a fresh setup because `read_latest_authorization_model` no longer raises `IndexError`. 

```diff
    async def read_latest_authorization_model(
        self, options: dict[str, int | str] = None
    ):
        """
        Convenient method of reading the latest authorization model
        :param header(options) - Custom headers to send alongside the request
        :param retryParams(options) - Override the retry parameters for this request
        :param retryParams.maxRetry(options) - Override the max number of retries on each API request
        :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
        """
        options = set_heading_if_not_set(
            options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel"
        )
        options["page_size"] = 1
        api_response = await self.read_authorization_models(options)
        options["page_size"] = 1
        api_response = await self.read_authorization_models(options)
-       return ReadAuthorizationModelResponse(api_response.authorization_models[0])
+       model = (
+           api_response.authorization_models[0]
+           if len(api_response.authorization_models) > 0
+           else None
+       )
+       return ReadAuthorizationModelResponse(model)

    #######################
    # Relationship Tuples
```