### PR TITLE
chore: update dependencies and add audioop-lts support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5763,4 +5763,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "db4b47d42642e8bd1688c4e4ab61969b6feb615834dcde115ac6915d8a8ad6e3"
+content-hash = "ba8cc582473056545e61eeaca515089787d9ff0fecc33bc98162931b5e91d81e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pybase64 = "^1.4.3"
 uuid-utils = "^0.14.0"
 pyairtable = "^3.3.0"
 cryptography = "^46.0.5"
+audioop-lts = { version = "^0.2.2", python = "^3.13" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 asyncio_mode=auto
+filterwarnings =
+    ignore:'audioop' is deprecated and slated for removal in Python 3.13:DeprecationWarning


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Added `audioop-lts` dependency for Python 3.13 compatibility.
- Updated `pytest.ini` to suppress deprecation warnings related to `audioop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependency for Python 3.13 support.
  * Updated test configuration to manage compatibility-related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->