### PR TITLE
chore(web): enforce SPA and no SSR

### DIFF
--- a/web/pingpong/src/routes/+layout.ts
+++ b/web/pingpong/src/routes/+layout.ts
@@ -16,6 +16,8 @@ const LTI_NO_ROLE = '/lti/no-role';
 const NO_GROUP = '/lti/no-group';
 const SETUP = '/lti/setup';
 
+export const ssr = false;
+
 /**
  * Load the current user and redirect if they are not logged in.
  */


### PR DESCRIPTION
Without it, `pnpm dev` will SSR the main layout, so dev matches prod more closely now.