### PR TITLE
feat(lti): add LTIClass membership URL to suggest configuration

### DIFF
--- a/pingpong/__main__.py
+++ b/pingpong/__main__.py
@@ -1208,7 +1208,15 @@ async def _send_activity_summaries(
     show_default=True,
     help="Print the suggested values as JSON.",
 )
-def lti_suggest_config_from_db(json_output: bool) -> None:
+@click.option(
+    "--suppress-registration-prints/--show-registration-prints",
+    default=False,
+    show_default=True,
+    help="Hide per-registration source lines in text output.",
+)
+def lti_suggest_config_from_db(
+    json_output: bool, suppress_registration_prints: bool
+) -> None:
     """
     Suggest LTI config values based on existing DB registrations.
     """
@@ -1345,8 +1353,9 @@ def lti_suggest_config_from_db(json_output: bool) -> None:
         )
         for host in suggested_hosts:
             click.echo(f"# {host}")
-            for source in sorted(hosts_to_sources[host]):
-                click.echo(f"#   - {source}")
+            if not suppress_registration_prints:
+                for source in sorted(hosts_to_sources[host]):
+                    click.echo(f"#   - {source}")
         if warnings:
             click.echo("")
             click.echo("# Warnings")


### PR DESCRIPTION
## Canvas Connect
### Updates & Improvements
- Enhanced LTI platform configuration suggestions to incorporate class membership data as an additional source for building URL allowlists.
- Use `--suppress-registration-prints` to hide the per-registration source lines at the end of text output. The default `--show-registration-prints` maintains current behavior.