### PR TITLE
chore: update deprecated 'version' sentry action identifier to 'release'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,4 +254,4 @@ jobs:
           SENTRY_PROJECT: ${{ github.event.release.prerelease && vars.SENTRY_PROJECT_STAGE || vars.SENTRY_PROJECT_PROD }}
         with:
           environment: ${{ github.event.release.prerelease && 'staging' || 'production' }}
-          version: ${{ env.RELEASE_VERSION }}
+          release: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## Internal
### Updates and Improvements
- Update deprecated `version` getsentry/action-release action identifier to `release`.