### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `claude-code-review.yml`

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,7 @@ jobs:
         github.event.comment.author_association
       )
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       run_review: ${{ steps.check.outputs.run_review }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/3](https://github.com/comppolicylab/pingpong/security/code-scanning/3)

To fix this, we should explicitly restrict the `GITHUB_TOKEN` permissions for the `detect-claude-command` job, since it does not need to access repository contents or modify anything on GitHub. The safest and most precise fix is to add a `permissions: {}` block to that job, which disables all default permissions for `GITHUB_TOKEN` while preserving the existing behavior (the job only uses the event payload and environment variables, which do not require token scopes).

Concretely:
- In `.github/workflows/claude-code-review.yml`, under `jobs.detect-claude-command` (around line 12), add a `permissions: {}` entry aligned with `runs-on`.  
- No changes are required for the `claude-review` job, since it already defines a `permissions` block.

This keeps functionality identical but documents and enforces least privilege for the `detect-claude-command` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
