### PR TITLE
change(lti): ignore course code in displayed course name

### DIFF
--- a/web/pingpong/src/routes/lti/setup/+page.svelte
+++ b/web/pingpong/src/routes/lti/setup/+page.svelte
@@ -8,11 +8,10 @@
 
 	const { context, ltiClassId } = data;
 
-	// Build display name: "Course Code: Course Name" or just the name if no code
-	const courseName =
-		context.course_code && context.course_name
-			? `${context.course_code}: ${context.course_name}`
-			: context.course_name || context.course_code || 'Your Course';
+	// Build display name: prefer course_name, then course_code, else generic
+	// Previously, we used "Course Code: Course Name", but in many cases the
+	// course code is included in the course name, leading to redundancy.
+	const courseName = context.course_name || context.course_code || 'Your Course';
 
 	const goToCreate = () => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve

--- a/web/pingpong/src/routes/lti/setup/create/+page.svelte
+++ b/web/pingpong/src/routes/lti/setup/create/+page.svelte
@@ -12,12 +12,10 @@
 	const { context, ltiClassId } = data;
 
 	// Pre-fill form with LTI context data
-	// Name: "Course Code: Course Name"
-	let name =
-		context.course_code && context.course_name
-			? `${context.course_code}: ${context.course_name}`
-			: context.course_name || context.course_code || '';
-
+	// Name: "Course Name"
+	// Previously, we used "Course Code: Course Name", but in many cases the
+	// course code is included in the course name, leading to redundancy.
+	let name = context.course_name || context.course_code || '';
 	let term = context.course_term || '';
 	let institutionId: number | null =
 		context.institutions.length === 1 ? context.institutions[0].id : null;

--- a/web/pingpong/src/routes/lti/setup/link/+page.svelte
+++ b/web/pingpong/src/routes/lti/setup/link/+page.svelte
@@ -12,11 +12,9 @@
 	const { context, groups, ltiClassId } = data;
 
 	// Build display name for the course
-	const courseName =
-		context.course_code && context.course_name
-			? `${context.course_code}: ${context.course_name}`
-			: context.course_name || context.course_code || 'Your Course';
-
+	// Previously, we used "Course Code: Course Name", but in many cases the
+	// course code is included in the course name, leading to redundancy.
+	const courseName = context.course_name || context.course_code || 'Your Course';
 	let selectedGroupId: number | undefined = undefined;
 	let error = '';
 


### PR DESCRIPTION
## Canvas Connect
### Updates & Improvements
- The setup screen now displays only the course name without the course code as the course display name, which is also pre-filled when creating a new group through Canvas Connect. Previously, we used "Course Code: Course Name", but in many cases the course code is included in the course name, leading to redundancy. Instructors can still edit their Group name before creating it, or later or in Group Settings.