### PR TITLE
fix(lv): warm seek preview on hover without eager initial preload

### DIFF
--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -552,6 +552,7 @@
 
 	function hideSeekPreview() {
 		seekPreviewVisible = false;
+		previewVideoActivated = false;
 	}
 
 	function updateSeekPreviewFromClientX(clientX: number, track: HTMLDivElement) {


### PR DESCRIPTION
## Lecture Videos
### Resolved Issues
* Fixed: Lecture video seek previews may appear black.