### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `test-on-staging.yml`

### DIFF
--- a/.github/workflows/test-on-staging.yml
+++ b/.github/workflows/test-on-staging.yml
@@ -1,5 +1,8 @@
 name: Push PR code to AWS Staging
 run-name: "Staging Test: Push ${{ github.event.issue.number }} on AWS"
+permissions:
+  contents: read
+  checks: write
 concurrency: release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/8](https://github.com/comppolicylab/pingpong/security/code-scanning/8)

Generally, the fix is to add an explicit `permissions` block that scopes `GITHUB_TOKEN` to only what this workflow needs. You can add it at the root of the workflow (applies to all jobs) or under the specific `release` job; given there is only one job, adding it at the root is clear and future‑proof.

For this particular workflow:

- It needs to read repository contents for `actions/checkout@v6` → `contents: read`.
- It creates GitHub check runs via `gh api` → `checks: write`.
- It does not push commits, manage issues, or perform other GitHub mutations, so no additional write scopes are required.

The minimal, correct fix is to insert:

```yaml
permissions:
  contents: read
  checks: write
```

near the top of `.github/workflows/test-on-staging.yml`, e.g., after `run-name:` (before `concurrency:` or `on:`). This change does not alter existing functional logic; it only restricts the implicit token permissions to exactly what the steps already require.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
