### PR TITLE
fix: copy patches folder to web docker image before pnpm install

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install -g pnpm@10
 WORKDIR /app/pingpong
 COPY pingpong/package.json pingpong/pnpm-lock.yaml ./
 COPY pingpong/patches ./patches
+
 RUN pnpm install --frozen-lockfile
 
 ARG node_env=production


### PR DESCRIPTION
## Internal
### Updates & Improvements 
- Pin `pnpm` version to `v10` in `web` Dockerfile.
### Resolved Issues
- Fixed: Building the `web` image may fail because the `patches/` directory is not copied before running `pnpm install --frozen-lockfile`.