### PR TITLE
change(lv): update expanded view for questions and pill row

### DIFF
--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionCard.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionCard.svelte
@@ -320,6 +320,9 @@
 			type="button"
 			class={answeredPillButtonClass(currentPillStyle.button, active)}
 			aria-pressed={active}
+			aria-label={active
+				? `Collapse question ${position} details`
+				: `Expand question ${position} details`}
 			title={active ? 'Collapse question details' : 'Expand question details'}
 			onclick={ontoggleExpand}
 		>

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionCard.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionCard.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	import { CheckOutline, CloseOutline, MinusOutline } from 'flowbite-svelte-icons';
+	import {
+		CheckOutline,
+		ChevronDownOutline,
+		CloseOutline,
+		MinusOutline
+	} from 'flowbite-svelte-icons';
 
 	type QuestionOption = {
 		id: number;
@@ -32,6 +37,7 @@
 		correctOptionId = null,
 		postAnswerText = null,
 		expanded = false,
+		active = false,
 		answeringDisabled = false,
 		showContinue = false,
 		continueDisabled = false,
@@ -47,6 +53,7 @@
 		correctOptionId: number | null;
 		postAnswerText: string | null;
 		expanded: boolean;
+		active?: boolean;
 		answeringDisabled?: boolean;
 		showContinue?: boolean;
 		continueDisabled?: boolean;
@@ -182,6 +189,14 @@
 		if (isAnswerCorrect === false) return pillStyles.wrong;
 		return pillStyles.neutral;
 	}
+
+	function answeredPillButtonClass(buttonClass: string, isActive: boolean): string {
+		return [
+			'inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium transition-[box-shadow,background-color,color]',
+			buttonClass,
+			isActive ? 'ring-2 ring-blue-200 ring-offset-1' : ''
+		].join(' ');
+	}
 </script>
 
 <div class={rendersAsPill ? 'shrink-0' : 'w-full'}>
@@ -303,7 +318,9 @@
 		{@const currentPillStyle = pillStyle(isCorrect)}
 		<button
 			type="button"
-			class="inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium transition-colors {currentPillStyle.button}"
+			class={answeredPillButtonClass(currentPillStyle.button, active)}
+			aria-pressed={active}
+			title={active ? 'Collapse question details' : 'Expand question details'}
 			onclick={ontoggleExpand}
 		>
 			Q{position}
@@ -313,6 +330,9 @@
 				<CloseOutline class="h-4 w-4 {currentPillStyle.icon}" strokeWidth="3" />
 			{:else}
 				<MinusOutline class="h-4 w-4 {currentPillStyle.icon}" strokeWidth="3" />
+			{/if}
+			{#if active}
+				<ChevronDownOutline class="h-3.5 w-3.5 text-blue-700" strokeWidth="2.5" />
 			{/if}
 		</button>
 	{/if}

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
@@ -64,6 +64,7 @@
 
 	let expandedAnsweredId: number | null = $state(null);
 	let isPillRailExpanded = $state(false);
+	let isPillRailMeasured = $state(false);
 	let collapsedVisiblePillIds: number[] = $state([]);
 	let hiddenPillCount = $state(0);
 	let isAwaitingAnswer = $derived(sessionState === 'awaiting_answer');
@@ -109,7 +110,15 @@
 	);
 
 	let visiblePillQuestions = $derived.by(() => {
-		if (isPillRailExpanded || hiddenPillCount === 0) {
+		if (isPillRailExpanded) {
+			return answeredPillQuestions;
+		}
+
+		if (!isPillRailMeasured) {
+			return [];
+		}
+
+		if (hiddenPillCount === 0) {
 			return answeredPillQuestions;
 		}
 
@@ -130,17 +139,13 @@
 		})
 	);
 
-	async function measureCollapsedPillRail(
-		_pillCount = answeredPillQuestions.length,
-		_expandedAnsweredId = expandedAnsweredId
-	) {
-		void _pillCount;
-		void _expandedAnsweredId;
+	async function measureCollapsedPillRail() {
 		await tick();
 
 		if (!pillMeasurementContainer || answeredPillQuestions.length === 0) {
 			collapsedVisiblePillIds = [];
 			hiddenPillCount = 0;
+			isPillRailMeasured = true;
 			isPillRailExpanded = false;
 			return;
 		}
@@ -152,6 +157,7 @@
 		if (pillNodes.length === 0) {
 			collapsedVisiblePillIds = [];
 			hiddenPillCount = 0;
+			isPillRailMeasured = true;
 			return;
 		}
 
@@ -173,6 +179,7 @@
 
 		collapsedVisiblePillIds = visibleIds;
 		hiddenPillCount = Math.max(answeredPillQuestions.length - visibleIds.length, 0);
+		isPillRailMeasured = true;
 
 		if (hiddenPillCount === 0) {
 			isPillRailExpanded = false;
@@ -180,7 +187,14 @@
 	}
 
 	$effect(() => {
-		void measureCollapsedPillRail(answeredPillQuestions.length, expandedAnsweredId);
+		answeredPillQuestions;
+		isPillRailMeasured = false;
+		void measureCollapsedPillRail();
+	});
+
+	$effect(() => {
+		expandedAnsweredId;
+		void measureCollapsedPillRail();
 	});
 
 	$effect(() => {
@@ -200,12 +214,16 @@
 	$effect(() => {
 		if (!active) return;
 		if (scrollToQuestionId == null) return;
-		expandedAnsweredId = scrollToQuestionId;
-		const el = document.getElementById(questionCardId(scrollToQuestionId));
-		if (el) {
-			el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		const questionId = scrollToQuestionId;
+
+		void (async () => {
+			expandedAnsweredId = questionId;
+			await tick();
+			document
+				.getElementById(questionCardId(questionId))
+				?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 			onscrollcomplete();
-		}
+		})();
 	});
 </script>
 
@@ -221,6 +239,7 @@
 					bind:this={pillMeasurementContainer}
 					class="pointer-events-none invisible absolute inset-x-0 top-0"
 					aria-hidden="true"
+					inert
 				>
 					<div class="flex flex-wrap gap-2">
 						{#each answeredPillQuestions as question (question.id)}
@@ -246,7 +265,7 @@
 					</div>
 				</div>
 
-				<div class="flex flex-wrap gap-2">
+				<div id="answered-question-pill-rail" class="flex flex-wrap gap-2">
 					{#each visiblePillQuestions as question (question.id)}
 						{@const answered = answeredQuestions.get(question.id)}
 						{#if answered}
@@ -273,6 +292,8 @@
 					<div class="mt-2">
 						<button
 							type="button"
+							aria-controls="answered-question-pill-rail"
+							aria-expanded={isPillRailExpanded}
 							class="inline-flex cursor-pointer items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200"
 							onclick={togglePillRailExpanded}
 						>

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
@@ -187,13 +187,15 @@
 	}
 
 	$effect(() => {
-		answeredPillQuestions;
+		const pillQuestionCount = answeredPillQuestions.length;
 		isPillRailMeasured = false;
+		void pillQuestionCount;
 		void measureCollapsedPillRail();
 	});
 
 	$effect(() => {
-		expandedAnsweredId;
+		const expandedQuestionId = expandedAnsweredId;
+		void expandedQuestionId;
 		void measureCollapsedPillRail();
 	});
 

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoQuestionSidebar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { tick } from 'svelte';
+
 	import LectureVideoQuestionCard from './LectureVideoQuestionCard.svelte';
 
 	type SidebarQuestion = { id: number; position: number; questionText: string };
@@ -61,10 +63,14 @@
 	} = $props();
 
 	let expandedAnsweredId: number | null = $state(null);
+	let isPillRailExpanded = $state(false);
+	let collapsedVisiblePillIds: number[] = $state([]);
+	let hiddenPillCount = $state(0);
 	let isAwaitingAnswer = $derived(sessionState === 'awaiting_answer');
 	let isAwaitingPostAnswerResume = $derived(sessionState === 'awaiting_post_answer_resume');
 	const noop = () => {};
 	let continueCardProps = $derived({ showContinue, continueDisabled, oncontinue });
+	let pillMeasurementContainer: HTMLDivElement | null = $state(null);
 
 	function questionCardId(questionId: number): string {
 		return `question-card-${questionId}`;
@@ -85,28 +91,111 @@
 		expandedAnsweredId = expandedAnsweredId === questionId ? null : questionId;
 	}
 
+	function togglePillRailExpanded() {
+		isPillRailExpanded = !isPillRailExpanded;
+	}
+
 	let sortedQuestions = $derived(
 		[...allQuestions]
 			.filter(({ id }) => isVisibleQuestion(id))
 			.sort((a, b) => a.position - b.position)
 	);
 
-	let pillQuestions = $derived(
+	let answeredPillQuestions = $derived(
 		sortedQuestions.filter((question) => {
 			const answered = answeredQuestions.get(question.id);
-			return answered && !isCurrentFeedback(question.id) && expandedAnsweredId !== question.id;
+			return answered && !isCurrentFeedback(question.id);
 		})
 	);
+
+	let visiblePillQuestions = $derived.by(() => {
+		if (isPillRailExpanded || hiddenPillCount === 0) {
+			return answeredPillQuestions;
+		}
+
+		const visibleIds = new Set(collapsedVisiblePillIds);
+		return answeredPillQuestions.filter((question) => visibleIds.has(question.id));
+	});
 
 	let fullCardQuestions = $derived(
 		sortedQuestions.filter((question) => {
 			const answered = answeredQuestions.get(question.id);
-			if (answered && !isCurrentFeedback(question.id) && expandedAnsweredId !== question.id) {
+			if (answered && !isCurrentFeedback(question.id)) {
+				return expandedAnsweredId === question.id;
+			}
+			if (!answered && !isCurrentFeedback(question.id)) {
 				return false;
 			}
 			return true;
 		})
 	);
+
+	async function measureCollapsedPillRail(
+		_pillCount = answeredPillQuestions.length,
+		_expandedAnsweredId = expandedAnsweredId
+	) {
+		void _pillCount;
+		void _expandedAnsweredId;
+		await tick();
+
+		if (!pillMeasurementContainer || answeredPillQuestions.length === 0) {
+			collapsedVisiblePillIds = [];
+			hiddenPillCount = 0;
+			isPillRailExpanded = false;
+			return;
+		}
+
+		const pillNodes = Array.from(
+			pillMeasurementContainer.querySelectorAll<HTMLElement>('[data-pill-measure-id]')
+		);
+
+		if (pillNodes.length === 0) {
+			collapsedVisiblePillIds = [];
+			hiddenPillCount = 0;
+			return;
+		}
+
+		const firstRowTop = pillNodes[0].offsetTop;
+		let visibleIds = pillNodes
+			.filter((node) => node.offsetTop === firstRowTop)
+			.map((node) => Number(node.dataset.pillMeasureId));
+
+		if (
+			expandedAnsweredId !== null &&
+			!visibleIds.includes(expandedAnsweredId) &&
+			answeredPillQuestions.some((question) => question.id === expandedAnsweredId)
+		) {
+			visibleIds =
+				visibleIds.length > 0
+					? [...visibleIds.slice(0, visibleIds.length - 1), expandedAnsweredId]
+					: [expandedAnsweredId];
+		}
+
+		collapsedVisiblePillIds = visibleIds;
+		hiddenPillCount = Math.max(answeredPillQuestions.length - visibleIds.length, 0);
+
+		if (hiddenPillCount === 0) {
+			isPillRailExpanded = false;
+		}
+	}
+
+	$effect(() => {
+		void measureCollapsedPillRail(answeredPillQuestions.length, expandedAnsweredId);
+	});
+
+	$effect(() => {
+		if (!pillMeasurementContainer) return;
+
+		const observer = new ResizeObserver(() => {
+			void measureCollapsedPillRail();
+		});
+
+		observer.observe(pillMeasurementContainer);
+
+		return () => {
+			observer.disconnect();
+		};
+	});
 
 	$effect(() => {
 		if (!active) return;
@@ -126,27 +215,75 @@
 	</div>
 
 	<div class="flex min-h-0 flex-col gap-3 overflow-y-auto pr-1">
-		{#if pillQuestions.length > 0}
-			<div class="flex flex-wrap gap-2">
-				{#each pillQuestions as question (question.id)}
-					{@const answered = answeredQuestions.get(question.id)}
-					{#if answered}
-						<div id={questionCardId(question.id)}>
-							<LectureVideoQuestionCard
-								position={question.position}
-								questionText={question.questionText}
-								options={answered.options}
-								state="answered"
-								selectedOptionId={answered.selectedOptionId}
-								correctOptionId={answered.correctOptionId}
-								postAnswerText={answered.postAnswerText}
-								expanded={false}
-								ontoggleExpand={() => toggleExpandedAnswered(question.id)}
-								onselectOption={noop}
-							/>
-						</div>
-					{/if}
-				{/each}
+		{#if answeredPillQuestions.length > 0}
+			<div class="relative">
+				<div
+					bind:this={pillMeasurementContainer}
+					class="pointer-events-none invisible absolute inset-x-0 top-0"
+					aria-hidden="true"
+				>
+					<div class="flex flex-wrap gap-2">
+						{#each answeredPillQuestions as question (question.id)}
+							{@const answered = answeredQuestions.get(question.id)}
+							{#if answered}
+								<div data-pill-measure-id={question.id}>
+									<LectureVideoQuestionCard
+										position={question.position}
+										questionText={question.questionText}
+										options={answered.options}
+										state="answered"
+										selectedOptionId={answered.selectedOptionId}
+										correctOptionId={answered.correctOptionId}
+										postAnswerText={answered.postAnswerText}
+										expanded={false}
+										active={expandedAnsweredId === question.id}
+										ontoggleExpand={noop}
+										onselectOption={noop}
+									/>
+								</div>
+							{/if}
+						{/each}
+					</div>
+				</div>
+
+				<div class="flex flex-wrap gap-2">
+					{#each visiblePillQuestions as question (question.id)}
+						{@const answered = answeredQuestions.get(question.id)}
+						{#if answered}
+							<div>
+								<LectureVideoQuestionCard
+									position={question.position}
+									questionText={question.questionText}
+									options={answered.options}
+									state="answered"
+									selectedOptionId={answered.selectedOptionId}
+									correctOptionId={answered.correctOptionId}
+									postAnswerText={answered.postAnswerText}
+									expanded={false}
+									active={expandedAnsweredId === question.id}
+									ontoggleExpand={() => toggleExpandedAnswered(question.id)}
+									onselectOption={noop}
+								/>
+							</div>
+						{/if}
+					{/each}
+				</div>
+
+				{#if hiddenPillCount > 0}
+					<div class="mt-2">
+						<button
+							type="button"
+							class="inline-flex cursor-pointer items-center rounded-full bg-slate-100 px-3 py-1 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200"
+							onclick={togglePillRailExpanded}
+						>
+							{#if isPillRailExpanded}
+								Show less
+							{:else}
+								+{hiddenPillCount} more
+							{/if}
+						</button>
+					</div>
+				{/if}
 			</div>
 		{/if}
 


### PR DESCRIPTION
## Lecture Video
### Updates & Improvements
* The knowledge check quick access row no longer expands past one line, allowing more space for the chat content.
* Expanding a knowledge check will no longer split the quick access row in two parts.
* Each item in the quick access row has a new active state to show how a knowledge check can be compacted again.