### PR TITLE
change(lv): preserve cached scrubber preview frame on quick re-hover

### DIFF
--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -576,6 +576,7 @@
 		previewVideoReady = false;
 		previewVideoFrameReady = false;
 		lastCapturedPreviewFrameTimeS = null;
+		snapshotCanvasHasFrame = false;
 	}
 
 	function schedulePreviewVideoDeactivate(delayMs: number = PREVIEW_VIDEO_IDLE_DEACTIVATE_MS) {


### PR DESCRIPTION
## Lecture Video
### Updates & Improvements
* Preserve the cached scrubber preview frame when re-entering the seek bar, so quick re-hovers no longer flash the live playback frame while the preview seek catches up.