### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `fe.yml`

### DIFF
--- a/.github/workflows/fe.yml
+++ b/.github/workflows/fe.yml
@@ -1,5 +1,8 @@
 name: UI - PingPong
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/2](https://github.com/comppolicylab/pingpong/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block so the `GITHUB_TOKEN` has only the scopes needed. For this workflow, the job only needs to read repository contents to run installs, linting, checks, formatting, and tests. It doesn’t interact with issues, PRs, or perform any write operations to the repo via the token, so `contents: read` is sufficient.

The best non‑breaking fix is to add a `permissions` section at the workflow root (top level, next to `name` and `on`) so all jobs inherit restricted permissions. Concretely, in `.github/workflows/fe.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: UI - PingPong` line and the `on:` block. This documents that the workflow only needs read access to repository contents and ensures that even if the repo/organization default token permissions are broader, this workflow will still run with least privilege. No imports, methods, or additional definitions are needed because this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
