### PR TITLE
fix: do not require python for create-worktree

### DIFF
--- a/create-worktree.sh
+++ b/create-worktree.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Preflight checks for required tools
-REQUIRED_TOOLS=(curl docker git jq pnpm uv python)
+REQUIRED_TOOLS=(curl docker git jq pnpm uv)
 MISSING_TOOLS=()
 
 for tool in "${REQUIRED_TOOLS[@]}"; do


### PR DESCRIPTION
## Internal
### Updates & Improvements
- Removed the hard requirement for `python` from `create-worktree.sh`, so the script now matches the repo’s uv-based setup.