### PR TITLE
feat(lti): add support for Harvard's LXP platform

### DIFF
--- a/alembic/versions/b4f9d7e21c5a_add_harvard_lxp_to_lmstype_enum.py
+++ b/alembic/versions/b4f9d7e21c5a_add_harvard_lxp_to_lmstype_enum.py
@@ -1,0 +1,184 @@
+"""Add HARVARD_LXP to lmstype enum
+
+Revision ID: b4f9d7e21c5a
+Revises: c7d3a9e12b84
+Create Date: 2026-04-17 11:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b4f9d7e21c5a"
+down_revision: Union[str, None] = "c7d3a9e12b84"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+enum_name = "lmstype"
+temp_enum_name = f"temp_{enum_name}"
+old_values = ("CANVAS",)
+new_values = ("CANVAS", "HARVARD_LXP")
+old_type = sa.Enum(*old_values, name=enum_name)
+new_type = sa.Enum(*new_values, name=enum_name)
+temp_type = sa.Enum(*new_values, name=temp_enum_name)
+
+users_classes_table = sa.sql.table(
+    "users_classes", sa.Column("lms_type", new_type, nullable=True)
+)
+classes_table = sa.sql.table(
+    "classes",
+    sa.Column("lms_type", new_type, nullable=True),
+    sa.Column("lms_class_id", sa.Integer(), nullable=True),
+)
+lms_classes_table = sa.sql.table(
+    "lms_classes",
+    sa.Column("id", sa.Integer(), nullable=False),
+    sa.Column("lms_type", new_type, nullable=False),
+)
+
+
+def upgrade() -> None:
+    _ = revision, down_revision, branch_labels, depends_on
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("users_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("lms_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    old_type.drop(op.get_bind(), checkfirst=False)
+    new_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("users_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("lms_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade() -> None:
+    harvard_lxp_lms_class_ids = sa.select(lms_classes_table.c.id).where(
+        lms_classes_table.c.lms_type == "HARVARD_LXP"
+    )
+
+    op.execute(
+        users_classes_table.update()
+        .where(users_classes_table.c.lms_type == "HARVARD_LXP")
+        .values(lms_type=None)
+    )
+    op.execute(
+        classes_table.update()
+        .where(classes_table.c.lms_type == "HARVARD_LXP")
+        .values(lms_type=None)
+    )
+    op.execute(
+        classes_table.update()
+        .where(classes_table.c.lms_class_id.in_(harvard_lxp_lms_class_ids))
+        .values(lms_class_id=None)
+    )
+    op.execute(
+        lms_classes_table.delete().where(lms_classes_table.c.lms_type == "HARVARD_LXP")
+    )
+
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("users_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("lms_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"lms_type::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    new_type.drop(op.get_bind(), checkfirst=False)
+    old_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("users_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("lms_classes") as batch_op:
+        batch_op.alter_column(
+            "lms_type",
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"lms_type::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)

--- a/alembic/versions/c7d3a9e12b84_add_harvard_lxp_lms_platform.py
+++ b/alembic/versions/c7d3a9e12b84_add_harvard_lxp_lms_platform.py
@@ -1,0 +1,134 @@
+"""Add HARVARD_LXP to lmsplatform enum
+
+Revision ID: c7d3a9e12b84
+Revises: 2f9a6b7e8c31
+Create Date: 2026-04-16 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d3a9e12b84"
+down_revision: Union[str, None] = "2f9a6b7e8c31"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+enum_name = "lmsplatform"
+temp_enum_name = f"temp_{enum_name}"
+old_values = ("CANVAS",)
+new_values = ("CANVAS", "HARVARD_LXP")
+old_type = sa.Enum(*old_values, name=enum_name)
+new_type = sa.Enum(*new_values, name=enum_name)
+temp_type = sa.Enum(*new_values, name=temp_enum_name)
+
+lti_classes_table = sa.sql.table(
+    "lti_classes", sa.Column("lti_platform", new_type, nullable=False)
+)
+lti_registrations_table = sa.sql.table(
+    "lti_registrations", sa.Column("lms_platform", new_type, nullable=True)
+)
+
+
+def upgrade() -> None:
+    # Resolves CodeQL's py/unused-global-variable
+    _ = revision, down_revision, branch_labels, depends_on
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("lti_classes") as batch_op:
+        batch_op.alter_column(
+            "lti_platform",
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"lti_platform::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+    with op.batch_alter_table("lti_registrations") as batch_op:
+        batch_op.alter_column(
+            "lms_platform",
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"lms_platform::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+
+    old_type.drop(op.get_bind(), checkfirst=False)
+    new_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("lti_classes") as batch_op:
+        batch_op.alter_column(
+            "lti_platform",
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"lti_platform::text::{enum_name}",
+            existing_nullable=False,
+        )
+    with op.batch_alter_table("lti_registrations") as batch_op:
+        batch_op.alter_column(
+            "lms_platform",
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"lms_platform::text::{enum_name}",
+            existing_nullable=True,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade() -> None:
+    op.execute(
+        lti_classes_table.delete().where(
+            lti_classes_table.c.lti_platform == "HARVARD_LXP"
+        )
+    )
+    op.execute(
+        lti_registrations_table.delete().where(
+            lti_registrations_table.c.lms_platform == "HARVARD_LXP"
+        )
+    )
+
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("lti_classes") as batch_op:
+        batch_op.alter_column(
+            "lti_platform",
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"lti_platform::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+    with op.batch_alter_table("lti_registrations") as batch_op:
+        batch_op.alter_column(
+            "lms_platform",
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"lms_platform::text::{temp_enum_name}",
+            existing_nullable=True,
+        )
+
+    new_type.drop(op.get_bind(), checkfirst=False)
+    old_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table("lti_classes") as batch_op:
+        batch_op.alter_column(
+            "lti_platform",
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"lti_platform::text::{enum_name}",
+            existing_nullable=False,
+        )
+    with op.batch_alter_table("lti_registrations") as batch_op:
+        batch_op.alter_column(
+            "lms_platform",
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"lms_platform::text::{enum_name}",
+            existing_nullable=True,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)

--- a/pingpong/lti/canvas_connect.py
+++ b/pingpong/lti/canvas_connect.py
@@ -618,7 +618,7 @@ class CanvasConnectClient:
         return CreateUserClassRoles(
             roles=list(unique_users.values()),
             silent=True,
-            lms_type=LMSType.CANVAS,
+            lms_type=LMSType.from_lti_platform(lti_class.lti_platform),
             lti_class_id=lti_class.id,
             sso_tenant=sso_tenant,
         )

--- a/pingpong/lti/claims.py
+++ b/pingpong/lti/claims.py
@@ -1,0 +1,10 @@
+"""Helpers for reading structured LTI launch claims."""
+
+from typing import Any
+
+
+def get_claim_object(claims: dict[str, Any], claim_key: str) -> dict[str, Any]:
+    claim_value = claims.get(claim_key)
+    if isinstance(claim_value, dict):
+        return claim_value
+    return {}

--- a/pingpong/lti/constants.py
+++ b/pingpong/lti/constants.py
@@ -1,5 +1,8 @@
 """Shared constants for LTI launch and Canvas Connect NRPS sync."""
 
+NO_SSO_PROVIDER_ID = 0
+NO_SSO_PROVIDER_ID_STR = str(NO_SSO_PROVIDER_ID)
+
 SSO_FIELD_FULL_NAME: dict[str, str] = {
     "canvas.sisIntegrationId": "Canvas.user.sisIntegrationId",
     "canvas.sisSourceId": "Canvas.user.sisSourceId",
@@ -38,7 +41,7 @@ LTI_CUSTOM_SSO_PROVIDER_ID_KEY = "sso_provider_id"
 LTI_CUSTOM_SSO_VALUE_KEY = "sso_value"
 
 LTI_CUSTOM_PARAM_DEFAULT_VALUES = {
-    LTI_CUSTOM_SSO_PROVIDER_ID_KEY: ["0"],
+    LTI_CUSTOM_SSO_PROVIDER_ID_KEY: [NO_SSO_PROVIDER_ID_STR],
     LTI_CUSTOM_SSO_VALUE_KEY: [""]
     + [f"${field}" for field in SSO_FIELD_FULL_NAME.values()],
 }

--- a/pingpong/lti/constants.py
+++ b/pingpong/lti/constants.py
@@ -41,8 +41,6 @@ LTI_CUSTOM_PARAM_DEFAULT_VALUES = {
     LTI_CUSTOM_SSO_PROVIDER_ID_KEY: ["0"],
     LTI_CUSTOM_SSO_VALUE_KEY: [""]
     + [f"${field}" for field in SSO_FIELD_FULL_NAME.values()],
-    "canvas_course_id": ["$Canvas.course.id"],
-    "canvas_term_name": ["$Canvas.term.name"],
 }
 
 NRPS_CONTEXT_MEMBERSHIP_SCOPE = (

--- a/pingpong/lti/platforms/__init__.py
+++ b/pingpong/lti/platforms/__init__.py
@@ -1,0 +1,36 @@
+"""Per-platform LTI handler registry.
+
+Use `get_handler(platform)` to obtain a handler that encapsulates the
+platform-specific parts of the LTI registration and launch flows.
+"""
+
+from pingpong.lti.platforms.base import (
+    LTIPlatformHandler,
+    parse_context_memberships_url,
+)
+from pingpong.lti.platforms.canvas import CanvasPlatformHandler
+from pingpong.lti.platforms.harvard_lxp import HarvardLxpPlatformHandler
+from pingpong.schemas import LMSPlatform
+
+
+_HANDLERS: dict[LMSPlatform, type[LTIPlatformHandler]] = {
+    LMSPlatform.CANVAS: CanvasPlatformHandler,
+    LMSPlatform.HARVARD_LXP: HarvardLxpPlatformHandler,
+}
+
+
+def get_handler(platform: LMSPlatform) -> LTIPlatformHandler:
+    try:
+        handler_cls = _HANDLERS[platform]
+    except KeyError as e:
+        raise ValueError(f"No LTI handler registered for platform {platform}") from e
+    return handler_cls()
+
+
+__all__ = [
+    "LTIPlatformHandler",
+    "CanvasPlatformHandler",
+    "HarvardLxpPlatformHandler",
+    "get_handler",
+    "parse_context_memberships_url",
+]

--- a/pingpong/lti/platforms/__init__.py
+++ b/pingpong/lti/platforms/__init__.py
@@ -28,9 +28,9 @@ def get_handler(platform: LMSPlatform) -> LTIPlatformHandler:
 
 
 __all__ = [
-    "LTIPlatformHandler",
     "CanvasPlatformHandler",
     "HarvardLxpPlatformHandler",
+    "LTIPlatformHandler",
     "get_handler",
     "parse_context_memberships_url",
 ]

--- a/pingpong/lti/platforms/base.py
+++ b/pingpong/lti/platforms/base.py
@@ -18,7 +18,7 @@ from pingpong.lti.constants import (
     LTI_CLAIM_NRPS_KEY,
 )
 from pingpong.lti.endpoints import generate_names_and_role_api_url
-from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.lti.schemas import LTILaunchCourseMetadata, LTIRegisterRequest
 from pingpong.models import Class, ExternalLoginProvider, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
@@ -118,7 +118,7 @@ class LTIPlatformHandler(ABC):
         self,
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
-    ) -> tuple[str | None, str | None, str | None, str | None]:
+    ) -> LTILaunchCourseMetadata:
         """Return (course_code, course_name, course_term, context_memberships_url)
         for persistence on LTIClass. Any field may be None.
         """
@@ -139,5 +139,4 @@ class LTIPlatformHandler(ABC):
 __all__ = [
     "LTIPlatformHandler",
     "parse_context_memberships_url",
-    "get_claim_object",
 ]

--- a/pingpong/lti/platforms/base.py
+++ b/pingpong/lti/platforms/base.py
@@ -19,7 +19,7 @@ from pingpong.lti.constants import (
 )
 from pingpong.lti.endpoints import generate_names_and_role_api_url
 from pingpong.lti.schemas import LTIRegisterRequest
-from pingpong.models import Class, LTIClass, LTIRegistration
+from pingpong.models import Class, ExternalLoginProvider, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
 
@@ -62,6 +62,17 @@ class LTIPlatformHandler(ABC):
         """Raise HTTPException(400) if the admin's registration form input is
         incompatible with this platform (e.g., SSO selection on a platform that
         does not support variable substitution)."""
+
+    def filter_sso_providers(
+        self, providers: list[ExternalLoginProvider]
+    ) -> list[ExternalLoginProvider]:
+        """Return the subset of public SSO providers selectable for this
+        platform's registration form. Default: all. Platforms that do not
+        support SSO-linked identifiers (e.g. no LTI variable substitution)
+        should override this to return an empty list so the UI can hide the
+        provider dropdown entirely.
+        """
+        return providers
 
     @abstractmethod
     def extract_registration_fields(

--- a/pingpong/lti/platforms/base.py
+++ b/pingpong/lti/platforms/base.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from pingpong.lti.claims import get_claim_object
 from pingpong.lti.constants import (
     LTI_CLAIM_NRPS_KEY,
 )
@@ -22,19 +23,12 @@ from pingpong.models import Class, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
 
-def _get_claim_object(claims: dict[str, Any], claim_key: str) -> dict[str, Any]:
-    claim_value = claims.get(claim_key)
-    if isinstance(claim_value, dict):
-        return claim_value
-    return {}
-
-
 def parse_context_memberships_url(claims: dict[str, Any]) -> str | None:
     """Extract and validate the NRPS context_memberships_url from an LTI launch
     claim dict. Returns None if the claim is missing or empty; raises
     HTTPException(400) if the URL is present but fails URL-security validation.
     """
-    nrps_claim = _get_claim_object(claims, LTI_CLAIM_NRPS_KEY)
+    nrps_claim = get_claim_object(claims, LTI_CLAIM_NRPS_KEY)
     url_value = nrps_claim.get("context_memberships_url")
     if not isinstance(url_value, str) or not url_value.strip():
         return None
@@ -130,5 +124,5 @@ class LTIPlatformHandler(ABC):
 __all__ = [
     "LTIPlatformHandler",
     "parse_context_memberships_url",
-    "_get_claim_object",
+    "get_claim_object",
 ]

--- a/pingpong/lti/platforms/base.py
+++ b/pingpong/lti/platforms/base.py
@@ -1,0 +1,134 @@
+"""Abstract base class for LTI platform-specific logic.
+
+Each supported LTI platform (Canvas, Harvard LXP, ...) has one concrete
+handler that encapsulates the differences between platforms: openid config
+validation, registration-payload construction, launch-claim extraction, and
+cross-registration class lookup. Shared flow (OIDC state, JWT verification,
+user resolution, role gating, class linking) lives in `pingpong/lti/server.py`.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pingpong.lti.constants import (
+    LTI_CLAIM_NRPS_KEY,
+)
+from pingpong.lti.endpoints import generate_names_and_role_api_url
+from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.models import Class, LTIClass, LTIRegistration
+from pingpong.schemas import LMSPlatform
+
+
+def _get_claim_object(claims: dict[str, Any], claim_key: str) -> dict[str, Any]:
+    claim_value = claims.get(claim_key)
+    if isinstance(claim_value, dict):
+        return claim_value
+    return {}
+
+
+def parse_context_memberships_url(claims: dict[str, Any]) -> str | None:
+    """Extract and validate the NRPS context_memberships_url from an LTI launch
+    claim dict. Returns None if the claim is missing or empty; raises
+    HTTPException(400) if the URL is present but fails URL-security validation.
+    """
+    nrps_claim = _get_claim_object(claims, LTI_CLAIM_NRPS_KEY)
+    url_value = nrps_claim.get("context_memberships_url")
+    if not isinstance(url_value, str) or not url_value.strip():
+        return None
+    try:
+        return generate_names_and_role_api_url(url_value)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid context_memberships_url",
+        ) from e
+
+
+class LTIPlatformHandler(ABC):
+    platform: LMSPlatform
+
+    # --- Registration-time ---
+
+    @abstractmethod
+    def validate_platform_config(
+        self,
+        platform_config: dict[str, Any],
+        message_types_supported: list[dict[str, Any]],
+    ) -> None:
+        """Raise HTTPException(400) if the platform's openid configuration is
+        unusable for this handler. The caller already verified that
+        `LtiResourceLinkRequest` is listed in `message_types_supported`.
+        """
+
+    @abstractmethod
+    def validate_registration_request(self, data: LTIRegisterRequest) -> None:
+        """Raise HTTPException(400) if the admin's registration form input is
+        incompatible with this platform (e.g., SSO selection on a platform that
+        does not support variable substitution)."""
+
+    @abstractmethod
+    def extract_registration_fields(
+        self, platform_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return platform-specific fields to persist on LTIRegistration
+        (e.g. canvas_account_name, canvas_account_lti_guid). Empty dict for
+        platforms that do not populate the Canvas-named columns.
+        """
+
+    @abstractmethod
+    def build_tool_registration_payload(
+        self,
+        *,
+        base_tool_config: dict[str, Any],
+        data: LTIRegisterRequest,
+        sso_field_full_name: str | None,
+    ) -> dict[str, Any]:
+        """Return the full tool_registration_data dict that will be POSTed to
+        the platform's registration_endpoint. The handler decides what goes
+        into custom_parameters, messages[].custom_parameters, and any
+        platform-specific vendor extensions.
+        """
+
+    # --- Launch-time ---
+
+    @abstractmethod
+    def extract_course_id(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> str:
+        """Return the course_id used to find/create the LTIClass.
+        Raise HTTPException(400) if unobtainable.
+        """
+
+    @abstractmethod
+    def extract_course_metadata(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> tuple[str | None, str | None, str | None, str | None]:
+        """Return (course_code, course_name, course_term, context_memberships_url)
+        for persistence on LTIClass. Any field may be None.
+        """
+
+    @abstractmethod
+    async def find_class_for_course(
+        self,
+        db: AsyncSession,
+        registration: LTIRegistration,
+        course_id: str,
+    ) -> LTIClass | Class | None:
+        """Return the existing LTIClass/Class for this (registration, course_id),
+        applying any platform-specific cross-registration lookup. Return None
+        if no class has been linked yet (caller will create a pending LTIClass).
+        """
+
+
+__all__ = [
+    "LTIPlatformHandler",
+    "parse_context_memberships_url",
+    "_get_claim_object",
+]

--- a/pingpong/lti/platforms/base.py
+++ b/pingpong/lti/platforms/base.py
@@ -74,6 +74,10 @@ class LTIPlatformHandler(ABC):
         """
         return providers
 
+    def show_course_navigation_control(self) -> bool:
+        """Whether the registration UI should show the course-navigation toggle."""
+        return False
+
     @abstractmethod
     def extract_registration_fields(
         self, platform_config: dict[str, Any]

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -24,7 +24,7 @@ from pingpong.lti.platforms.base import (
     LTIPlatformHandler,
     parse_context_memberships_url,
 )
-from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.lti.schemas import LTILaunchCourseMetadata, LTIRegisterRequest
 from pingpong.models import Class, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
@@ -133,7 +133,7 @@ class CanvasPlatformHandler(LTIPlatformHandler):
         self,
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
-    ) -> tuple[str | None, str | None, str | None, str | None]:
+    ) -> LTILaunchCourseMetadata:
         context = get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
 
         course_code_value = context.get("label")
@@ -151,7 +151,12 @@ class CanvasPlatformHandler(LTIPlatformHandler):
             course_term = None
 
         context_memberships_url = parse_context_memberships_url(claims)
-        return course_code, course_name, course_term, context_memberships_url
+        return LTILaunchCourseMetadata(
+            course_code=course_code,
+            course_name=course_name,
+            course_term=course_term,
+            context_memberships_url=context_memberships_url,
+        )
 
     async def find_class_for_course(
         self,

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -39,6 +39,9 @@ CANVAS_CUSTOM_PARAM_DEFAULT_VALUES = {
 class CanvasPlatformHandler(LTIPlatformHandler):
     platform = LMSPlatform.CANVAS
 
+    def show_course_navigation_control(self) -> bool:
+        return True
+
     def validate_platform_config(
         self,
         platform_config: dict[str, Any],

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -5,12 +5,12 @@ from typing import Any
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from pingpong.lti.claims import get_claim_object
 from pingpong.lti.constants import (
     CANVAS_ACCOUNT_LTI_GUID_KEY,
     CANVAS_ACCOUNT_NAME_KEY,
     CANVAS_MESSAGE_PLACEMENT,
     LTI_CLAIM_CONTEXT_KEY,
-    LTI_CUSTOM_PARAM_DEFAULT_VALUES,
     LTI_CUSTOM_SSO_PROVIDER_ID_KEY,
     LTI_CUSTOM_SSO_VALUE_KEY,
     LTI_TOOL_CONFIGURATION_KEY,
@@ -22,12 +22,18 @@ from pingpong.lti.lti_course import (
 )
 from pingpong.lti.platforms.base import (
     LTIPlatformHandler,
-    _get_claim_object,
     parse_context_memberships_url,
 )
 from pingpong.lti.schemas import LTIRegisterRequest
 from pingpong.models import Class, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
+
+CANVAS_COURSE_ID_KEY = "canvas_course_id"
+CANVAS_TERM_NAME_KEY = "canvas_term_name"
+CANVAS_CUSTOM_PARAM_DEFAULT_VALUES = {
+    CANVAS_COURSE_ID_KEY: ["$Canvas.course.id"],
+    CANVAS_TERM_NAME_KEY: ["$Canvas.term.name"],
+}
 
 
 class CanvasPlatformHandler(LTIPlatformHandler):
@@ -90,8 +96,12 @@ class CanvasPlatformHandler(LTIPlatformHandler):
                 "placements": ["course_navigation"],
                 "custom_parameters": {
                     "placement": "course_navigation",
-                    "canvas_course_id": "$Canvas.course.id",
-                    "canvas_term_name": "$Canvas.term.name",
+                    CANVAS_COURSE_ID_KEY: CANVAS_CUSTOM_PARAM_DEFAULT_VALUES[
+                        CANVAS_COURSE_ID_KEY
+                    ][0],
+                    CANVAS_TERM_NAME_KEY: CANVAS_CUSTOM_PARAM_DEFAULT_VALUES[
+                        CANVAS_TERM_NAME_KEY
+                    ][0],
                 },
                 "https://canvas.instructure.com/lti/display_type": "full_width_in_context",
                 "https://canvas.instructure.com/lti/course_navigation/default_enabled": data.show_in_course_navigation,
@@ -107,11 +117,11 @@ class CanvasPlatformHandler(LTIPlatformHandler):
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
     ) -> str:
-        course_id = launch_custom_params.get("canvas_course_id")
+        course_id = launch_custom_params.get(CANVAS_COURSE_ID_KEY)
         if (
             not isinstance(course_id, str)
             or not course_id
-            or course_id in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_course_id"]
+            or course_id in CANVAS_CUSTOM_PARAM_DEFAULT_VALUES[CANVAS_COURSE_ID_KEY]
         ):
             raise HTTPException(status_code=400, detail="Missing or invalid course_id")
         return course_id
@@ -121,7 +131,7 @@ class CanvasPlatformHandler(LTIPlatformHandler):
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
     ) -> tuple[str | None, str | None, str | None, str | None]:
-        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+        context = get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
 
         course_code_value = context.get("label")
         course_code = course_code_value if isinstance(course_code_value, str) else None
@@ -129,11 +139,11 @@ class CanvasPlatformHandler(LTIPlatformHandler):
         course_name_value = context.get("title")
         course_name = course_name_value if isinstance(course_name_value, str) else None
 
-        course_term_value = launch_custom_params.get("canvas_term_name")
+        course_term_value = launch_custom_params.get(CANVAS_TERM_NAME_KEY)
         course_term = course_term_value if isinstance(course_term_value, str) else None
         if (
             not course_term
-            or course_term in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_term_name"]
+            or course_term in CANVAS_CUSTOM_PARAM_DEFAULT_VALUES[CANVAS_TERM_NAME_KEY]
         ):
             course_term = None
 

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -78,7 +78,7 @@ class CanvasPlatformHandler(LTIPlatformHandler):
 
         tool_config["custom_parameters"] = {
             "platform": self.platform.value,
-            "pingpong_lti_tool_version": "2.0",
+            "pingpong_lti_tool_version": "1.0",
             LTI_CUSTOM_SSO_PROVIDER_ID_KEY: str(data.provider_id),
             LTI_CUSTOM_SSO_VALUE_KEY: (
                 f"${sso_field_full_name}" if sso_field_full_name else ""

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -78,7 +78,7 @@ class CanvasPlatformHandler(LTIPlatformHandler):
 
         tool_config["custom_parameters"] = {
             "platform": self.platform.value,
-            "pingpong_lti_tool_version": "1.0",
+            "pingpong_lti_tool_version": "2.0",
             LTI_CUSTOM_SSO_PROVIDER_ID_KEY: str(data.provider_id),
             LTI_CUSTOM_SSO_VALUE_KEY: (
                 f"${sso_field_full_name}" if sso_field_full_name else ""

--- a/pingpong/lti/platforms/canvas.py
+++ b/pingpong/lti/platforms/canvas.py
@@ -1,0 +1,160 @@
+"""Canvas-specific LTI platform handler."""
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pingpong.lti.constants import (
+    CANVAS_ACCOUNT_LTI_GUID_KEY,
+    CANVAS_ACCOUNT_NAME_KEY,
+    CANVAS_MESSAGE_PLACEMENT,
+    LTI_CLAIM_CONTEXT_KEY,
+    LTI_CUSTOM_PARAM_DEFAULT_VALUES,
+    LTI_CUSTOM_SSO_PROVIDER_ID_KEY,
+    LTI_CUSTOM_SSO_VALUE_KEY,
+    LTI_TOOL_CONFIGURATION_KEY,
+    MESSAGE_TYPE,
+)
+from pingpong.lti.lti_course import (
+    find_class_by_course_id,
+    find_class_by_course_id_search_by_canvas_account_lti_guid,
+)
+from pingpong.lti.platforms.base import (
+    LTIPlatformHandler,
+    _get_claim_object,
+    parse_context_memberships_url,
+)
+from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.models import Class, LTIClass, LTIRegistration
+from pingpong.schemas import LMSPlatform
+
+
+class CanvasPlatformHandler(LTIPlatformHandler):
+    platform = LMSPlatform.CANVAS
+
+    def validate_platform_config(
+        self,
+        platform_config: dict[str, Any],
+        message_types_supported: list[dict[str, Any]],
+    ) -> None:
+        if not any(
+            CANVAS_MESSAGE_PLACEMENT in msg.get("placements", [])
+            for msg in message_types_supported
+            if msg.get("type") == MESSAGE_TYPE
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Canvas course navigation placement not supported by platform",
+            )
+
+    def validate_registration_request(self, data: LTIRegisterRequest) -> None:
+        # Canvas accepts all SSO configurations the generic validator already allows.
+        return None
+
+    def extract_registration_fields(
+        self, platform_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            "canvas_account_name": platform_config.get(CANVAS_ACCOUNT_NAME_KEY),
+            "canvas_account_lti_guid": platform_config.get(CANVAS_ACCOUNT_LTI_GUID_KEY),
+        }
+
+    def build_tool_registration_payload(
+        self,
+        *,
+        base_tool_config: dict[str, Any],
+        data: LTIRegisterRequest,
+        sso_field_full_name: str | None,
+    ) -> dict[str, Any]:
+        payload = dict(base_tool_config)
+        tool_config = dict(payload[LTI_TOOL_CONFIGURATION_KEY])
+
+        tool_config["custom_parameters"] = {
+            "platform": self.platform.value,
+            "pingpong_lti_tool_version": "1.0",
+            LTI_CUSTOM_SSO_PROVIDER_ID_KEY: str(data.provider_id),
+            LTI_CUSTOM_SSO_VALUE_KEY: (
+                f"${sso_field_full_name}" if sso_field_full_name else ""
+            ),
+        }
+        tool_config["https://canvas.instructure.com/lti/vendor"] = (
+            "Computational Policy Lab"
+        )
+        target_link_uri = tool_config["target_link_uri"]
+        tool_config["messages"] = [
+            {
+                "type": MESSAGE_TYPE,
+                "target_link_uri": target_link_uri,
+                "label": "PingPong",
+                "placements": ["course_navigation"],
+                "custom_parameters": {
+                    "placement": "course_navigation",
+                    "canvas_course_id": "$Canvas.course.id",
+                    "canvas_term_name": "$Canvas.term.name",
+                },
+                "https://canvas.instructure.com/lti/display_type": "full_width_in_context",
+                "https://canvas.instructure.com/lti/course_navigation/default_enabled": data.show_in_course_navigation,
+                "https://canvas.instructure.com/lti/visibility": "members",
+            }
+        ]
+
+        payload[LTI_TOOL_CONFIGURATION_KEY] = tool_config
+        return payload
+
+    def extract_course_id(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> str:
+        course_id = launch_custom_params.get("canvas_course_id")
+        if (
+            not isinstance(course_id, str)
+            or not course_id
+            or course_id in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_course_id"]
+        ):
+            raise HTTPException(status_code=400, detail="Missing or invalid course_id")
+        return course_id
+
+    def extract_course_metadata(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> tuple[str | None, str | None, str | None, str | None]:
+        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+
+        course_code_value = context.get("label")
+        course_code = course_code_value if isinstance(course_code_value, str) else None
+
+        course_name_value = context.get("title")
+        course_name = course_name_value if isinstance(course_name_value, str) else None
+
+        course_term_value = launch_custom_params.get("canvas_term_name")
+        course_term = course_term_value if isinstance(course_term_value, str) else None
+        if (
+            not course_term
+            or course_term in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_term_name"]
+        ):
+            course_term = None
+
+        context_memberships_url = parse_context_memberships_url(claims)
+        return course_code, course_name, course_term, context_memberships_url
+
+    async def find_class_for_course(
+        self,
+        db: AsyncSession,
+        registration: LTIRegistration,
+        course_id: str,
+    ) -> LTIClass | Class | None:
+        if registration.canvas_account_lti_guid:
+            return await find_class_by_course_id_search_by_canvas_account_lti_guid(
+                db,
+                registration_id=registration.id,
+                canvas_account_lti_guid=registration.canvas_account_lti_guid,
+                course_id=course_id,
+            )
+        return await find_class_by_course_id(
+            db,
+            registration.id,
+            course_id,
+        )

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -1,0 +1,125 @@
+"""Harvard LXP LTI platform handler.
+
+Harvard LXP differs from Canvas in three meaningful ways for this integration:
+- No LTI variable substitution, so the course_id is read from the standard
+  `context.id` claim rather than a Canvas-style custom parameter.
+- No `account_lti_guid` equivalent, so cross-registration class lookup is
+  not supported; each deployment stands alone.
+- No Canvas vendor extensions in the tool registration payload.
+"""
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pingpong.lti.constants import (
+    LTI_CLAIM_CONTEXT_KEY,
+    LTI_TOOL_CONFIGURATION_KEY,
+    MESSAGE_TYPE,
+)
+from pingpong.lti.lti_course import find_class_by_course_id
+from pingpong.lti.platforms.base import (
+    LTIPlatformHandler,
+    _get_claim_object,
+    parse_context_memberships_url,
+)
+from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.models import Class, LTIClass, LTIRegistration
+from pingpong.schemas import LMSPlatform
+
+
+class HarvardLxpPlatformHandler(LTIPlatformHandler):
+    platform = LMSPlatform.HARVARD_LXP
+
+    def validate_platform_config(
+        self,
+        platform_config: dict[str, Any],
+        message_types_supported: list[dict[str, Any]],
+    ) -> None:
+        # The generic caller already asserted LtiResourceLinkRequest is
+        # supported. LXP has no additional platform-config requirements.
+        return None
+
+    def validate_registration_request(self, data: LTIRegisterRequest) -> None:
+        # Harvard LXP does not support variable substitution, so an SSO field
+        # would be sent to the tool as a literal string (e.g. "$Person.sourcedId")
+        # rather than the resolved identifier — never usable. Reject up front.
+        if data.provider_id != 0:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Harvard LXP does not support SSO-linked identifiers "
+                    "(no LTI variable substitution)."
+                ),
+            )
+
+    def extract_registration_fields(
+        self, platform_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        # LXP has no account_name / account_lti_guid equivalent.
+        return {}
+
+    def build_tool_registration_payload(
+        self,
+        *,
+        base_tool_config: dict[str, Any],
+        data: LTIRegisterRequest,
+        sso_field_full_name: str | None,
+    ) -> dict[str, Any]:
+        payload = dict(base_tool_config)
+        tool_config = dict(payload[LTI_TOOL_CONFIGURATION_KEY])
+
+        tool_config["custom_parameters"] = {
+            "platform": self.platform.value,
+            "pingpong_lti_tool_version": "1.0",
+        }
+        target_link_uri = tool_config["target_link_uri"]
+        tool_config["messages"] = [
+            {
+                "type": MESSAGE_TYPE,
+                "target_link_uri": target_link_uri,
+                "label": "PingPong",
+            }
+        ]
+
+        payload[LTI_TOOL_CONFIGURATION_KEY] = tool_config
+        return payload
+
+    def extract_course_id(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> str:
+        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+        course_id = context.get("id")
+        if not isinstance(course_id, str) or not course_id:
+            raise HTTPException(status_code=400, detail="Missing or invalid course_id")
+        return course_id
+
+    def extract_course_metadata(
+        self,
+        claims: dict[str, Any],
+        launch_custom_params: dict[str, Any],
+    ) -> tuple[str | None, str | None, str | None, str | None]:
+        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+
+        course_name_value = context.get("title")
+        course_name = course_name_value if isinstance(course_name_value, str) else None
+
+        context_memberships_url = parse_context_memberships_url(claims)
+        # LXP does not provide a meaningful course_code (label is a synthetic
+        # "LES-<uuid>" prefix + UUID) or a course term.
+        return None, course_name, None, context_memberships_url
+
+    async def find_class_for_course(
+        self,
+        db: AsyncSession,
+        registration: LTIRegistration,
+        course_id: str,
+    ) -> LTIClass | Class | None:
+        return await find_class_by_course_id(
+            db,
+            registration.id,
+            course_id,
+        )

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -72,7 +72,7 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
 
         tool_config["custom_parameters"] = {
             "platform": self.platform.value,
-            "pingpong_lti_tool_version": "1.0",
+            "pingpong_lti_tool_version": "2.0",
         }
         target_link_uri = tool_config["target_link_uri"]
         tool_config["messages"] = [

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -18,13 +18,14 @@ from pingpong.lti.constants import (
     LTI_CLAIM_CONTEXT_KEY,
     LTI_TOOL_CONFIGURATION_KEY,
     MESSAGE_TYPE,
+    NO_SSO_PROVIDER_ID,
 )
 from pingpong.lti.lti_course import find_class_by_course_id
 from pingpong.lti.platforms.base import (
     LTIPlatformHandler,
     parse_context_memberships_url,
 )
-from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.lti.schemas import LTILaunchCourseMetadata, LTIRegisterRequest
 from pingpong.models import Class, ExternalLoginProvider, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
@@ -45,7 +46,7 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
         # Harvard LXP does not support variable substitution, so an SSO field
         # would be sent to the tool as a literal string (e.g. "$Person.sourcedId")
         # rather than the resolved identifier — never usable. Reject up front.
-        if data.provider_id != 0:
+        if data.provider_id != NO_SSO_PROVIDER_ID:
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -108,16 +109,19 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
         self,
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
-    ) -> tuple[str | None, str | None, str | None, str | None]:
+    ) -> LTILaunchCourseMetadata:
         context = get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
 
         course_name_value = context.get("title")
         course_name = course_name_value if isinstance(course_name_value, str) else None
 
         context_memberships_url = parse_context_memberships_url(claims)
-        # LXP does not provide a meaningful course_code (label is a synthetic
-        # "LES-<uuid>" prefix + UUID) or a course term.
-        return None, course_name, None, context_memberships_url
+        return LTILaunchCourseMetadata(
+            course_code=None,
+            course_name=course_name,
+            course_term=None,
+            context_memberships_url=context_memberships_url,
+        )
 
     async def find_class_for_course(
         self,

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from pingpong.lti.claims import get_claim_object
 from pingpong.lti.constants import (
     LTI_CLAIM_CONTEXT_KEY,
     LTI_TOOL_CONFIGURATION_KEY,
@@ -21,7 +22,6 @@ from pingpong.lti.constants import (
 from pingpong.lti.lti_course import find_class_by_course_id
 from pingpong.lti.platforms.base import (
     LTIPlatformHandler,
-    _get_claim_object,
     parse_context_memberships_url,
 )
 from pingpong.lti.schemas import LTIRegisterRequest
@@ -91,7 +91,7 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
     ) -> str:
-        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+        context = get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
         course_id = context.get("id")
         if not isinstance(course_id, str) or not course_id:
             raise HTTPException(status_code=400, detail="Missing or invalid course_id")
@@ -102,7 +102,7 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
         claims: dict[str, Any],
         launch_custom_params: dict[str, Any],
     ) -> tuple[str | None, str | None, str | None, str | None]:
-        context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
+        context = get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
 
         course_name_value = context.get("title")
         course_name = course_name_value if isinstance(course_name_value, str) else None

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -25,7 +25,7 @@ from pingpong.lti.platforms.base import (
     parse_context_memberships_url,
 )
 from pingpong.lti.schemas import LTIRegisterRequest
-from pingpong.models import Class, LTIClass, LTIRegistration
+from pingpong.models import Class, ExternalLoginProvider, LTIClass, LTIRegistration
 from pingpong.schemas import LMSPlatform
 
 
@@ -53,6 +53,13 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
                     "(no LTI variable substitution)."
                 ),
             )
+
+    def filter_sso_providers(
+        self, providers: list[ExternalLoginProvider]
+    ) -> list[ExternalLoginProvider]:
+        # Mirrors validate_registration_request: SSO-linked identifiers are
+        # never usable on LXP, so hide the provider dropdown entirely.
+        return []
 
     def extract_registration_fields(
         self, platform_config: dict[str, Any]

--- a/pingpong/lti/platforms/harvard_lxp.py
+++ b/pingpong/lti/platforms/harvard_lxp.py
@@ -72,7 +72,7 @@ class HarvardLxpPlatformHandler(LTIPlatformHandler):
 
         tool_config["custom_parameters"] = {
             "platform": self.platform.value,
-            "pingpong_lti_tool_version": "2.0",
+            "pingpong_lti_tool_version": "1.0",
         }
         target_link_uri = tool_config["target_link_uri"]
         tool_config["messages"] = [

--- a/pingpong/lti/schemas.py
+++ b/pingpong/lti/schemas.py
@@ -12,6 +12,11 @@ class LTIPublicSSOProviders(BaseModel):
     providers: list[LTIPublicSSOProvider]
 
 
+class LTIPublicSSOProvidersRequest(BaseModel):
+    openid_configuration: str
+    registration_token: str
+
+
 class LTIPublicInstitution(BaseModel):
     id: int
     name: str

--- a/pingpong/lti/schemas.py
+++ b/pingpong/lti/schemas.py
@@ -1,6 +1,8 @@
 from typing import Literal
 from pydantic import BaseModel, Field
 
+from pingpong.schemas import LMSPlatform
+
 
 class LTIPublicSSOProvider(BaseModel):
     id: int
@@ -8,11 +10,7 @@ class LTIPublicSSOProvider(BaseModel):
     display_name: str | None
 
 
-class LTIPublicSSOProviders(BaseModel):
-    providers: list[LTIPublicSSOProvider]
-
-
-class LTIPublicSSOProvidersRequest(BaseModel):
+class LTIRegisterSetupRequest(BaseModel):
     openid_configuration: str
     registration_token: str
 
@@ -22,8 +20,11 @@ class LTIPublicInstitution(BaseModel):
     name: str
 
 
-class LTIPublicInstitutions(BaseModel):
+class LTIRegisterSetupResponse(BaseModel):
+    platform: LMSPlatform
+    providers: list[LTIPublicSSOProvider]
     institutions: list[LTIPublicInstitution]
+    show_course_navigation_control: bool
 
 
 LTISSOField = Literal[

--- a/pingpong/lti/schemas.py
+++ b/pingpong/lti/schemas.py
@@ -87,3 +87,10 @@ class LTISetupLinkRequest(BaseModel):
 
 class LTISetupLinkResponse(BaseModel):
     class_id: int
+
+
+class LTILaunchCourseMetadata(BaseModel):
+    course_code: str | None
+    course_name: str | None
+    course_term: str | None
+    context_memberships_url: str | None

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -43,6 +43,8 @@ from pingpong.lti.constants import (
     LTI_TOOL_CONFIGURATION_KEY,
     MESSAGE_TYPES_KEY,
     MESSAGE_TYPE,
+    NO_SSO_PROVIDER_ID,
+    NO_SSO_PROVIDER_ID_STR,
     PLATFORM_CONFIGURATION_KEY,
     REGISTRATION_ENDPOINT_KEY,
     REQUIRED_SCOPES,
@@ -273,7 +275,9 @@ async def _resolve_platform(
 
     product_family_code = platform_config.get("product_family_code")
     if product_family_code not in {p.value for p in LMSPlatform}:
-        raise HTTPException(status_code=400, detail="Invalid product family")
+        raise HTTPException(
+            status_code=400, detail="Missing or unsupported product_family_code"
+        )
 
     return LMSPlatform(product_family_code), response_data
 
@@ -410,7 +414,7 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
             status_code=400, detail="At least one institution must be selected"
         )
 
-    if data.provider_id == 0:
+    if data.provider_id == NO_SSO_PROVIDER_ID:
         if data.sso_field is not None:
             raise HTTPException(
                 status_code=400, detail="SSO field must be null when no SSO is selected"
@@ -906,7 +910,9 @@ async def lti_launch(
             sanitize_for_log(user_email),
         )
 
-    sso_provider_id_str = launch_custom_params.get(LTI_CUSTOM_SSO_PROVIDER_ID_KEY, "0")
+    sso_provider_id_str = launch_custom_params.get(
+        LTI_CUSTOM_SSO_PROVIDER_ID_KEY, NO_SSO_PROVIDER_ID_STR
+    )
     user: User | None = None
     sso_provider: ExternalLoginProvider | None = None
     sso_value: str | None = None
@@ -919,7 +925,7 @@ async def lti_launch(
             )
         )
 
-    if int(sso_provider_id_str) != 0:
+    if int(sso_provider_id_str) != NO_SSO_PROVIDER_ID:
         sso_provider = await ExternalLoginProvider.get_by_id(
             request.state["db"], int(sso_provider_id_str)
         )

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -64,9 +64,8 @@ from pingpong.lti.roles import (
 )
 from pingpong.lti.schemas import (
     LTIRegisterRequest,
-    LTIPublicInstitutions,
-    LTIPublicSSOProviders,
-    LTIPublicSSOProvidersRequest,
+    LTIRegisterSetupRequest,
+    LTIRegisterSetupResponse,
     LTISetupContext,
     LTISetupInstitution,
     LTILinkableGroup,
@@ -374,10 +373,8 @@ async def get_jwks(key_manager: LTIKeyManager = Depends(get_lti_key_manager)):
         raise HTTPException(status_code=500, detail="Error retrieving public keys")
 
 
-@lti_router.post("/public/sso/providers", response_model=LTIPublicSSOProviders)
-async def get_public_sso_providers(
-    request: StateRequest, data: LTIPublicSSOProvidersRequest
-):
+@lti_router.post("/register/setup", response_model=LTIRegisterSetupResponse)
+async def get_lti_register_setup(request: StateRequest, data: LTIRegisterSetupRequest):
     platform, _ = await _resolve_platform(
         data.openid_configuration, data.registration_token
     )
@@ -386,19 +383,15 @@ async def get_public_sso_providers(
     all_providers = await ExternalLoginProvider.get_all(request.state["db"])
     public_providers = [p for p in all_providers if _is_public_sso_provider(p)]
     allowed = handler.filter_sso_providers(public_providers)
+    institutions = await Institution.get_all_with_default_api_key(request.state["db"])
     return {
+        "platform": platform,
         "providers": [
             {"id": p.id, "name": p.name, "display_name": p.display_name}
             for p in allowed
-        ]
-    }
-
-
-@lti_router.get("/public/institutions", response_model=LTIPublicInstitutions)
-async def get_public_institutions(request: StateRequest):
-    institutions = await Institution.get_all_with_default_api_key(request.state["db"])
-    return {
-        "institutions": [{"id": inst.id, "name": inst.name} for inst in institutions]
+        ],
+        "institutions": [{"id": inst.id, "name": inst.name} for inst in institutions],
+        "show_course_navigation_control": handler.show_course_navigation_control(),
     }
 
 

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -21,16 +21,12 @@ from pingpong.lti.endpoints import (
     allow_redirects,
     generate_authorization_endpoint_url,
     generate_jwks_uri_url,
-    generate_names_and_role_api_url,
     generate_openid_configuration_url,
     generate_registration_endpoint_url,
     generate_token_endpoint_url,
 )
 from pingpong.lti.constants import (
     AUTHORIZATION_ENDPOINT_KEY,
-    CANVAS_ACCOUNT_LTI_GUID_KEY,
-    CANVAS_ACCOUNT_NAME_KEY,
-    CANVAS_MESSAGE_PLACEMENT,
     ISSUER_KEY,
     KEYS_ENDPOINT_KEY,
     LTI_CLAIM_CONTEXT_KEY,
@@ -59,10 +55,7 @@ from pingpong.lti.http import (
     create_lti_redirect_trace_config,
     request_with_validated_redirects,
 )
-from pingpong.lti.lti_course import (
-    find_class_by_course_id,
-    find_class_by_course_id_search_by_canvas_account_lti_guid,
-)
+from pingpong.lti.platforms import get_handler
 from pingpong.lti.roles import (
     is_admin as is_lti_admin,
     is_instructor as is_lti_instructor,
@@ -105,6 +98,7 @@ from pingpong.schemas import (
     CreateUserClassRoles,
     ExternalLoginLookupItem,
     LMSPlatform,
+    LMSType,
     LTIRegistrationReviewStatus,
     LTIStatus,
     UserState,
@@ -332,45 +326,6 @@ def _get_claim_object(claims: dict[str, Any], claim_key: str) -> dict[str, Any]:
     return {}
 
 
-def parse_lti_context_and_nrps(
-    claims: dict[str, Any], launch_custom_params: dict[str, Any]
-) -> tuple[str | None, str | None, str | None, str | None]:
-    context = _get_claim_object(claims, LTI_CLAIM_CONTEXT_KEY)
-    nrps_claim = _get_claim_object(claims, LTI_CLAIM_NRPS_KEY)
-
-    course_code_value = context.get("label")
-    course_code = course_code_value if isinstance(course_code_value, str) else None
-
-    course_name_value = context.get("title")
-    course_name = course_name_value if isinstance(course_name_value, str) else None
-
-    course_term_value = launch_custom_params.get("canvas_term_name")
-    course_term = course_term_value if isinstance(course_term_value, str) else None
-    if (
-        not course_term
-        or course_term in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_term_name"]
-    ):
-        course_term = None
-
-    context_memberships_url_value = nrps_claim.get("context_memberships_url")
-    context_memberships_url = None
-    if (
-        isinstance(context_memberships_url_value, str)
-        and context_memberships_url_value.strip()
-    ):
-        try:
-            context_memberships_url = generate_names_and_role_api_url(
-                context_memberships_url_value
-            )
-        except ValueError as e:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid context_memberships_url",
-            ) from e
-
-    return course_code, course_name, course_term, context_memberships_url
-
-
 def get_lti_key_manager() -> LTIKeyManager:
     """Get the LTI key manager from config."""
     lti_settings = config.lti
@@ -486,6 +441,8 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
         raise HTTPException(status_code=400, detail="Invalid product family")
 
     platform = LMSPlatform(product_family_code)
+    handler = get_handler(platform)
+    handler.validate_registration_request(data)
 
     missing_required_fields_detail = "Missing required OpenID configuration fields"
     issuer = _require_non_empty_string(issuer, missing_required_fields_detail)
@@ -521,15 +478,7 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
             status_code=400, detail="LtiResourceLinkRequest not supported by platform"
         )
 
-    if not any(
-        CANVAS_MESSAGE_PLACEMENT in msg.get("placements", [])
-        for msg in message_types_supported
-        if msg.get("type") == MESSAGE_TYPE
-    ):
-        raise HTTPException(
-            status_code=400,
-            detail="Canvas course navigation placement not supported by platform",
-        )
+    handler.validate_platform_config(platform_config, message_types_supported)
 
     if "RS256" not in token_algorithms:
         raise HTTPException(
@@ -539,10 +488,9 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
     if "public" not in subject_types:
         raise HTTPException(status_code=400, detail="public subject type not supported")
 
-    canvas_account_name = platform_config.get(CANVAS_ACCOUNT_NAME_KEY)
-    canvas_account_lti_guid = platform_config.get(CANVAS_ACCOUNT_LTI_GUID_KEY)
+    platform_registration_fields = handler.extract_registration_fields(platform_config)
 
-    tool_registration_data = {
+    base_tool_config = {
         "application_type": "web",
         "grant_types": ["client_credentials", "implicit"],
         "initiate_login_uri": config.url("/api/v1/lti/login"),
@@ -559,14 +507,6 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
             .replace("/", ""),
             "target_link_uri": config.url("/api/v1/lti/launch"),
             "description": "A platform carefully designed for AI-driven learning.",
-            "custom_parameters": {
-                "platform": platform.value,
-                "pingpong_lti_tool_version": "1.0",
-                LTI_CUSTOM_SSO_PROVIDER_ID_KEY: str(data.provider_id),
-                LTI_CUSTOM_SSO_VALUE_KEY: (
-                    f"${sso_field_full_name}" if sso_field_full_name else ""
-                ),
-            },
             "claims": [
                 "sub",
                 "iss",
@@ -579,25 +519,13 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
                 LTI_CLAIM_TOOL_PLATFORM_KEY,
                 LTI_CLAIM_NRPS_KEY,
             ],
-            "https://canvas.instructure.com/lti/vendor": "Computational Policy Lab",
-            "messages": [
-                {
-                    "type": MESSAGE_TYPE,
-                    "target_link_uri": config.url("/api/v1/lti/launch"),
-                    "label": "PingPong",
-                    "placements": ["course_navigation"],
-                    "custom_parameters": {
-                        "placement": "course_navigation",
-                        "canvas_course_id": "$Canvas.course.id",
-                        "canvas_term_name": "$Canvas.term.name",
-                    },
-                    "https://canvas.instructure.com/lti/display_type": "full_width_in_context",
-                    "https://canvas.instructure.com/lti/course_navigation/default_enabled": data.show_in_course_navigation,
-                    "https://canvas.instructure.com/lti/visibility": "members",
-                }
-            ],
         },
     }
+    tool_registration_data = handler.build_tool_registration_payload(
+        base_tool_config=base_tool_config,
+        data=data,
+        sso_field_full_name=sso_field_full_name,
+    )
 
     registration_response_data: dict[str, Any] | None = None
     try:
@@ -687,11 +615,10 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
         "key_set_url": keys_endpoint,
         "lms_platform": platform,
         "token_algorithm": "RS256",
-        "canvas_account_name": canvas_account_name,
-        "canvas_account_lti_guid": canvas_account_lti_guid,
         "admin_name": data.admin_name,
         "admin_email": data.admin_email,
         "friendly_name": data.name,
+        **platform_registration_fields,
     }
 
     await LTIRegistration.create(
@@ -930,27 +857,11 @@ async def lti_launch(
     ):
         return RedirectResponse(url=config.url("/lti/inactive"), status_code=302)
 
-    course_id = launch_custom_params.get("canvas_course_id")
-    if (
-        not isinstance(course_id, str)
-        or not course_id
-        or course_id in LTI_CUSTOM_PARAM_DEFAULT_VALUES["canvas_course_id"]
-    ):
-        raise HTTPException(status_code=400, detail="Missing or invalid course_id")
-
-    if registration.canvas_account_lti_guid:
-        class_ = await find_class_by_course_id_search_by_canvas_account_lti_guid(
-            request.state["db"],
-            registration_id=registration.id,
-            canvas_account_lti_guid=registration.canvas_account_lti_guid,
-            course_id=course_id,
-        )
-    else:
-        class_ = await find_class_by_course_id(
-            request.state["db"],
-            registration.id,
-            course_id,
-        )
+    handler = get_handler(registration.lms_platform)
+    course_id = handler.extract_course_id(claims, launch_custom_params)
+    class_ = await handler.find_class_for_course(
+        request.state["db"], registration, course_id
+    )
 
     user_roles = claims.get(LTI_CLAIM_ROLES_KEY, [])
     is_instructor = _is_instructor(user_roles)
@@ -1158,10 +1069,7 @@ async def lti_launch(
                     course_name,
                     course_term,
                     context_memberships_url,
-                ) = parse_lti_context_and_nrps(
-                    claims,
-                    launch_custom_params,
-                )
+                ) = handler.extract_course_metadata(claims, launch_custom_params)
 
                 pending_lti_class = LTIClass(
                     registration_id=registration.id,
@@ -1236,7 +1144,7 @@ async def lti_launch(
                     ],
                     silent=True,
                     lms_tenant=None,
-                    lms_type=registration.lms_platform,
+                    lms_type=LMSType.from_lti_platform(registration.lms_platform),
                     lti_class_id=class_.id,
                     is_lti_launch=True,
                 )
@@ -1281,10 +1189,7 @@ async def lti_launch(
                     course_name,
                     course_term,
                     context_memberships_url,
-                ) = parse_lti_context_and_nrps(
-                    claims,
-                    launch_custom_params,
-                )
+                ) = handler.extract_course_metadata(claims, launch_custom_params)
                 second_lti_class = LTIClass(
                     registration_id=registration.id,
                     lti_status=LTIStatus.LINKED,
@@ -1338,7 +1243,11 @@ async def lti_launch(
                         )
                     ],
                     silent=True,
-                    lms_type=class_.lti_platform if not second_lti_class else None,
+                    lms_type=(
+                        LMSType.from_lti_platform(class_.lti_platform)
+                        if not second_lti_class
+                        else None
+                    ),
                     lti_class_id=second_lti_class.id if second_lti_class else class_.id,
                     is_lti_launch=True,
                 )
@@ -1378,10 +1287,7 @@ async def lti_launch(
                     course_name,
                     course_term,
                     context_memberships_url,
-                ) = parse_lti_context_and_nrps(
-                    claims,
-                    launch_custom_params,
-                )
+                ) = handler.extract_course_metadata(claims, launch_custom_params)
                 new_lti_class = LTIClass(
                     registration_id=registration.id,
                     lti_status=LTIStatus.LINKED,
@@ -1436,7 +1342,7 @@ async def lti_launch(
                     lms_tenant=class_.lms_tenant if not new_lti_class else None,
                     lms_type=class_.lms_type
                     if not new_lti_class
-                    else new_lti_class.lti_platform,
+                    else LMSType.from_lti_platform(new_lti_class.lti_platform),
                     lti_class_id=new_lti_class.id if new_lti_class else None,
                     is_lti_launch=True,
                 )

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -66,6 +66,7 @@ from pingpong.lti.schemas import (
     LTIRegisterRequest,
     LTIPublicInstitutions,
     LTIPublicSSOProviders,
+    LTIPublicSSOProvidersRequest,
     LTISetupContext,
     LTISetupInstitution,
     LTILinkableGroup,
@@ -250,6 +251,34 @@ async def _fetch_openid_configuration(
             ) from e
 
 
+async def _resolve_platform(
+    openid_configuration: str, registration_token: str
+) -> tuple[LMSPlatform, dict[str, Any]]:
+    """Fetch the platform's openid configuration and return (platform, response).
+    Raises HTTPException(400) if the product_family_code is missing or unknown.
+    The full response is returned so callers that will also register can reuse
+    it without a second fetch.
+    """
+    headers = {"Authorization": f"Bearer {registration_token}"}
+    response_data = await _fetch_openid_configuration(openid_configuration, headers)
+    if not response_data:
+        raise HTTPException(
+            status_code=500, detail="Failed to fetch OpenID configuration"
+        )
+
+    platform_config = response_data.get(PLATFORM_CONFIGURATION_KEY)
+    if not isinstance(platform_config, dict):
+        raise HTTPException(
+            status_code=400, detail="Missing platform configuration in OpenID response"
+        )
+
+    product_family_code = platform_config.get("product_family_code")
+    if product_family_code not in {p.value for p in LMSPlatform}:
+        raise HTTPException(status_code=400, detail="Invalid product family")
+
+    return LMSPlatform(product_family_code), response_data
+
+
 def _select_jwk(jwks: dict[str, Any], kid: str | None) -> dict[str, Any]:
     keys = jwks.get("keys")
     if not isinstance(keys, list) or not keys:
@@ -345,14 +374,22 @@ async def get_jwks(key_manager: LTIKeyManager = Depends(get_lti_key_manager)):
         raise HTTPException(status_code=500, detail="Error retrieving public keys")
 
 
-@lti_router.get("/public/sso/providers", response_model=LTIPublicSSOProviders)
-async def get_public_sso_providers(request: StateRequest):
-    providers = await ExternalLoginProvider.get_all(request.state["db"])
+@lti_router.post("/public/sso/providers", response_model=LTIPublicSSOProviders)
+async def get_public_sso_providers(
+    request: StateRequest, data: LTIPublicSSOProvidersRequest
+):
+    platform, _ = await _resolve_platform(
+        data.openid_configuration, data.registration_token
+    )
+    handler = get_handler(platform)
+
+    all_providers = await ExternalLoginProvider.get_all(request.state["db"])
+    public_providers = [p for p in all_providers if _is_public_sso_provider(p)]
+    allowed = handler.filter_sso_providers(public_providers)
     return {
         "providers": [
             {"id": p.id, "name": p.name, "display_name": p.display_name}
-            for p in providers
-            if _is_public_sso_provider(p)
+            for p in allowed
         ]
     }
 
@@ -403,15 +440,11 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
         None if data.sso_field is None else SSO_FIELD_FULL_NAME[data.sso_field]
     )
 
-    headers = {"Authorization": f"Bearer {data.registration_token}"}
-    response_data = await _fetch_openid_configuration(
-        data.openid_configuration, headers
+    platform, response_data = await _resolve_platform(
+        data.openid_configuration, data.registration_token
     )
-
-    if not response_data:
-        raise HTTPException(
-            status_code=500, detail="Failed to fetch OpenID configuration"
-        )
+    handler = get_handler(platform)
+    handler.validate_registration_request(data)
 
     issuer = response_data.get(ISSUER_KEY)
     authorization_endpoint = response_data.get(AUTHORIZATION_ENDPOINT_KEY)
@@ -421,22 +454,7 @@ async def register_lti_instance(request: StateRequest, data: LTIRegisterRequest)
     scopes_supported = response_data.get(SCOPES_SUPPORTED_KEY, [])
     token_algorithms = response_data.get(TOKEN_ALG_KEY, [])
     subject_types = response_data.get(SUBJECT_TYPES_KEY, [])
-
-    platform_config = response_data.get(PLATFORM_CONFIGURATION_KEY)
-    if not isinstance(platform_config, dict):
-        raise HTTPException(
-            status_code=400, detail="Missing platform configuration in OpenID response"
-        )
-
-    product_family_code = platform_config.get("product_family_code")
-
-    # Check that the product family code exists in schema.LMSPlatform
-    if product_family_code not in {platform.value for platform in LMSPlatform}:
-        raise HTTPException(status_code=400, detail="Invalid product family")
-
-    platform = LMSPlatform(product_family_code)
-    handler = get_handler(platform)
-    handler.validate_registration_request(data)
+    platform_config = response_data[PLATFORM_CONFIGURATION_KEY]
 
     missing_required_fields_detail = "Missing required OpenID configuration fields"
     issuer = _require_non_empty_string(issuer, missing_required_fields_detail)

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -1075,12 +1075,7 @@ async def lti_launch(
                 await request.state["db"].flush()
             else:
                 # Create new pending LTIClass to store context
-                (
-                    course_code,
-                    course_name,
-                    course_term,
-                    context_memberships_url,
-                ) = handler.extract_course_metadata(claims, launch_custom_params)
+                metadata = handler.extract_course_metadata(claims, launch_custom_params)
 
                 pending_lti_class = LTIClass(
                     registration_id=registration.id,
@@ -1088,12 +1083,12 @@ async def lti_launch(
                     lti_platform=registration.lms_platform,
                     course_id=course_id,
                     resource_link_id=resource_link_id,
-                    course_code=course_code,
-                    course_name=course_name,
-                    course_term=course_term,
+                    course_code=metadata.course_code,
+                    course_name=metadata.course_name,
+                    course_term=metadata.course_term,
                     class_id=None,
                     setup_user_id=user.id,
-                    context_memberships_url=context_memberships_url,
+                    context_memberships_url=metadata.context_memberships_url,
                 )
                 request.state["db"].add(pending_lti_class)
                 await request.state["db"].flush()
@@ -1195,24 +1190,19 @@ async def lti_launch(
                 )
 
             if is_instructor or is_admin_supervisor:
-                (
-                    course_code,
-                    course_name,
-                    course_term,
-                    context_memberships_url,
-                ) = handler.extract_course_metadata(claims, launch_custom_params)
+                metadata = handler.extract_course_metadata(claims, launch_custom_params)
                 second_lti_class = LTIClass(
                     registration_id=registration.id,
                     lti_status=LTIStatus.LINKED,
                     lti_platform=registration.lms_platform,
                     course_id=course_id,
                     resource_link_id=resource_link_id,
-                    course_code=course_code,
-                    course_name=course_name,
-                    course_term=course_term,
+                    course_code=metadata.course_code,
+                    course_name=metadata.course_name,
+                    course_term=metadata.course_term,
                     class_id=pp_class.id,
                     setup_user_id=user.id,
-                    context_memberships_url=context_memberships_url,
+                    context_memberships_url=metadata.context_memberships_url,
                 )
                 request.state["db"].add(second_lti_class)
                 await request.state["db"].flush()
@@ -1293,24 +1283,19 @@ async def lti_launch(
                 )
 
             if is_instructor or is_admin_supervisor:
-                (
-                    course_code,
-                    course_name,
-                    course_term,
-                    context_memberships_url,
-                ) = handler.extract_course_metadata(claims, launch_custom_params)
+                metadata = handler.extract_course_metadata(claims, launch_custom_params)
                 new_lti_class = LTIClass(
                     registration_id=registration.id,
                     lti_status=LTIStatus.LINKED,
                     lti_platform=registration.lms_platform,
                     course_id=course_id,
                     resource_link_id=resource_link_id,
-                    course_code=course_code,
-                    course_name=course_name,
-                    course_term=course_term,
+                    course_code=metadata.course_code,
+                    course_name=metadata.course_name,
+                    course_term=metadata.course_term,
                     class_id=class_.id,
                     setup_user_id=user.id,
-                    context_memberships_url=context_memberships_url,
+                    context_memberships_url=metadata.context_memberships_url,
                 )
                 request.state["db"].add(new_lti_class)
                 await request.state["db"].flush()

--- a/pingpong/lti/server.py
+++ b/pingpong/lti/server.py
@@ -17,6 +17,7 @@ from pingpong.authz.openfga import OpenFgaAuthzClient
 from pingpong.config import config
 from pingpong.invite import send_lti_registration_submitted
 from pingpong.log_utils import sanitize_for_log
+from pingpong.lti.claims import get_claim_object as _get_claim_object
 from pingpong.lti.endpoints import (
     allow_redirects,
     generate_authorization_endpoint_url,
@@ -317,13 +318,6 @@ async def _verify_lti_id_token(
     if not isinstance(claims, dict):
         raise HTTPException(status_code=400, detail="Invalid id_token claims")
     return cast(dict[str, Any], claims)
-
-
-def _get_claim_object(claims: dict[str, Any], claim_key: str) -> dict[str, Any]:
-    claim_value = claims.get(claim_key)
-    if isinstance(claim_value, dict):
-        return claim_value
-    return {}
 
 
 def get_lti_key_manager() -> LTIKeyManager:

--- a/pingpong/migrations/m05_populate_account_lti_guid.py
+++ b/pingpong/migrations/m05_populate_account_lti_guid.py
@@ -4,7 +4,10 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import pingpong.models as models
-from pingpong.lti.server import CANVAS_ACCOUNT_LTI_GUID_KEY, PLATFORM_CONFIGURATION_KEY
+from pingpong.lti.constants import (
+    CANVAS_ACCOUNT_LTI_GUID_KEY,
+    PLATFORM_CONFIGURATION_KEY,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1399,6 +1399,11 @@ class CreateUserClassRole(BaseModel):
 
 class LMSType(Enum):
     CANVAS = "canvas"
+    HARVARD_LXP = "harvard_lxp"
+
+    @classmethod
+    def from_lti_platform(cls, platform: "LMSPlatform") -> "LMSType":
+        return cls(platform.value)
 
 
 class CreateUserResult(BaseModel):
@@ -1601,6 +1606,7 @@ class InstitutionAdminResponse(BaseModel):
 
 class LMSPlatform(StrEnum):
     CANVAS = "canvas"
+    HARVARD_LXP = "harvard_lxp"
 
 
 class LTIRegistrationReviewStatus(StrEnum):

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1397,9 +1397,6 @@ class CreateUserClassRole(BaseModel):
     roles: ClassUserRoles
 
 
-_LTI_PLATFORM_TO_LMS_TYPE: dict["LMSPlatform", "LMSType"] = {}
-
-
 class LMSType(Enum):
     CANVAS = "canvas"
     HARVARD_LXP = "harvard_lxp"
@@ -1407,8 +1404,8 @@ class LMSType(Enum):
     @classmethod
     def from_lti_platform(cls, platform: "LMSPlatform") -> "LMSType":
         try:
-            return _LTI_PLATFORM_TO_LMS_TYPE[platform]
-        except KeyError:
+            return cls(platform.value)
+        except ValueError:
             raise ValueError(
                 f"No LMSType mapping for LMSPlatform {platform!r}"
             ) from None

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1397,13 +1397,21 @@ class CreateUserClassRole(BaseModel):
     roles: ClassUserRoles
 
 
+_LTI_PLATFORM_TO_LMS_TYPE: dict["LMSPlatform", "LMSType"] = {}
+
+
 class LMSType(Enum):
     CANVAS = "canvas"
     HARVARD_LXP = "harvard_lxp"
 
     @classmethod
     def from_lti_platform(cls, platform: "LMSPlatform") -> "LMSType":
-        return cls(platform.value)
+        try:
+            return _LTI_PLATFORM_TO_LMS_TYPE[platform]
+        except KeyError:
+            raise ValueError(
+                f"No LMSType mapping for LMSPlatform {platform!r}"
+            ) from None
 
 
 class CreateUserResult(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -2127,7 +2127,7 @@ async def delete_lti_class(
         request.state["db"],
         lti_class.id,
         class_id_int,
-        schemas.LMSType(lti_class.lti_platform),
+        schemas.LMSType.from_lti_platform(lti_class.lti_platform),
         keep_users=keep_users,
     )
 

--- a/pingpong/test_canvas_connect.py
+++ b/pingpong/test_canvas_connect.py
@@ -6,6 +6,7 @@ import pytest
 from yarl import URL
 
 import pingpong.config as config_module
+import pingpong.schemas as schemas
 from pingpong.lti import canvas_connect as canvas_connect_module
 
 
@@ -1303,6 +1304,7 @@ async def test_get_nrps_create_user_class_roles_maps_members_and_pages(monkeypat
     lti_class = SimpleNamespace(
         id=21,
         registration=registration,
+        lti_platform=schemas.LMSPlatform.CANVAS,
         context_memberships_url=context_memberships_url,
         resource_link_id="resource-link-id",
         course_id="1",
@@ -1483,6 +1485,7 @@ async def test_get_nrps_create_user_class_roles_allows_missing_members(monkeypat
     lti_class = SimpleNamespace(
         id=22,
         registration=registration,
+        lti_platform=schemas.LMSPlatform.CANVAS,
         context_memberships_url=context_memberships_url,
         resource_link_id=None,
         course_id="1",
@@ -1535,12 +1538,83 @@ async def test_get_nrps_create_user_class_roles_allows_missing_members(monkeypat
         create_roles = await client.get_nrps_create_user_class_roles()
 
     assert create_roles.roles == []
+    assert create_roles.lms_type == schemas.LMSType.CANVAS
     assert len(fake_session.requests) == 3
     assert fake_session.requests[1]["url"] == context_memberships_url
     assert (
         fake_session.requests[2]["url"]
         == f"{context_memberships_url}?rlid=fallback-context-id"
     )
+
+
+@pytest.mark.asyncio
+async def test_get_nrps_create_user_class_roles_uses_lti_platform_lms_type(
+    monkeypatch,
+):
+    token_endpoint = "https://platform.example.com/token"
+    context_memberships_url = "https://platform.example.com/api/lti/names_and_roles"
+    registration = SimpleNamespace(
+        client_id="client-123",
+        issuer="https://platform.example.com",
+        openid_configuration=f'{{"token_endpoint":"{token_endpoint}"}}',
+        auth_token_url="https://platform.example.com/fallback-token",
+    )
+    lti_class = SimpleNamespace(
+        id=2201,
+        registration=registration,
+        lti_platform=schemas.LMSPlatform.HARVARD_LXP,
+        context_memberships_url=context_memberships_url,
+        resource_link_id="resource-link-id",
+        course_id="1",
+    )
+
+    async def _get_by_id_with_registration(cls, db, id_):
+        return lti_class
+
+    monkeypatch.setattr(
+        canvas_connect_module.LTIClass,
+        "get_by_id_with_registration",
+        classmethod(_get_by_id_with_registration),
+    )
+    monkeypatch.setattr(
+        canvas_connect_module.ExternalLoginProvider,
+        "get_by_id",
+        classmethod(lambda cls, db, id_: _async_return(None)),
+    )
+    monkeypatch.setattr(
+        canvas_connect_module.jwt,
+        "encode",
+        lambda *args, **kwargs: "signed-client-assertion",
+    )
+    monkeypatch.setattr(canvas_connect_module.uuid, "uuid7", lambda: "uuid7-test")
+
+    fake_session = FakeClientSession(
+        [
+            FakeTokenResponse(
+                payload={
+                    "access_token": "short-lived-token",
+                    "expires_in": 3600,
+                }
+            ),
+            FakeTokenResponse(payload={"members": []}),
+        ]
+    )
+    monkeypatch.setattr(
+        canvas_connect_module.aiohttp,
+        "ClientSession",
+        _client_session_factory(fake_session),
+    )
+
+    async with canvas_connect_module.CanvasConnectClient(
+        db=SimpleNamespace(),
+        lti_class_id=2201,
+        key_manager=FakeKeyManager(),
+        nowfn=lambda: datetime(2026, 2, 10, 10, 0, tzinfo=timezone.utc),
+    ) as client:
+        create_roles = await client.get_nrps_create_user_class_roles()
+
+    assert create_roles.roles == []
+    assert create_roles.lms_type == schemas.LMSType.HARVARD_LXP
 
 
 @pytest.mark.asyncio
@@ -1652,6 +1726,7 @@ async def test_get_nrps_create_user_class_roles_no_sso_when_provider_id_zero(
     lti_class = SimpleNamespace(
         id=23,
         registration=registration,
+        lti_platform=schemas.LMSPlatform.CANVAS,
         context_memberships_url=context_memberships_url,
         resource_link_id="resource-link-id",
         course_id="1",
@@ -1748,6 +1823,7 @@ async def test_get_nrps_create_user_class_roles_ignores_sso_provider_ids_from_sk
     lti_class = SimpleNamespace(
         id=2301,
         registration=registration,
+        lti_platform=schemas.LMSPlatform.CANVAS,
         context_memberships_url=context_memberships_url,
         resource_link_id="resource-link-id",
         course_id="1",

--- a/pingpong/test_lti_platforms.py
+++ b/pingpong/test_lti_platforms.py
@@ -14,6 +14,8 @@ from pingpong.lti.constants import (
     LTI_CLAIM_NRPS_KEY,
     LTI_TOOL_CONFIGURATION_KEY,
     MESSAGE_TYPE,
+    NO_SSO_PROVIDER_ID,
+    NO_SSO_PROVIDER_ID_STR,
 )
 from pingpong.lti.platforms import get_handler
 from pingpong.lti.platforms.canvas import CanvasPlatformHandler
@@ -71,7 +73,7 @@ LXP_SAMPLE_CLAIMS = {
 }
 
 
-def _lxp_register_request(provider_id: int = 0) -> LTIRegisterRequest:
+def _lxp_register_request(provider_id: int = NO_SSO_PROVIDER_ID) -> LTIRegisterRequest:
     return LTIRegisterRequest(
         name="PingPong",
         admin_name="Admin",
@@ -152,7 +154,7 @@ def test_canvas_build_tool_registration_payload_includes_vendor_extensions():
         name="PingPong",
         admin_name="Admin",
         admin_email="admin@example.com",
-        provider_id=0,
+        provider_id=NO_SSO_PROVIDER_ID,
         sso_field=None,
         openid_configuration="https://platform.example.com/.well-known/openid",
         registration_token="token",
@@ -166,7 +168,7 @@ def test_canvas_build_tool_registration_payload_includes_vendor_extensions():
     )
     tool = payload[LTI_TOOL_CONFIGURATION_KEY]
     assert tool["custom_parameters"]["platform"] == "canvas"
-    assert tool["custom_parameters"]["sso_provider_id"] == "0"
+    assert tool["custom_parameters"]["sso_provider_id"] == NO_SSO_PROVIDER_ID_STR
     assert tool["custom_parameters"]["sso_value"] == ""
     assert tool["https://canvas.instructure.com/lti/vendor"] == (
         "Computational Policy Lab"
@@ -196,13 +198,13 @@ def test_canvas_extract_course_metadata_reads_all_fields():
         LTI_CLAIM_CONTEXT_KEY: {"label": "CS50", "title": "Intro to CS"},
         LTI_CLAIM_NRPS_KEY: {"context_memberships_url": "https://example.com/nrps"},
     }
-    code, name, term, url = handler.extract_course_metadata(
+    metadata = handler.extract_course_metadata(
         claims, {"canvas_term_name": "Fall 2026"}
     )
-    assert code == "CS50"
-    assert name == "Intro to CS"
-    assert term == "Fall 2026"
-    assert url == "https://example.com/nrps"
+    assert metadata.course_code == "CS50"
+    assert metadata.course_name == "Intro to CS"
+    assert metadata.course_term == "Fall 2026"
+    assert metadata.context_memberships_url == "https://example.com/nrps"
 
 
 # --- HarvardLxpPlatformHandler ---
@@ -225,7 +227,9 @@ def test_lxp_validate_registration_request_rejects_sso():
 
 def test_lxp_validate_registration_request_allows_no_sso():
     handler = HarvardLxpPlatformHandler()
-    handler.validate_registration_request(_lxp_register_request(provider_id=0))
+    handler.validate_registration_request(
+        _lxp_register_request(provider_id=NO_SSO_PROVIDER_ID)
+    )
 
 
 def test_lxp_extract_registration_fields_is_empty():
@@ -271,8 +275,10 @@ def test_lxp_extract_course_id_rejects_missing_context_id():
 
 def test_lxp_extract_course_metadata_omits_code_and_term():
     handler = HarvardLxpPlatformHandler()
-    code, name, term, url = handler.extract_course_metadata(LXP_SAMPLE_CLAIMS, {})
-    assert code is None
-    assert name == "Learning Experience Showcase"
-    assert term is None
-    assert url.endswith("/memberships/39b59151-4bcb-4b17-a4f1-c4c8669a6a80?page=1")
+    metadata = handler.extract_course_metadata(LXP_SAMPLE_CLAIMS, {})
+    assert metadata.course_code is None
+    assert metadata.course_name == "Learning Experience Showcase"
+    assert metadata.course_term is None
+    assert metadata.context_memberships_url.endswith(
+        "/memberships/39b59151-4bcb-4b17-a4f1-c4c8669a6a80?page=1"
+    )

--- a/pingpong/test_lti_platforms.py
+++ b/pingpong/test_lti_platforms.py
@@ -243,7 +243,7 @@ def test_lxp_build_tool_registration_payload_omits_canvas_extensions():
     tool = payload[LTI_TOOL_CONFIGURATION_KEY]
     assert tool["custom_parameters"] == {
         "platform": "harvard_lxp",
-        "pingpong_lti_tool_version": "1.0",
+        "pingpong_lti_tool_version": "2.0",
     }
     assert "https://canvas.instructure.com/lti/vendor" not in tool
     as_json = str(payload)

--- a/pingpong/test_lti_platforms.py
+++ b/pingpong/test_lti_platforms.py
@@ -21,7 +21,7 @@ from pingpong.lti.platforms import get_handler
 from pingpong.lti.platforms.canvas import CanvasPlatformHandler
 from pingpong.lti.platforms.harvard_lxp import HarvardLxpPlatformHandler
 from pingpong.lti.schemas import LTIRegisterRequest
-from pingpong.schemas import LMSPlatform
+from pingpong.schemas import LMSPlatform, LMSType
 
 
 @pytest.fixture(autouse=True)
@@ -112,6 +112,11 @@ def test_get_handler_returns_harvard_lxp_handler():
     h = get_handler(LMSPlatform.HARVARD_LXP)
     assert isinstance(h, HarvardLxpPlatformHandler)
     assert h.platform == LMSPlatform.HARVARD_LXP
+
+
+def test_lms_type_from_lti_platform_maps_current_platform_values():
+    assert LMSType.from_lti_platform(LMSPlatform.CANVAS) == LMSType.CANVAS
+    assert LMSType.from_lti_platform(LMSPlatform.HARVARD_LXP) == LMSType.HARVARD_LXP
 
 
 # --- CanvasPlatformHandler ---

--- a/pingpong/test_lti_platforms.py
+++ b/pingpong/test_lti_platforms.py
@@ -243,7 +243,7 @@ def test_lxp_build_tool_registration_payload_omits_canvas_extensions():
     tool = payload[LTI_TOOL_CONFIGURATION_KEY]
     assert tool["custom_parameters"] == {
         "platform": "harvard_lxp",
-        "pingpong_lti_tool_version": "2.0",
+        "pingpong_lti_tool_version": "1.0",
     }
     assert "https://canvas.instructure.com/lti/vendor" not in tool
     as_json = str(payload)

--- a/pingpong/test_lti_platforms.py
+++ b/pingpong/test_lti_platforms.py
@@ -1,0 +1,278 @@
+"""Unit tests for pingpong.lti.platforms handlers."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import pingpong.config as config_module
+from pingpong.lti.constants import (
+    CANVAS_ACCOUNT_LTI_GUID_KEY,
+    CANVAS_ACCOUNT_NAME_KEY,
+    CANVAS_MESSAGE_PLACEMENT,
+    LTI_CLAIM_CONTEXT_KEY,
+    LTI_CLAIM_NRPS_KEY,
+    LTI_TOOL_CONFIGURATION_KEY,
+    MESSAGE_TYPE,
+)
+from pingpong.lti.platforms import get_handler
+from pingpong.lti.platforms.canvas import CanvasPlatformHandler
+from pingpong.lti.platforms.harvard_lxp import HarvardLxpPlatformHandler
+from pingpong.lti.schemas import LTIRegisterRequest
+from pingpong.schemas import LMSPlatform
+
+
+@pytest.fixture(autouse=True)
+def _patch_lti_security_config(monkeypatch):
+    real_config = config_module.config
+    allow_deny = SimpleNamespace(allow=["*"], deny=[])
+    url_security = SimpleNamespace(
+        allow_http_in_development=True,
+        allow_redirects=True,
+        hosts=allow_deny,
+        paths=allow_deny,
+    )
+    security = SimpleNamespace(
+        allow_http_in_development=True,
+        allow_redirects=True,
+        hosts=allow_deny,
+        paths=allow_deny,
+        authorization_endpoint=url_security,
+        jwks_uri=url_security,
+        names_and_role_endpoint=url_security,
+        openid_configuration=url_security,
+        registration_endpoint=url_security,
+        token_endpoint=url_security,
+    )
+    lti = SimpleNamespace(security=security)
+    patched_config = SimpleNamespace(
+        lti=lti,
+        development=False,
+        url=real_config.url,
+        public_url=real_config.public_url,
+    )
+    monkeypatch.setattr(config_module, "config", patched_config)
+
+
+LXP_SAMPLE_CLAIMS = {
+    LTI_CLAIM_CONTEXT_KEY: {
+        "id": "39b59151-4bcb-4b17-a4f1-c4c8669a6a80",
+        "type": ["CourseSection"],
+        "title": "Learning Experience Showcase",
+        "label": "LES-39b59151-4bcb-4b17-a4f1-c4c8669a6a80",
+    },
+    LTI_CLAIM_NRPS_KEY: {
+        "context_memberships_url": (
+            "https://example.com/api/v1/lti/nrps/memberships/"
+            "39b59151-4bcb-4b17-a4f1-c4c8669a6a80?page=1"
+        ),
+        "service_version": "2.0",
+    },
+}
+
+
+def _lxp_register_request(provider_id: int = 0) -> LTIRegisterRequest:
+    return LTIRegisterRequest(
+        name="PingPong",
+        admin_name="Admin",
+        admin_email="admin@example.com",
+        provider_id=provider_id,
+        sso_field=None,
+        openid_configuration="https://platform.example.com/.well-known/openid",
+        registration_token="token",
+        institution_ids=[1],
+    )
+
+
+def _base_tool_config() -> dict:
+    return {
+        "application_type": "web",
+        "client_name": "PingPong",
+        LTI_TOOL_CONFIGURATION_KEY: {
+            "domain": "tool.example.com",
+            "target_link_uri": "https://tool.example.com/api/v1/lti/launch",
+            "description": "desc",
+            "claims": ["sub", "iss"],
+        },
+    }
+
+
+# --- Factory ---
+
+
+def test_get_handler_returns_canvas_handler():
+    h = get_handler(LMSPlatform.CANVAS)
+    assert isinstance(h, CanvasPlatformHandler)
+    assert h.platform == LMSPlatform.CANVAS
+
+
+def test_get_handler_returns_harvard_lxp_handler():
+    h = get_handler(LMSPlatform.HARVARD_LXP)
+    assert isinstance(h, HarvardLxpPlatformHandler)
+    assert h.platform == LMSPlatform.HARVARD_LXP
+
+
+# --- CanvasPlatformHandler ---
+
+
+def test_canvas_validate_platform_config_rejects_missing_course_navigation():
+    handler = CanvasPlatformHandler()
+    with pytest.raises(HTTPException) as excinfo:
+        handler.validate_platform_config(
+            {},
+            [{"type": MESSAGE_TYPE, "placements": ["https://other.example/placement"]}],
+        )
+    assert excinfo.value.status_code == 400
+    assert "Canvas course navigation" in excinfo.value.detail
+
+
+def test_canvas_validate_platform_config_accepts_course_navigation():
+    handler = CanvasPlatformHandler()
+    handler.validate_platform_config(
+        {},
+        [{"type": MESSAGE_TYPE, "placements": [CANVAS_MESSAGE_PLACEMENT]}],
+    )
+
+
+def test_canvas_extract_registration_fields():
+    handler = CanvasPlatformHandler()
+    platform_config = {
+        CANVAS_ACCOUNT_NAME_KEY: "Harvard Canvas",
+        CANVAS_ACCOUNT_LTI_GUID_KEY: "guid-123",
+    }
+    assert handler.extract_registration_fields(platform_config) == {
+        "canvas_account_name": "Harvard Canvas",
+        "canvas_account_lti_guid": "guid-123",
+    }
+
+
+def test_canvas_build_tool_registration_payload_includes_vendor_extensions():
+    handler = CanvasPlatformHandler()
+    data = LTIRegisterRequest(
+        name="PingPong",
+        admin_name="Admin",
+        admin_email="admin@example.com",
+        provider_id=0,
+        sso_field=None,
+        openid_configuration="https://platform.example.com/.well-known/openid",
+        registration_token="token",
+        institution_ids=[1],
+        show_in_course_navigation=True,
+    )
+    payload = handler.build_tool_registration_payload(
+        base_tool_config=_base_tool_config(),
+        data=data,
+        sso_field_full_name=None,
+    )
+    tool = payload[LTI_TOOL_CONFIGURATION_KEY]
+    assert tool["custom_parameters"]["platform"] == "canvas"
+    assert tool["custom_parameters"]["sso_provider_id"] == "0"
+    assert tool["custom_parameters"]["sso_value"] == ""
+    assert tool["https://canvas.instructure.com/lti/vendor"] == (
+        "Computational Policy Lab"
+    )
+    message = tool["messages"][0]
+    assert message["placements"] == ["course_navigation"]
+    assert message["custom_parameters"]["canvas_course_id"] == "$Canvas.course.id"
+    assert message["custom_parameters"]["canvas_term_name"] == "$Canvas.term.name"
+    assert (
+        message["https://canvas.instructure.com/lti/course_navigation/default_enabled"]
+        is True
+    )
+
+
+def test_canvas_extract_course_id_rejects_placeholder():
+    handler = CanvasPlatformHandler()
+    with pytest.raises(HTTPException):
+        handler.extract_course_id({}, {"canvas_course_id": "$Canvas.course.id"})
+    with pytest.raises(HTTPException):
+        handler.extract_course_id({}, {})
+    assert handler.extract_course_id({}, {"canvas_course_id": "abc123"}) == "abc123"
+
+
+def test_canvas_extract_course_metadata_reads_all_fields():
+    handler = CanvasPlatformHandler()
+    claims = {
+        LTI_CLAIM_CONTEXT_KEY: {"label": "CS50", "title": "Intro to CS"},
+        LTI_CLAIM_NRPS_KEY: {"context_memberships_url": "https://example.com/nrps"},
+    }
+    code, name, term, url = handler.extract_course_metadata(
+        claims, {"canvas_term_name": "Fall 2026"}
+    )
+    assert code == "CS50"
+    assert name == "Intro to CS"
+    assert term == "Fall 2026"
+    assert url == "https://example.com/nrps"
+
+
+# --- HarvardLxpPlatformHandler ---
+
+
+def test_lxp_validate_platform_config_is_permissive():
+    handler = HarvardLxpPlatformHandler()
+    # LXP has no extra platform-config requirements beyond LtiResourceLinkRequest
+    # which the caller already asserts.
+    handler.validate_platform_config({}, [{"type": MESSAGE_TYPE}])
+
+
+def test_lxp_validate_registration_request_rejects_sso():
+    handler = HarvardLxpPlatformHandler()
+    with pytest.raises(HTTPException) as excinfo:
+        handler.validate_registration_request(_lxp_register_request(provider_id=5))
+    assert excinfo.value.status_code == 400
+    assert "SSO-linked" in excinfo.value.detail
+
+
+def test_lxp_validate_registration_request_allows_no_sso():
+    handler = HarvardLxpPlatformHandler()
+    handler.validate_registration_request(_lxp_register_request(provider_id=0))
+
+
+def test_lxp_extract_registration_fields_is_empty():
+    handler = HarvardLxpPlatformHandler()
+    assert handler.extract_registration_fields({"anything": "here"}) == {}
+
+
+def test_lxp_build_tool_registration_payload_omits_canvas_extensions():
+    handler = HarvardLxpPlatformHandler()
+    payload = handler.build_tool_registration_payload(
+        base_tool_config=_base_tool_config(),
+        data=_lxp_register_request(),
+        sso_field_full_name=None,
+    )
+    tool = payload[LTI_TOOL_CONFIGURATION_KEY]
+    assert tool["custom_parameters"] == {
+        "platform": "harvard_lxp",
+        "pingpong_lti_tool_version": "1.0",
+    }
+    assert "https://canvas.instructure.com/lti/vendor" not in tool
+    as_json = str(payload)
+    assert "$Canvas" not in as_json
+    assert "canvas_course_id" not in as_json
+    assert "canvas_term_name" not in as_json
+    message = tool["messages"][0]
+    assert message["type"] == MESSAGE_TYPE
+    assert "placements" not in message
+    assert "custom_parameters" not in message
+
+
+def test_lxp_extract_course_id_reads_context_id():
+    handler = HarvardLxpPlatformHandler()
+    course_id = handler.extract_course_id(LXP_SAMPLE_CLAIMS, {})
+    assert course_id == "39b59151-4bcb-4b17-a4f1-c4c8669a6a80"
+
+
+def test_lxp_extract_course_id_rejects_missing_context_id():
+    handler = HarvardLxpPlatformHandler()
+    with pytest.raises(HTTPException) as excinfo:
+        handler.extract_course_id({LTI_CLAIM_CONTEXT_KEY: {"title": "Foo"}}, {})
+    assert excinfo.value.status_code == 400
+
+
+def test_lxp_extract_course_metadata_omits_code_and_term():
+    handler = HarvardLxpPlatformHandler()
+    code, name, term, url = handler.extract_course_metadata(LXP_SAMPLE_CLAIMS, {})
+    assert code is None
+    assert name == "Learning Experience Showcase"
+    assert term is None
+    assert url.endswith("/memberships/39b59151-4bcb-4b17-a4f1-c4c8669a6a80?page=1")

--- a/pingpong/test_lti_server.py
+++ b/pingpong/test_lti_server.py
@@ -10,12 +10,20 @@ from yarl import URL
 
 import pingpong.config as config_module
 from pingpong.lti import server as server_module
+from pingpong.lti.constants import CANVAS_MESSAGE_PLACEMENT
+from pingpong.lti.platforms import canvas as canvas_module
+from pingpong.lti.platforms.canvas import CanvasPlatformHandler
 from pingpong.lti.schemas import (
     LTIRegisterRequest,
     LTISetupCreateRequest,
     LTISetupLinkRequest,
 )
-from pingpong.schemas import LMSPlatform, LTIRegistrationReviewStatus, LTIStatus
+from pingpong.schemas import (
+    LMSType,
+    LMSPlatform,
+    LTIRegistrationReviewStatus,
+    LTIStatus,
+)
 
 
 class FakeResponse:
@@ -666,7 +674,7 @@ def test_get_claim_object_returns_dict_for_dict_claim():
     )
 
 
-def test_parse_lti_context_and_nrps_filters_non_string_values():
+def test_canvas_extract_course_metadata_filters_non_string_values():
     claims = {
         server_module.LTI_CLAIM_CONTEXT_KEY: {
             "label": 123,
@@ -682,7 +690,7 @@ def test_parse_lti_context_and_nrps_filters_non_string_values():
         course_name,
         course_term,
         context_memberships_url,
-    ) = server_module.parse_lti_context_and_nrps(
+    ) = CanvasPlatformHandler().extract_course_metadata(
         claims,
         {"canvas_term_name": {"name": "Fall"}},
     )
@@ -693,7 +701,7 @@ def test_parse_lti_context_and_nrps_filters_non_string_values():
     assert context_memberships_url == "https://example.com/nrps"
 
 
-def test_parse_lti_context_and_nrps_rejects_invalid_context_memberships_url():
+def test_canvas_extract_course_metadata_rejects_invalid_context_memberships_url():
     claims = {
         server_module.LTI_CLAIM_NRPS_KEY: {
             "context_memberships_url": "not-a-url",
@@ -701,14 +709,14 @@ def test_parse_lti_context_and_nrps_rejects_invalid_context_memberships_url():
     }
 
     with pytest.raises(HTTPException) as excinfo:
-        server_module.parse_lti_context_and_nrps(claims, {})
+        CanvasPlatformHandler().extract_course_metadata(claims, {})
 
     assert excinfo.value.status_code == 400
     assert excinfo.value.detail == "Invalid context_memberships_url"
 
 
 @pytest.mark.parametrize("claim_value", ["", "   "])
-def test_parse_lti_context_and_nrps_treats_blank_context_memberships_url_as_missing(
+def test_canvas_extract_course_metadata_treats_blank_context_memberships_url_as_missing(
     claim_value,
 ):
     claims = {
@@ -717,7 +725,7 @@ def test_parse_lti_context_and_nrps_treats_blank_context_memberships_url_as_miss
         },
     }
 
-    _, _, _, context_memberships_url = server_module.parse_lti_context_and_nrps(
+    _, _, _, context_memberships_url = CanvasPlatformHandler().extract_course_metadata(
         claims, {}
     )
 
@@ -796,7 +804,7 @@ async def test_register_lti_instance_success(monkeypatch):
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -876,7 +884,7 @@ async def test_register_lti_instance_rejects_non_string_registration_endpoint(
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1046,7 +1054,7 @@ async def test_register_lti_instance_rejects_invalid_authorization_endpoint(
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1101,7 +1109,7 @@ async def test_register_lti_instance_does_not_forward_auth_to_openid_redirect(
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1194,7 +1202,7 @@ async def test_register_lti_instance_preserves_auth_on_same_origin_openid_redire
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1289,7 +1297,7 @@ async def test_register_lti_instance_returns_bad_gateway_for_invalid_registratio
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1347,7 +1355,7 @@ async def test_register_lti_instance_converts_post_302_redirect_to_get(
         "messages_supported": [
             {
                 "type": "LtiResourceLinkRequest",
-                "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                "placements": [CANVAS_MESSAGE_PLACEMENT],
             }
         ],
     }
@@ -1498,7 +1506,7 @@ async def test_register_lti_instance_rejects_registration_redirect_to_unallowlis
                     "messages_supported": [
                         {
                             "type": "LtiResourceLinkRequest",
-                            "placements": [server_module.CANVAS_MESSAGE_PLACEMENT],
+                            "placements": [CANVAS_MESSAGE_PLACEMENT],
                         }
                     ],
                 },
@@ -2361,7 +2369,7 @@ async def test_lti_launch_rejects_invalid_context_memberships_url(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2430,7 +2438,7 @@ async def test_lti_launch_no_recognized_roles(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2485,7 +2493,7 @@ async def test_lti_launch_missing_email(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2541,7 +2549,7 @@ async def test_lti_launch_unknown_sso_provider(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2608,7 +2616,7 @@ async def test_lti_launch_instructor_pending_class_redirect(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2682,7 +2690,7 @@ async def test_lti_launch_admin_and_instructor_pending_class_redirect(monkeypatc
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2746,7 +2754,7 @@ async def test_lti_launch_admin_only_no_user_redirect(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2806,7 +2814,7 @@ async def test_lti_launch_student_no_group_redirect(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -2874,7 +2882,7 @@ async def test_lti_launch_existing_lti_class_setup_user(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -2896,6 +2904,91 @@ async def test_lti_launch_existing_lti_class_setup_user(monkeypatch):
 
     assert response.status_code == 302
     assert response.headers["location"].endswith("/group/99?lti_session=token")
+
+
+@pytest.mark.asyncio
+async def test_lti_launch_harvard_lxp_existing_lti_class_add_user(monkeypatch):
+    from pingpong.lti.platforms import harvard_lxp as lxp_module
+
+    oidc_session = _make_oidc_session(
+        redirect_uri=server_module.config.url("/api/v1/lti/launch")
+    )
+    registration = _make_registration(
+        review_status=LTIRegistrationReviewStatus.APPROVED, enabled=True
+    )
+    registration.lms_platform = LMSPlatform.HARVARD_LXP
+    linked_class = SimpleNamespace(
+        id=99,
+        lms_user_id=10,
+        lms_course_id="course-1",
+        lms_tenant=None,
+        lms_type=None,
+    )
+    claims = {
+        "nonce": "nonce",
+        "email": "user@example.com",
+        server_module.LTI_CLAIM_CUSTOM_KEY: {"sso_provider_id": "0"},
+        server_module.LTI_CLAIM_CONTEXT_KEY: {
+            "id": "course-1",
+            "title": "Learning Experience Showcase",
+        },
+        server_module.LTI_CLAIM_ROLES_KEY: [
+            "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
+        ],
+    }
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "get_by_state",
+        lambda db, state: _async_return(oidc_session),
+    )
+    monkeypatch.setattr(
+        server_module.LTIRegistration,
+        "get_by_client_id",
+        lambda db, client_id: _async_return(registration),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_verify_lti_id_token",
+        lambda **kwargs: _async_return(claims),
+    )
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "validate_and_consume",
+        lambda *args, **kwargs: _async_return(True),
+    )
+    monkeypatch.setattr(
+        lxp_module,
+        "find_class_by_course_id",
+        lambda *args, **kwargs: _async_return(linked_class),
+    )
+
+    captured: dict[str, object] = {}
+
+    class FakeAddUsers:
+        def __init__(self, *args, **kwargs):
+            captured["new_ucr"] = args[1]
+
+        async def add_new_users(self):
+            return None
+
+    monkeypatch.setattr(server_module, "User", FakeUserModel)
+    monkeypatch.setattr(server_module, "AddNewUsersManual", FakeAddUsers)
+    monkeypatch.setattr(
+        server_module, "encode_session_token", lambda user_id, nowfn: "token"
+    )
+    monkeypatch.setattr(
+        server_module, "get_now_fn", lambda request: lambda: datetime.now(timezone.utc)
+    )
+
+    request = FakeRequest(
+        payload={"state": "state", "id_token": "token"}, state=_make_request_state()
+    )
+
+    response = await server_module.lti_launch(request, tasks=SimpleNamespace())
+
+    assert response.status_code == 302
+    assert response.headers["location"].endswith("/group/99?lti_session=token")
+    assert captured["new_ucr"].lms_type == LMSType.HARVARD_LXP
 
 
 @pytest.mark.asyncio
@@ -2945,7 +3038,7 @@ async def test_lti_launch_existing_class_add_user(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -3017,7 +3110,7 @@ async def test_lti_launch_resume_pending_lti_class(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(pending_class),
     )
@@ -3086,7 +3179,7 @@ async def test_lti_launch_resume_unlinked_linked_lti_class(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(unlinked_class),
     )
@@ -3170,12 +3263,12 @@ async def test_lti_launch_unlinked_class_from_other_registration_creates_new_pen
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id_search_by_canvas_account_lti_guid",
         lambda *args, **kwargs: _async_return(stale_other_registration_class),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -3253,7 +3346,7 @@ async def test_lti_launch_sso_user_update(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -3377,7 +3470,7 @@ async def test_lti_launch_ambiguous_lookup_returns_conflict(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -3470,7 +3563,7 @@ async def test_lti_launch_updates_email_after_merge(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(None),
     )
@@ -3567,7 +3660,7 @@ async def test_lti_launch_non_lti_class_redirect_when_owner(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -3637,7 +3730,7 @@ async def test_lti_launch_non_lti_class_add_user_same_course(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -3715,7 +3808,7 @@ async def test_lti_launch_non_lti_class_add_user_other_course(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -3791,7 +3884,7 @@ async def test_lti_launch_add_user_exception(monkeypatch):
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -3902,7 +3995,7 @@ async def test_lti_launch_admin_with_can_view_on_lti_class_redirects_to_group(
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -3982,7 +4075,7 @@ async def test_lti_launch_admin_without_can_view_on_lti_class_redirects_to_no_ro
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -4066,7 +4159,7 @@ async def test_lti_launch_admin_supervisor_creates_second_lti_class(monkeypatch)
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -4164,7 +4257,7 @@ async def test_lti_launch_admin_non_supervisor_does_not_create_second_lti_class(
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -4266,7 +4359,7 @@ async def test_lti_launch_admin_non_supervisor_does_not_create_lti_class_for_non
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -4358,7 +4451,7 @@ async def test_lti_launch_admin_with_can_view_on_second_lti_class_redirects_to_g
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -4444,7 +4537,7 @@ async def test_lti_launch_admin_without_can_view_on_second_lti_class_redirects_t
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(lti_class),
     )
@@ -4535,7 +4628,7 @@ async def test_lti_launch_admin_supervisor_creates_new_lti_class_for_non_lti_cla
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -4623,7 +4716,7 @@ async def test_lti_launch_admin_with_can_view_on_non_lti_class_redirects_to_grou
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -4703,7 +4796,7 @@ async def test_lti_launch_admin_without_can_view_on_non_lti_class_redirects_to_n
         lambda *args, **kwargs: _async_return(True),
     )
     monkeypatch.setattr(
-        server_module,
+        canvas_module,
         "find_class_by_course_id",
         lambda *args, **kwargs: _async_return(class_),
     )
@@ -4731,3 +4824,287 @@ async def test_lti_launch_admin_without_can_view_on_non_lti_class_redirects_to_n
 
     assert response.status_code == 302
     assert response.headers["location"].endswith("/lti/no-role")
+
+
+# --------------------------------------------------------------------------- #
+# Harvard LXP platform-specific tests                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _lxp_openid_payload():
+    return {
+        "issuer": "issuer",
+        "authorization_endpoint": "https://platform.example.com/auth",
+        "registration_endpoint": "https://platform.example.com/reg",
+        "jwks_uri": "https://platform.example.com/jwks",
+        "token_endpoint": "https://platform.example.com/token",
+        "scopes_supported": server_module.REQUIRED_SCOPES,
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "subject_types_supported": ["public"],
+        server_module.PLATFORM_CONFIGURATION_KEY: {
+            "product_family_code": "harvard_lxp",
+            "messages_supported": [{"type": "LtiResourceLinkRequest"}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_lti_instance_harvard_lxp_success(monkeypatch):
+    openid_payload = _lxp_openid_payload()
+    registration_payload = {"client_id": "client"}
+
+    fake_factory = _fake_session_factory(
+        get_payload=openid_payload, post_payload=registration_payload
+    )
+    sessions: list = []
+
+    def _factory(*args, **kwargs):
+        session = fake_factory(*args, **kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(server_module.aiohttp, "ClientSession", _factory)
+    monkeypatch.setattr(
+        server_module.Institution,
+        "all_have_default_api_key",
+        lambda db, ids: _async_return(True),
+    )
+    created = {}
+
+    async def _create(db, data, institution_ids):
+        created["data"] = data
+        created["institution_ids"] = institution_ids
+
+    monkeypatch.setattr(server_module.LTIRegistration, "create", _create)
+    monkeypatch.setattr(
+        server_module,
+        "send_lti_registration_submitted",
+        lambda *args, **kwargs: _async_return(None),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "config",
+        SimpleNamespace(
+            url=lambda path: f"https://tool.example.com{path}",
+            public_url="https://tool.example.com",
+            email=SimpleNamespace(sender="sender"),
+            lti=config_module.config.lti,
+        ),
+    )
+
+    data = LTIRegisterRequest(
+        name="PingPong",
+        admin_name="Admin",
+        admin_email="admin@example.com",
+        provider_id=0,
+        sso_field=None,
+        openid_configuration="https://platform.example.com/.well-known/openid",
+        registration_token="token",
+        institution_ids=[1],
+    )
+    request = FakeRequest(state=SimpleNamespace(db="db"))
+
+    result = await server_module.register_lti_instance(request, data)
+
+    assert result == {"status": "ok"}
+    assert created["data"]["client_id"] == "client"
+    assert created["data"]["lms_platform"] == LMSPlatform.HARVARD_LXP
+    assert "canvas_account_name" not in created["data"]
+    assert "canvas_account_lti_guid" not in created["data"]
+
+    post_calls = [call for session in sessions for call in session.post_calls]
+    assert post_calls, "expected POST to registration_endpoint"
+    posted_payload = post_calls[0][1]["json"]
+    serialized = json.dumps(posted_payload)
+    assert "$Canvas" not in serialized
+    assert "canvas_course_id" not in serialized
+    assert "canvas_term_name" not in serialized
+    assert "https://canvas.instructure.com/lti/vendor" not in serialized
+    tool_config = posted_payload[
+        "https://purl.imsglobal.org/spec/lti-tool-configuration"
+    ]
+    assert tool_config["custom_parameters"]["platform"] == "harvard_lxp"
+    assert "sso_provider_id" not in tool_config["custom_parameters"]
+
+
+@pytest.mark.asyncio
+async def test_register_lti_instance_harvard_lxp_rejects_sso(monkeypatch):
+    openid_payload = _lxp_openid_payload()
+
+    monkeypatch.setattr(
+        server_module.aiohttp,
+        "ClientSession",
+        _fake_session_factory(get_payload=openid_payload),
+    )
+    monkeypatch.setattr(
+        server_module.Institution,
+        "all_have_default_api_key",
+        lambda db, ids: _async_return(True),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "config",
+        SimpleNamespace(
+            url=lambda path: f"https://tool.example.com{path}",
+            public_url="https://tool.example.com",
+            email=SimpleNamespace(sender="sender"),
+            lti=config_module.config.lti,
+        ),
+    )
+
+    data = LTIRegisterRequest(
+        name="PingPong",
+        admin_name="Admin",
+        admin_email="admin@example.com",
+        provider_id=5,
+        sso_field="person.sourcedId",
+        openid_configuration="https://platform.example.com/.well-known/openid",
+        registration_token="token",
+        institution_ids=[1],
+    )
+    request = FakeRequest(state=SimpleNamespace(db="db"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await server_module.register_lti_instance(request, data)
+
+    assert excinfo.value.status_code == 400
+    assert "SSO-linked" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_lti_launch_harvard_lxp_missing_context_id(monkeypatch):
+    oidc_session = _make_oidc_session(
+        redirect_uri=server_module.config.url("/api/v1/lti/launch")
+    )
+    registration = _make_registration(
+        review_status=LTIRegistrationReviewStatus.APPROVED, enabled=True
+    )
+    registration.lms_platform = LMSPlatform.HARVARD_LXP
+    claims = {
+        "nonce": "nonce",
+        "email": "user@example.com",
+        server_module.LTI_CLAIM_CUSTOM_KEY: {},
+        server_module.LTI_CLAIM_CONTEXT_KEY: {"title": "Some Course"},
+        server_module.LTI_CLAIM_ROLES_KEY: [
+            "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
+        ],
+    }
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "get_by_state",
+        lambda db, state: _async_return(oidc_session),
+    )
+    monkeypatch.setattr(
+        server_module.LTIRegistration,
+        "get_by_client_id",
+        lambda db, client_id: _async_return(registration),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_verify_lti_id_token",
+        lambda **kwargs: _async_return(claims),
+    )
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "validate_and_consume",
+        lambda *args, **kwargs: _async_return(True),
+    )
+    monkeypatch.setattr(
+        server_module, "get_now_fn", lambda request: lambda: datetime.now(timezone.utc)
+    )
+
+    request = FakeRequest(
+        payload={"state": "state", "id_token": "token"}, state=_make_request_state()
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        await server_module.lti_launch(request, tasks=SimpleNamespace())
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "Missing or invalid course_id"
+
+
+@pytest.mark.asyncio
+async def test_lti_launch_harvard_lxp_pending_setup(monkeypatch):
+    from pingpong.lti.platforms import harvard_lxp as lxp_module
+
+    oidc_session = _make_oidc_session(
+        redirect_uri=server_module.config.url("/api/v1/lti/launch")
+    )
+    registration = _make_registration(
+        review_status=LTIRegistrationReviewStatus.APPROVED, enabled=True
+    )
+    registration.lms_platform = LMSPlatform.HARVARD_LXP
+    course_section_id = "39b59151-4bcb-4b17-a4f1-c4c8669a6a80"
+    claims = {
+        "nonce": "nonce",
+        "email": "user@example.com",
+        "given_name": "Evangelos",
+        "family_name": "Kassos",
+        server_module.LTI_CLAIM_CUSTOM_KEY: {},
+        server_module.LTI_CLAIM_CONTEXT_KEY: {
+            "id": course_section_id,
+            "title": "Learning Experience Showcase",
+            "label": "LES-" + course_section_id,
+        },
+        server_module.LTI_CLAIM_ROLES_KEY: [
+            "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
+        ],
+    }
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "get_by_state",
+        lambda db, state: _async_return(oidc_session),
+    )
+    monkeypatch.setattr(
+        server_module.LTIRegistration,
+        "get_by_client_id",
+        lambda db, client_id: _async_return(registration),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_verify_lti_id_token",
+        lambda **kwargs: _async_return(claims),
+    )
+    monkeypatch.setattr(
+        server_module.LTIOIDCSession,
+        "validate_and_consume",
+        lambda *args, **kwargs: _async_return(True),
+    )
+    monkeypatch.setattr(
+        lxp_module,
+        "find_class_by_course_id",
+        lambda *args, **kwargs: _async_return(None),
+    )
+    monkeypatch.setattr(server_module, "User", FakeUserModel)
+    monkeypatch.setattr(
+        server_module.User,
+        "get_by_email",
+        lambda db, email: _async_return(FakeUserModel(email)),
+    )
+    monkeypatch.setattr(server_module, "LTIClass", FakeLTIClass)
+    monkeypatch.setattr(
+        server_module, "encode_session_token", lambda user_id, nowfn: "token"
+    )
+    monkeypatch.setattr(
+        server_module, "get_now_fn", lambda request: lambda: datetime.now(timezone.utc)
+    )
+
+    state = _make_request_state()
+    request = FakeRequest(
+        payload={"state": "state", "id_token": "token"},
+        state=state,
+    )
+
+    response = await server_module.lti_launch(request, tasks=SimpleNamespace())
+
+    assert response.status_code == 302
+    assert "/lti/setup" in response.headers["location"]
+
+    created = [obj for obj in state.db.added if isinstance(obj, FakeLTIClass)]
+    assert len(created) == 1
+    pending = created[0]
+    assert pending.lti_platform == LMSPlatform.HARVARD_LXP
+    assert pending.course_id == course_section_id
+    assert pending.course_name == "Learning Experience Showcase"
+    assert pending.course_code is None
+    assert pending.course_term is None
+    assert pending.lti_status == LTIStatus.PENDING

--- a/pingpong/test_lti_server.py
+++ b/pingpong/test_lti_server.py
@@ -767,34 +767,82 @@ async def test_get_jwks_error():
 
 
 @pytest.mark.asyncio
-async def test_get_public_sso_providers(monkeypatch):
+async def test_get_lti_register_setup_canvas(monkeypatch):
     providers = [
         SimpleNamespace(id=1, name="email", display_name="Email"),
         SimpleNamespace(id=2, name="saml", display_name="SAML"),
+        SimpleNamespace(id=3, name="okta", display_name="Okta", internal_only=True),
     ]
+    institutions = [
+        SimpleNamespace(id=2, name="B", default_api_key_id=5),
+    ]
+    monkeypatch.setattr(
+        server_module,
+        "_resolve_platform",
+        lambda openid_configuration, registration_token: _async_return(
+            (LMSPlatform.CANVAS, {})
+        ),
+    )
     monkeypatch.setattr(
         server_module.ExternalLoginProvider,
         "get_all",
         lambda db: _async_return(providers),
     )
-    request = FakeRequest(state=SimpleNamespace(db="db"))
-    result = await server_module.get_public_sso_providers(request)
-    assert result["providers"] == [{"id": 2, "name": "saml", "display_name": "SAML"}]
-
-
-@pytest.mark.asyncio
-async def test_get_public_institutions(monkeypatch):
-    institutions = [
-        SimpleNamespace(id=2, name="B", default_api_key_id=5),
-    ]
     monkeypatch.setattr(
         server_module.Institution,
         "get_all_with_default_api_key",
         lambda db: _async_return(institutions),
     )
     request = FakeRequest(state=SimpleNamespace(db="db"))
-    result = await server_module.get_public_institutions(request)
+    result = await server_module.get_lti_register_setup(
+        request,
+        SimpleNamespace(
+            openid_configuration="https://platform.example.com/openid",
+            registration_token="token",
+        ),
+    )
+    assert result["providers"] == [{"id": 2, "name": "saml", "display_name": "SAML"}]
     assert result["institutions"] == [{"id": 2, "name": "B"}]
+    assert result["show_course_navigation_control"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_lti_register_setup_harvard_lxp(monkeypatch):
+    providers = [
+        SimpleNamespace(id=1, name="email", display_name="Email"),
+        SimpleNamespace(id=2, name="saml", display_name="SAML"),
+    ]
+    institutions = [
+        SimpleNamespace(id=2, name="B", default_api_key_id=5),
+    ]
+    monkeypatch.setattr(
+        server_module,
+        "_resolve_platform",
+        lambda openid_configuration, registration_token: _async_return(
+            (LMSPlatform.HARVARD_LXP, {})
+        ),
+    )
+    monkeypatch.setattr(
+        server_module.ExternalLoginProvider,
+        "get_all",
+        lambda db: _async_return(providers),
+    )
+    monkeypatch.setattr(
+        server_module.Institution,
+        "get_all_with_default_api_key",
+        lambda db: _async_return(institutions),
+    )
+    request = FakeRequest(state=SimpleNamespace(db="db"))
+    result = await server_module.get_lti_register_setup(
+        request,
+        SimpleNamespace(
+            openid_configuration="https://platform.example.com/openid",
+            registration_token="token",
+        ),
+    )
+    assert result["providers"] == []
+    assert result["institutions"] == [{"id": 2, "name": "B"}]
+    assert result["show_course_navigation_control"] is False
 
 
 @pytest.mark.asyncio

--- a/pingpong/test_lti_server.py
+++ b/pingpong/test_lti_server.py
@@ -4244,8 +4244,12 @@ async def test_lti_launch_admin_supervisor_creates_second_lti_class(monkeypatch)
     # Should create second LTI class and redirect to group
     assert response.status_code == 302
     assert response.headers["location"].endswith("/group/77?lti_session=token")
-    # Check that a new LTI class was added
-    assert any(isinstance(obj, FakeLTIClass) for obj in db.added)
+    created = [obj for obj in db.added if isinstance(obj, FakeLTIClass)]
+    assert len(created) == 1
+    assert created[0].course_code == "CS1"
+    assert created[0].course_name == "Intro"
+    assert created[0].course_term is None
+    assert created[0].context_memberships_url is None
     # Verify supervisor check was called (this determines LTI class creation)
     assert any(call[1] == "supervisor" for call in authz.test_calls)
 
@@ -4708,8 +4712,12 @@ async def test_lti_launch_admin_supervisor_creates_new_lti_class_for_non_lti_cla
     # Should create new LTI class and redirect to group
     assert response.status_code == 302
     assert response.headers["location"].endswith("/group/321?lti_session=token")
-    # Check that a new LTI class was added
-    assert any(isinstance(obj, FakeLTIClass) for obj in db.added)
+    created = [obj for obj in db.added if isinstance(obj, FakeLTIClass)]
+    assert len(created) == 1
+    assert created[0].course_code == "CS1"
+    assert created[0].course_name == "Intro"
+    assert created[0].course_term is None
+    assert created[0].context_memberships_url is None
     # Verify supervisor check was called (this determines LTI class creation)
     assert any(call[1] == "supervisor" for call in authz.test_calls)
 

--- a/pingpong/test_lti_server.py
+++ b/pingpong/test_lti_server.py
@@ -685,20 +685,15 @@ def test_canvas_extract_course_metadata_filters_non_string_values():
         },
     }
 
-    (
-        course_code,
-        course_name,
-        course_term,
-        context_memberships_url,
-    ) = CanvasPlatformHandler().extract_course_metadata(
+    metadata = CanvasPlatformHandler().extract_course_metadata(
         claims,
         {"canvas_term_name": {"name": "Fall"}},
     )
 
-    assert course_code is None
-    assert course_name is None
-    assert course_term is None
-    assert context_memberships_url == "https://example.com/nrps"
+    assert metadata.course_code is None
+    assert metadata.course_name is None
+    assert metadata.course_term is None
+    assert metadata.context_memberships_url == "https://example.com/nrps"
 
 
 def test_canvas_extract_course_metadata_rejects_invalid_context_memberships_url():
@@ -725,11 +720,9 @@ def test_canvas_extract_course_metadata_treats_blank_context_memberships_url_as_
         },
     }
 
-    _, _, _, context_memberships_url = CanvasPlatformHandler().extract_course_metadata(
-        claims, {}
-    )
+    metadata = CanvasPlatformHandler().extract_course_metadata(claims, {})
 
-    assert context_memberships_url is None
+    assert metadata.context_memberships_url is None
 
 
 def test_get_lti_key_manager_missing_config(monkeypatch):

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1,5 +1,6 @@
 import importlib
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,6 +14,11 @@ from .now import offset
 from .testutil import with_authz, with_authz_series, with_user, with_institution
 
 copy_module = importlib.import_module("pingpong.copy")
+server_module = importlib.import_module("pingpong.server")
+
+
+async def _async_return(value):
+    return value
 
 
 @with_user(123)
@@ -130,6 +136,60 @@ async def test_copy_class_allows_institution_admin(
     )
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_delete_lti_class_accepts_harvard_lxp_lms_type(monkeypatch):
+    lti_class = SimpleNamespace(
+        id=55,
+        class_id=321,
+        lti_platform=schemas.LMSPlatform.HARVARD_LXP,
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        server_module.models.LTIClass,
+        "get_by_id",
+        classmethod(lambda cls, db, id_: _async_return(lti_class)),
+    )
+
+    async def _remove_lti_sync(
+        cls, session, lti_class_id, class_id, lms_type, keep_users
+    ):
+        captured["lti_class_id"] = lti_class_id
+        captured["class_id"] = class_id
+        captured["lms_type"] = lms_type
+        captured["keep_users"] = keep_users
+        return []
+
+    monkeypatch.setattr(
+        server_module.models.LTIClass,
+        "remove_lti_sync",
+        classmethod(_remove_lti_sync),
+    )
+    monkeypatch.setattr(
+        server_module.models.LTIClass,
+        "delete",
+        classmethod(lambda cls, db, id_: _async_return(None)),
+    )
+
+    request = SimpleNamespace(
+        state={
+            "db": object(),
+            "authz": object(),
+            "session": SimpleNamespace(user=SimpleNamespace(id=123)),
+        }
+    )
+
+    result = await server_module.delete_lti_class(
+        "321", "55", request=request, keep_users=True
+    )
+
+    assert result == {"status": "ok"}
+    assert captured["lti_class_id"] == 55
+    assert captured["class_id"] == 321
+    assert captured["lms_type"] == schemas.LMSType.HARVARD_LXP
+    assert captured["keep_users"] is True
 
 
 @with_user(123)

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -503,8 +503,20 @@ export type LTIPublicSSOProviders = {
 	providers: LTIPublicSSOProvider[];
 };
 
-export const getPublicExternalLoginProvidersForLTI = async (f: Fetcher) => {
-	return await GET<never, LTIPublicSSOProviders>(f, 'lti/public/sso/providers');
+export type LTIPublicSSOProvidersRequest = {
+	openid_configuration: string;
+	registration_token: string;
+};
+
+export const getPublicExternalLoginProvidersForLTI = async (
+	f: Fetcher,
+	data: LTIPublicSSOProvidersRequest
+) => {
+	return await POST<LTIPublicSSOProvidersRequest, LTIPublicSSOProviders>(
+		f,
+		'lti/public/sso/providers',
+		data
+	);
 };
 
 export const LTI_SSO_FIELDS = [

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -507,10 +507,7 @@ export type LTIRegisterSetup = {
 	show_course_navigation_control: boolean;
 };
 
-export const getLTIRegisterSetup = async (
-	f: Fetcher,
-	data: LTIRegisterSetupRequest
-) => {
+export const getLTIRegisterSetup = async (f: Fetcher, data: LTIRegisterSetupRequest) => {
 	return await POST<LTIRegisterSetupRequest, LTIRegisterSetup>(f, 'lti/register/setup', data);
 };
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -495,6 +495,9 @@ export type LTIPublicSSOProvider = {
 	display_name: string | null;
 };
 
+export const NO_SSO_PROVIDER_ID = 0;
+export const NO_SSO_PROVIDER_ID_VALUE = `${NO_SSO_PROVIDER_ID}`;
+
 export type LTIRegisterSetupRequest = {
 	openid_configuration: string;
 	registration_token: string;

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -414,10 +414,6 @@ export type LTIPublicInstitution = {
 	name: string;
 };
 
-export type LTIPublicInstitutions = {
-	institutions: LTIPublicInstitution[];
-};
-
 export type InstitutionAdmin = {
 	id: number;
 	email: string | null;
@@ -499,24 +495,23 @@ export type LTIPublicSSOProvider = {
 	display_name: string | null;
 };
 
-export type LTIPublicSSOProviders = {
-	providers: LTIPublicSSOProvider[];
-};
-
-export type LTIPublicSSOProvidersRequest = {
+export type LTIRegisterSetupRequest = {
 	openid_configuration: string;
 	registration_token: string;
 };
 
-export const getPublicExternalLoginProvidersForLTI = async (
+export type LTIRegisterSetup = {
+	platform: LMSPlatform;
+	providers: LTIPublicSSOProvider[];
+	institutions: LTIPublicInstitution[];
+	show_course_navigation_control: boolean;
+};
+
+export const getLTIRegisterSetup = async (
 	f: Fetcher,
-	data: LTIPublicSSOProvidersRequest
+	data: LTIRegisterSetupRequest
 ) => {
-	return await POST<LTIPublicSSOProvidersRequest, LTIPublicSSOProviders>(
-		f,
-		'lti/public/sso/providers',
-		data
-	);
+	return await POST<LTIRegisterSetupRequest, LTIRegisterSetup>(f, 'lti/register/setup', data);
 };
 
 export const LTI_SSO_FIELDS = [
@@ -819,10 +814,6 @@ export const getInstitutions = async (f: Fetcher, role?: string) => {
 		q.role = role;
 	}
 	return await GET<GetInstitutionsRequest, Institutions>(f, 'institutions', q);
-};
-
-export const getPublicInstitutionsForLTI = async (f: Fetcher) => {
-	return await GET<never, LTIPublicInstitutions>(f, 'lti/public/institutions');
 };
 
 /**
@@ -3990,7 +3981,7 @@ export const loginWithMagicLink = async (f: Fetcher, email: string, forward: str
 	return response;
 };
 
-export type LMSPlatform = 'canvas';
+export type LMSPlatform = 'canvas' | 'harvard_lxp';
 
 export type LTIStatus = 'pending' | 'linked' | 'error';
 

--- a/web/pingpong/src/routes/lti/register/+page.svelte
+++ b/web/pingpong/src/routes/lti/register/+page.svelte
@@ -8,6 +8,7 @@
 
 	export let data;
 	$: registrationSetup = data.registrationSetup;
+	$: registrationSetupError = data.registrationSetupError?.detail ?? null;
 	$: externalLoginProviders = registrationSetup?.providers ?? [];
 	$: institutions = registrationSetup?.institutions ?? [];
 	$: showCourseNavigationControl = registrationSetup?.show_course_navigation_control ?? false;
@@ -17,7 +18,7 @@
 	let missing_params = false;
 	let showModal = false;
 
-	let ssoProviderId = '0';
+	let ssoProviderId = api.NO_SSO_PROVIDER_ID_VALUE;
 	let institutionIds: number[] = [];
 	let showInCourseNavigation = true;
 
@@ -40,6 +41,11 @@
 		evt.preventDefault();
 		$loading = true;
 
+		if (!registrationSetup) {
+			$loading = false;
+			return sadToast(registrationSetupError || 'Unable to load registration setup');
+		}
+
 		const form = evt.target as HTMLFormElement;
 		const formData = new FormData(form);
 		const name = formData.get('name')?.toString();
@@ -48,7 +54,10 @@
 			return sadToast('Name is required');
 		}
 
-		const ssoId = formData.get('sso_id')?.toString();
+		const ssoId =
+			externalLoginProviders.length > 0
+				? (formData.get('sso_id')?.toString() ?? api.NO_SSO_PROVIDER_ID_VALUE)
+				: api.NO_SSO_PROVIDER_ID_VALUE;
 		if (!ssoId) {
 			$loading = false;
 			return sadToast('SSO identifier is required');
@@ -56,7 +65,7 @@
 		const providerId = parseInt(ssoId, 10);
 
 		let ssoField: api.LTISSOField | null = null;
-		if (providerId !== 0) {
+		if (providerId !== api.NO_SSO_PROVIDER_ID) {
 			const rawSsoField = formData.get('sso_field')?.toString()?.trim() ?? '';
 			if (!rawSsoField) {
 				$loading = false;
@@ -115,6 +124,11 @@
 <div class="flex w-full flex-col items-center gap-8 p-8">
 	<Heading tag="h2" class="serif">Set up your LTI instance with PingPong</Heading>
 	<form class="flex max-w-lg flex-col gap-4 sm:min-w-[32rem]" onsubmit={handleSubmit}>
+		{#if registrationSetupError}
+			<div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+				{registrationSetupError}
+			</div>
+		{/if}
 		<div>
 			<Label for="name" class="mb-1">Instance name</Label>
 			<Helper class="mb-2"
@@ -160,11 +174,11 @@
 						<option value={provider.id}>{provider.display_name || provider.name}</option>
 					{/each}
 					<option disabled>──────────</option>
-					<option value="0">No SSO</option>
+					<option value={api.NO_SSO_PROVIDER_ID_VALUE}>No SSO</option>
 				</Select>
 			</div>
 		{/if}
-		{#if externalLoginProviders.length > 0 && parseInt(ssoProviderId, 10) !== 0}
+		{#if externalLoginProviders.length > 0 && parseInt(ssoProviderId, 10) !== api.NO_SSO_PROVIDER_ID}
 			<div>
 				<Label for="sso_field" class="mb-1">SSO Field</Label>
 				<Helper class="mb-2"
@@ -221,7 +235,7 @@
 				pill
 				class="bg-orange text-white hover:bg-orange-dark"
 				type="submit"
-				disabled={$loading}>Submit</Button
+				disabled={$loading || !!registrationSetupError}>Submit</Button
 			>
 		</div>
 	</form>

--- a/web/pingpong/src/routes/lti/register/+page.svelte
+++ b/web/pingpong/src/routes/lti/register/+page.svelte
@@ -7,8 +7,10 @@
 	import { ExclamationCircleOutline } from 'flowbite-svelte-icons';
 
 	export let data;
-	$: externalLoginProviders = data.externalLoginProviders;
-	$: institutions = data.institutions || [];
+	$: registrationSetup = data.registrationSetup;
+	$: externalLoginProviders = registrationSetup?.providers ?? [];
+	$: institutions = registrationSetup?.institutions ?? [];
+	$: showCourseNavigationControl = registrationSetup?.show_course_navigation_control ?? false;
 
 	let openid_configuration: string | null = null;
 	let registration_token: string | null = null;
@@ -79,7 +81,8 @@
 			return sadToast('Administrator email is required');
 		}
 
-		const showInCourseNav = formData.get('show_in_course_navigation') === 'on';
+		const showInCourseNav =
+			showCourseNavigationControl && formData.get('show_in_course_navigation') === 'on';
 
 		if (!institutionIds.length) {
 			$loading = false;
@@ -130,33 +133,37 @@
 			<Label for="admin_email" class="mb-1">Administrator Email</Label>
 			<Input id="admin_email" name="admin_email" placeholder="john.doe@example.com" type="email" />
 		</div>
-		<div>
-			<Label for="show_in_course_navigation" class="mb-1">Show in Course Navigation</Label>
-			<Helper class="mb-2">By default, PingPong will be shown in the course navigation menu.</Helper
-			>
-			<Checkbox
-				id="show_in_course_navigation"
-				name="show_in_course_navigation"
-				color="blue"
-				bind:checked={showInCourseNavigation}>Show PingPong app in Course Navigation</Checkbox
-			>
-		</div>
-		<div>
-			<Label for="sso_id" class="mb-1">SSO Provider</Label>
-			<Helper class="mb-2"
-				>Choose the SSO identifier your LTI instance will provide to PingPong. If PingPong doesn’t
-				support your SSO identifier, select "No SSO." PingPong will use SSO identifiers and fall
-				back to email addresses to identify users.</Helper
-			>
-			<Select name="sso_id" id="sso_id" disabled={$loading} bind:value={ssoProviderId}>
-				{#each externalLoginProviders as provider (provider.id)}
-					<option value={provider.id}>{provider.display_name || provider.name}</option>
-				{/each}
-				<option disabled>──────────</option>
-				<option value="0">No SSO</option>
-			</Select>
-		</div>
-		{#if parseInt(ssoProviderId, 10) !== 0}
+		{#if showCourseNavigationControl}
+			<div>
+				<Label for="show_in_course_navigation" class="mb-1">Show in Course Navigation</Label>
+				<Helper class="mb-2">By default, PingPong will be shown in the course navigation menu.</Helper
+				>
+				<Checkbox
+					id="show_in_course_navigation"
+					name="show_in_course_navigation"
+					color="blue"
+					bind:checked={showInCourseNavigation}>Show PingPong app in Course Navigation</Checkbox
+				>
+			</div>
+		{/if}
+		{#if externalLoginProviders.length > 0}
+			<div>
+				<Label for="sso_id" class="mb-1">SSO Provider</Label>
+				<Helper class="mb-2"
+					>Choose the SSO identifier your LTI instance will provide to PingPong. If PingPong doesn’t
+					support your SSO identifier, select "No SSO." PingPong will use SSO identifiers and fall
+					back to email addresses to identify users.</Helper
+				>
+				<Select name="sso_id" id="sso_id" disabled={$loading} bind:value={ssoProviderId}>
+					{#each externalLoginProviders as provider (provider.id)}
+						<option value={provider.id}>{provider.display_name || provider.name}</option>
+					{/each}
+					<option disabled>──────────</option>
+					<option value="0">No SSO</option>
+				</Select>
+			</div>
+		{/if}
+		{#if externalLoginProviders.length > 0 && parseInt(ssoProviderId, 10) !== 0}
 			<div>
 				<Label for="sso_field" class="mb-1">SSO Field</Label>
 				<Helper class="mb-2"

--- a/web/pingpong/src/routes/lti/register/+page.svelte
+++ b/web/pingpong/src/routes/lti/register/+page.svelte
@@ -136,7 +136,8 @@
 		{#if showCourseNavigationControl}
 			<div>
 				<Label for="show_in_course_navigation" class="mb-1">Show in Course Navigation</Label>
-				<Helper class="mb-2">By default, PingPong will be shown in the course navigation menu.</Helper
+				<Helper class="mb-2"
+					>By default, PingPong will be shown in the course navigation menu.</Helper
 				>
 				<Checkbox
 					id="show_in_course_navigation"

--- a/web/pingpong/src/routes/lti/register/+page.ts
+++ b/web/pingpong/src/routes/lti/register/+page.ts
@@ -4,32 +4,20 @@ import * as api from '$lib/api';
 export const load: PageLoad = async ({ fetch, url }) => {
 	const openid_configuration = url.searchParams.get('openid_configuration');
 	const registration_token = url.searchParams.get('registration_token');
-	const providersPromise =
+	const registrationSetupResult =
 		openid_configuration && registration_token
-			? api
-					.getPublicExternalLoginProvidersForLTI(fetch, {
+			? await api
+					.getLTIRegisterSetup(fetch, {
 						openid_configuration,
 						registration_token
 					})
 					.then(api.expandResponse)
-			: Promise.resolve(null);
-
-	const [externalLoginProvidersResult, institutionsResult] = await Promise.all([
-		providersPromise,
-		api.getPublicInstitutionsForLTI(fetch).then(api.expandResponse)
-	]);
-
-	const externalLoginProviders: api.LTIPublicSSOProvider[] =
-		externalLoginProvidersResult && !externalLoginProvidersResult.error
-			? externalLoginProvidersResult.data.providers
-			: [];
-
-	const institutions: api.LTIPublicInstitution[] = institutionsResult.error
-		? []
-		: institutionsResult.data.institutions;
+			: null;
 
 	return {
-		externalLoginProviders,
-		institutions
+		registrationSetup:
+			registrationSetupResult && !registrationSetupResult.error
+				? registrationSetupResult.data
+				: null
 	};
 };

--- a/web/pingpong/src/routes/lti/register/+page.ts
+++ b/web/pingpong/src/routes/lti/register/+page.ts
@@ -1,15 +1,28 @@
 import type { PageLoad } from './$types';
 import * as api from '$lib/api';
 
-export const load: PageLoad = async ({ fetch }) => {
+export const load: PageLoad = async ({ fetch, url }) => {
+	const openid_configuration = url.searchParams.get('openid_configuration');
+	const registration_token = url.searchParams.get('registration_token');
+	const providersPromise =
+		openid_configuration && registration_token
+			? api
+					.getPublicExternalLoginProvidersForLTI(fetch, {
+						openid_configuration,
+						registration_token
+					})
+					.then(api.expandResponse)
+			: Promise.resolve(null);
+
 	const [externalLoginProvidersResult, institutionsResult] = await Promise.all([
-		api.getPublicExternalLoginProvidersForLTI(fetch).then(api.expandResponse),
+		providersPromise,
 		api.getPublicInstitutionsForLTI(fetch).then(api.expandResponse)
 	]);
 
-	const externalLoginProviders: api.LTIPublicSSOProvider[] = externalLoginProvidersResult.error
-		? []
-		: externalLoginProvidersResult.data.providers;
+	const externalLoginProviders: api.LTIPublicSSOProvider[] =
+		externalLoginProvidersResult && !externalLoginProvidersResult.error
+			? externalLoginProvidersResult.data.providers
+			: [];
 
 	const institutions: api.LTIPublicInstitution[] = institutionsResult.error
 		? []

--- a/web/pingpong/src/routes/lti/register/+page.ts
+++ b/web/pingpong/src/routes/lti/register/+page.ts
@@ -18,6 +18,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		registrationSetup:
 			registrationSetupResult && !registrationSetupResult.error
 				? registrationSetupResult.data
-				: null
+				: null,
+		registrationSetupError: registrationSetupResult?.error ?? null
 	};
 };


### PR DESCRIPTION
## Canvas Connect
### New Features
* This update introduces support for Canvas Connect LTI 1.3 features in Harvard's LXP platform.
### Updates & Improvements
* Consolidated registration data calls to a single setup information call under the `POST /lti/register/setup` endpoint.
* Registration page data calls now require `{ openid_configuration, registration_token }` so the server can determine the platform details before returning information the UI can use to populate the dynamic registration form.