### PR TITLE
fix: claude's track_progress not always supported

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,17 @@ jobs:
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
+          track_progress: >-
+            ${{
+              (
+                github.event_name == 'pull_request' &&
+                contains(fromJson('["opened","synchronize","ready_for_review","reopened"]'), github.event.action)
+              ) ||
+              (
+                github.event_name == 'issues' &&
+                contains(fromJson('["opened","edited","labeled","assigned"]'), github.event.action)
+              )
+            }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}'


### PR DESCRIPTION
## Internal
### Resolved Issues
- Fixed: Claude code reviews triggered by `@claude review` may fail because `track_progress` is unconditionally requested including in unsupported events.