### PR TITLE
feat: add instructions for qualtrics shared link integration

### DIFF
--- a/web/pingpong/src/lib/components/ViewAssistant.svelte
+++ b/web/pingpong/src/lib/components/ViewAssistant.svelte
@@ -365,9 +365,10 @@
 		>
 	</slot>
 	<p class="mb-2 text-sm text-blue-dark-50">
-		Use the instructions below to embed <i>&ldquo;{assistant.name}&rdquo;</i> in a Qualtrics survey. Each respondent will be
-		assigned a random Conversation ID that can be used to match their conversation between PingPong thread
-		exports and Qualtrics data exports.
+		Use the instructions below to embed <i
+			>&ldquo;{assistant.name}&rdquo; ({qualtricsCodeLinkName})</i
+		> in a Qualtrics survey. Each respondent will be assigned a random Conversation ID that can be used
+		to match their conversation between PingPong thread exports and Qualtrics data exports.
 	</p>
 	<ol class="ml-5 list-decimal text-blue-dark-50">
 		<li class="mb-2 text-sm text-blue-dark-50">
@@ -408,7 +409,7 @@
 				>replace</b
 			>
 			the placeholder content in the editor, then save your changes. You can change the
-			<span class="font-mono">{`height="1000px"`}</span>
+			<span class="font-mono">height="1000px"</span>
 			attribute in the HTML code if you want to adjust the height of the assistant iframe in your survey.
 			<div class="mt-2 mb-3 rounded-xl border border-blue-light-30 bg-white p-4">
 				<div class="mb-2 flex items-center justify-between gap-2">

--- a/web/pingpong/src/routes/group/[classId]/assistant/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/+page.svelte
@@ -159,9 +159,7 @@
 		$loading = false;
 	};
 
-	const showCopiedLink = (e: Event) => {
-		e.preventDefault();
-		e.stopPropagation();
+	const showCopiedLink = () => {
 		happyToast('Link copied to clipboard', 2000);
 	};
 
@@ -310,8 +308,10 @@
 										class="hover:text-blue-dark-100 text-blue-dark-40"
 										aria-label="Copy assistant link"
 										onclick={() => {}}
-										oncopy={showCopiedLink}
-										use:copy={assistantLink(assistant.id)}
+										use:copy={{
+											text: assistantLink(assistant.id),
+											onCopy: showCopiedLink
+										}}
 									>
 										<LinkOutline class="h-5 w-5" />
 									</button>


### PR DESCRIPTION
Resolves #1352.

## Assistants
### New Features
- Click Qualtrics Instructions in Manage Shared Links to find easy to follow instructions on how to embed shared links with respondent tracking in Qualtrics.
### Resolved Issues
- Fixed: Copy-to-clipboard actions may not show the successful action toast notification.