### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `claude.yml`

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   detect-non-claude-review:
     name: Skip Exact @claude Review Command
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       run_claude: ${{ steps.check.outputs.run_claude }}


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/4](https://github.com/comppolicylab/pingpong/security/code-scanning/4)

To fix the problem, explicitly define a `permissions` block for the `detect-non-claude-review` job so it does not inherit potentially broad default `GITHUB_TOKEN` permissions. This job only reads event data passed via environment variables and writes to `$GITHUB_OUTPUT`; it does not interact with repository contents, issues, or PRs. Therefore, it can safely run with no repository or workflow permissions.

The best way to fix this without changing existing functionality is to add `permissions: {}` (or the equivalent multiline form) directly under the `detect-non-claude-review` job header. In GitHub Actions, `permissions: {}` means the `GITHUB_TOKEN` has no scopes, which is sufficient here because the job does not call the GitHub API or manipulate repo state. Concretely, in `.github/workflows/claude.yml`, between the job name line (`name: Skip Exact @claude Review Command`) and the `runs-on` line, insert a `permissions` block that disables all permissions.

No new imports, methods, or definitions are required; this is a pure workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
