### PR TITLE
fix: prevent duplicate external login collisions during merge

### DIFF
--- a/pingpong/merge.py
+++ b/pingpong/merge.py
@@ -262,7 +262,10 @@ async def merge_external_logins(
         ExternalLoginProvider.internal_only.is_(True)
     )
     old_login_is_internal_only = or_(
-        old_login.c.provider_id.in_(internal_only_provider_ids),
+        and_(
+            old_login.c.provider_id.is_not(None),
+            old_login.c.provider_id.in_(internal_only_provider_ids),
+        ),
         old_login.c.provider.in_(internal_only_provider_names),
     )
 

--- a/pingpong/test_merge_external_logins.py
+++ b/pingpong/test_merge_external_logins.py
@@ -19,7 +19,7 @@ async def _create_external_login(
     user_id: int,
     provider: str,
     identifier: str,
-    provider_id: int,
+    provider_id: int | None,
 ) -> models.ExternalLogin:
     login = models.ExternalLogin(
         user_id=user_id,
@@ -230,6 +230,68 @@ async def test_merge_external_logins_keeps_conflict_filter_when_internal_only_ex
         assert old_conflicting_harvardkey.id not in {
             login.id for login in new_user_rows
         }
+
+
+async def test_merge_external_logins_handles_null_provider_id_as_non_internal(
+    db,
+):
+    async with db.async_session() as session:
+        old_user = await _create_user(session, 2018, "old-legacy-null@example.com")
+        new_user = await _create_user(session, 2019, "new-legacy-null@example.com")
+
+        harvardkey_provider = await models.ExternalLoginProvider.get_or_create_by_name(
+            session, "harvardkey"
+        )
+        canvas_provider = await models.ExternalLoginProvider.get_or_create_by_name(
+            session, "canvas"
+        )
+        await models.ExternalLoginProvider.get_or_create_by_name(
+            session, "canvas-issuer-internal", internal_only=True
+        )
+
+        old_legacy_harvardkey = await _create_external_login(
+            session,
+            user_id=old_user.id,
+            provider="harvardkey",
+            provider_id=None,
+            identifier="maf9695",
+        )
+        old_canvas_login = await _create_external_login(
+            session,
+            user_id=old_user.id,
+            provider="canvas",
+            provider_id=canvas_provider.id,
+            identifier="canvas-only-old-user-null-provider-id-test",
+        )
+        existing_new_harvardkey = await _create_external_login(
+            session,
+            user_id=new_user.id,
+            provider="harvardkey",
+            provider_id=harvardkey_provider.id,
+            identifier="maf9695",
+        )
+
+        await merge_external_logins(session, new_user.id, old_user.id)
+        await session.flush()
+
+        old_user_login_count = await session.scalar(
+            select(func.count(models.ExternalLogin.id)).where(
+                models.ExternalLogin.user_id == old_user.id
+            )
+        )
+        assert old_user_login_count == 0
+
+        new_user_rows_result = await session.execute(
+            select(models.ExternalLogin).where(
+                models.ExternalLogin.user_id == new_user.id
+            )
+        )
+        new_user_rows = new_user_rows_result.scalars().all()
+        assert {login.id for login in new_user_rows} == {
+            existing_new_harvardkey.id,
+            old_canvas_login.id,
+        }
+        assert old_legacy_harvardkey.id not in {login.id for login in new_user_rows}
 
 
 async def test_merge_external_logins_allows_multiple_email_identifiers(db):


### PR DESCRIPTION
## External Logins
### Resolved Issues
- Fixed: Merging users when both accounts already have the same external login may fail.