### PR TITLE
fix(lms): Canvas Sync should use the linker's identity

### DIFF
--- a/pingpong/canvas.py
+++ b/pingpong/canvas.py
@@ -792,6 +792,7 @@ class ManualCanvasClient(CanvasCourseClient):
         self,
         canvas_backend_config: CanvasSettings,
         class_id: int,
+        user_id: int,
         request: Request,
         tasks: BackgroundTasks,
         nowfn: NowFn = utcnow,
@@ -800,7 +801,7 @@ class ManualCanvasClient(CanvasCourseClient):
             canvas_backend_config,
             request.state.db,
             class_id,
-            request.state.session.user.id,
+            user_id,
             nowfn=nowfn,
         )
         self.request = request
@@ -823,7 +824,7 @@ class ManualCanvasClient(CanvasCourseClient):
     async def _update_user_roles(self):
         """Update the user roles for the class."""
         await AddNewUsersManual(
-            str(self.class_id), self.new_ucr, self.request, self.tasks
+            str(self.class_id), self.new_ucr, self.request, self.tasks, self.user_id
         ).add_new_users()
 
     def _raise_sync_error_if_manual(self):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -2086,10 +2086,14 @@ async def update_canvas_class(
 async def sync_canvas_class(
     class_id: str, tenant: str, request: Request, tasks: BackgroundTasks
 ):
+    class_ = await models.Class.get_by_id(request.state.db, int(class_id))
+    if not class_ or not class_.lms_user_id:
+        raise HTTPException(status_code=404, detail="Canvas class not linked")
     canvas_settings = get_canvas_config(tenant)
     async with ManualCanvasClient(
         canvas_settings,
         int(class_id),
+        class_.lms_user_id,
         request,
         tasks,
     ) as client:


### PR DESCRIPTION
## Canvas Connect
### Resolved Issues
- Fixed: When a manual roster sync is triggered with Canvas Sync, the requestor's user id is used instead of the user identity of the user who set up Canvas Sync. As a result, the user who set up Canvas Sync is not skipped when syncing the roster. Users who set up Canvas Sync should not be managed by Canvas.