### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ concurrency: release
 on:
   release:
     types: [published, released]
+permissions:
+  contents: read
 jobs:
   release:
     name: Build and Push/Tag Docker Images for Release


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/7](https://github.com/comppolicylab/pingpong/security/code-scanning/7)

In general, the fix is to declare an explicit `permissions:` block that grants only the minimal scopes required by this workflow, instead of relying on inherited defaults. This can be done at the top level of the workflow (applies to all jobs) or per job; here a top-level `permissions:` is sufficient since there is a single job and it does not need to write to the repository.

The best minimal change, without altering any behavior, is to add a workflow-level `permissions:` block after the `on:` trigger (or after `concurrency:`) to set `contents: read`. The workflow only needs to read release metadata and checkout code; it does not push commits, manage issues, or modify PRs, so `contents: read` is appropriate and will satisfy CodeQL’s recommendation. No other permissions (like `pull-requests` or `issues`) are needed based on the provided snippet. No additional imports or methods are required because this is YAML configuration only.

Concretely: in `.github/workflows/release.yml`, between the existing `on:` block (lines 5–7) and the `jobs:` block (line 8), insert:

```yaml
permissions:
  contents: read
```

This restricts `GITHUB_TOKEN` to read-only repository contents for this workflow, documents the intended privilege level, and keeps behavior unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
