### PR TITLE
fix: cannot copy groups/missing mcp tools select

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -2598,6 +2598,7 @@ class Assistant(Base):
                 )
             )
             .options(selectinload(Assistant.code_interpreter_files))
+            .options(selectinload(Assistant.mcp_server_tools))
         )
 
         result = await session.execute(stmt)


### PR DESCRIPTION
## Groups
### Resolved Issues
- Fixed: Copying a Group may raise an error because Assistant MCP tools are not included in the Assistant objects being copied.