### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `python.yml`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     name: Test Python
+    permissions:
+      contents: read
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/6](https://github.com/comppolicylab/pingpong/security/code-scanning/6)

In general, the fix is to add an explicit `permissions` block either at the workflow level (applies to all jobs) or on the specific `build` job. Since there is only one job shown and it only needs to read repository content via `actions/checkout`, we can set `contents: read` and omit any write scopes. This constrains the `GITHUB_TOKEN` to the minimum privileges required.

The best minimal change without altering existing functionality is to add a job-level `permissions` block under `jobs.build`, at the same indentation level as `name`, `timeout-minutes`, etc. Specifically, in `.github/workflows/python.yml`, between lines 13 and 14 (after `name: Test Python` and before `timeout-minutes: 10`), insert:

```yaml
    permissions:
      contents: read
```

No additional imports, methods, or other definitions are needed, as this is purely a YAML configuration adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
