### PR TITLE
fix(lv): don't show continue button while on auto-resume

### DIFF
--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -112,6 +112,7 @@
 		return (
 			(sessionState === 'awaiting_post_answer_resume' &&
 				!postAnswerNarrationPending &&
+				!autoContinueInFlight &&
 				hasVisiblePostAnswerFeedback(currentContinuation)) ||
 			autoContinueFailed
 		);


### PR DESCRIPTION
## Lecture Videos
### Resolved Issues
* Fixed: While in auto-resume mode, the continue button may appear briefly between the post-answer narration finishing and the question card auto-closing.