### PR TITLE
change: move external logins to new user instead of creating new one

### DIFF
--- a/pingpong/merge.py
+++ b/pingpong/merge.py
@@ -259,15 +259,12 @@ async def merge_external_logins(
         .where(
             and_(
                 existing_login.c.user_id == new_user_id,
+                ExternalLogin.provider != "email",
                 or_(
-                    and_(
-                        existing_login.c.provider == ExternalLogin.provider,
-                        existing_login.c.identifier == ExternalLogin.identifier,
-                    ),
+                    existing_login.c.provider == ExternalLogin.provider,
                     and_(
                         ExternalLogin.provider_id.is_not(None),
                         existing_login.c.provider_id == ExternalLogin.provider_id,
-                        existing_login.c.identifier == ExternalLogin.identifier,
                     ),
                 ),
             )

--- a/pingpong/test_merge_external_logins.py
+++ b/pingpong/test_merge_external_logins.py
@@ -58,12 +58,15 @@ async def test_merge_external_logins_moves_rows_to_new_user(db):
             provider_id=canvas_provider.id,
             identifier="canvas-old-id",
         )
+        github_provider = await models.ExternalLoginProvider.get_or_create_by_name(
+            session, "github"
+        )
         existing_new_login = await _create_external_login(
             session,
             user_id=new_user.id,
-            provider="canvas",
-            provider_id=canvas_provider.id,
-            identifier="canvas-new-id",
+            provider="github",
+            provider_id=github_provider.id,
+            identifier="github-new-id",
         )
 
         moved_login_ids = {old_saml_login.id, old_canvas_login.id}
@@ -98,7 +101,7 @@ async def test_merge_external_logins_moves_rows_to_new_user(db):
         }
 
 
-async def test_merge_external_logins_drops_conflicting_duplicates(db):
+async def test_merge_external_logins_drops_same_provider_different_identifier(db):
     async with db.async_session() as session:
         old_user = await _create_user(session, 2011, "old-dup@example.com")
         new_user = await _create_user(session, 2012, "new-dup@example.com")
@@ -115,7 +118,7 @@ async def test_merge_external_logins_drops_conflicting_duplicates(db):
             user_id=old_user.id,
             provider="saml",
             provider_id=saml_provider.id,
-            identifier="shared-sso-id",
+            identifier="shared-sso-id-old",
         )
         old_canvas_login = await _create_external_login(
             session,
@@ -129,7 +132,7 @@ async def test_merge_external_logins_drops_conflicting_duplicates(db):
             user_id=new_user.id,
             provider="saml",
             provider_id=saml_provider.id,
-            identifier="shared-sso-id",
+            identifier="shared-sso-id-new",
         )
 
         await merge_external_logins(session, new_user.id, old_user.id)
@@ -153,3 +156,49 @@ async def test_merge_external_logins_drops_conflicting_duplicates(db):
             old_canvas_login.id,
         }
         assert old_conflicting_saml.id not in {login.id for login in new_user_rows}
+
+
+async def test_merge_external_logins_allows_multiple_email_identifiers(db):
+    async with db.async_session() as session:
+        old_user = await _create_user(session, 2021, "old-email@example.com")
+        new_user = await _create_user(session, 2022, "new-email@example.com")
+
+        email_provider = await models.ExternalLoginProvider.get_or_create_by_name(
+            session, "email"
+        )
+
+        old_email_login = await _create_external_login(
+            session,
+            user_id=old_user.id,
+            provider="email",
+            provider_id=email_provider.id,
+            identifier="old-secondary@example.com",
+        )
+        new_email_login = await _create_external_login(
+            session,
+            user_id=new_user.id,
+            provider="email",
+            provider_id=email_provider.id,
+            identifier="new-secondary@example.com",
+        )
+
+        await merge_external_logins(session, new_user.id, old_user.id)
+        await session.flush()
+
+        old_user_login_count = await session.scalar(
+            select(func.count(models.ExternalLogin.id)).where(
+                models.ExternalLogin.user_id == old_user.id
+            )
+        )
+        assert old_user_login_count == 0
+
+        new_user_rows_result = await session.execute(
+            select(models.ExternalLogin).where(
+                models.ExternalLogin.user_id == new_user.id
+            )
+        )
+        new_user_rows = new_user_rows_result.scalars().all()
+        assert {login.id for login in new_user_rows} == {
+            old_email_login.id,
+            new_email_login.id,
+        }


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Decrease the number of new External Login records created by moving the existing External Login records to the new user ID.