### PR TITLE
security: lock pnpm/action-setup version

### DIFF
--- a/.github/workflows/fe.yml
+++ b/.github/workflows/fe.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
         name: Install pnpm
         with:
           version: 10


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Lock `pnpm/action-setup` version in workflows.