### PR TITLE
fix(gha): add explicit permissions for GITHUB_TOKEN in `commit.yml`

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   tag:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/comppolicylab/pingpong/security/code-scanning/5](https://github.com/comppolicylab/pingpong/security/code-scanning/5)

In general, to fix this class of issue you explicitly set a `permissions:` block in the workflow (either at the root or per job), granting only the minimal necessary scopes instead of relying on repository defaults. This documents the workflow’s needs and ensures least-privilege even if org/repo defaults change.

For this specific workflow (`.github/workflows/commit.yml`), the `tag` job needs to be able to push git tags back to the repository, which requires `contents: write`. There is no evidence in the snippet that it needs any additional scopes (no issues, PRs, packages, etc.). The most straightforward, non-breaking change is to add a job-level permissions block under `jobs: tag:`:

```yaml
jobs:
  tag:
    permissions:
      contents: write
    runs-on: ubuntu-latest
    ...
```

This confines elevated permissions only to this job and keeps them as narrow as possible. No imports or code changes inside the Python script are required; only the YAML needs updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
