### PR TITLE
fix: controls have primary color fill instead of flowbite's blue

### DIFF
--- a/web/pingpong/src/app.css
+++ b/web/pingpong/src/app.css
@@ -8,6 +8,13 @@
 	--default-ring-color: var(--color-blue-500);
 }
 
+@layer base {
+	/* Flowbite form controls use --color-brand for checked/focus states. */
+	:root {
+		--color-brand: var(--color-blue-600);
+	}
+}
+
 @media print {
 	body {
 		background: white !important;


### PR DESCRIPTION
## UI
### Resolved Issues
- Fixed: Radio buttons and checkboxes have primary (black) color fill instead of the default blue.