### PR TITLE
fix(threads): use high-cardinality strategy for institutional admins

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -6289,11 +6289,21 @@ async def list_all_threads(
     #
     # For high cardinality users, it's much faster to pull all threads from the database
     # and filter out the relative few they can't see.
-    expect_high_cardinality = await request.state["authz"].test(
-        f"user:{request.state['session'].user.id}",
+    user_ref = f"user:{request.state['session'].user.id}"
+    is_root_admin_coro = request.state["authz"].test(
+        user_ref,
         "admin",
         request.state["authz"].root,
     )
+    institution_admins_coro = request.state["authz"].list(
+        user_ref,
+        "admin",
+        "institution",
+    )
+    is_root_admin, institution_admin_ids = await asyncio.gather(
+        is_root_admin_coro, institution_admins_coro
+    )
+    expect_high_cardinality = is_root_admin or bool(institution_admin_ids)
 
     if expect_high_cardinality:
         logger.info("Using high-cardinality strategy for all_threads query")
@@ -6304,7 +6314,7 @@ async def list_all_threads(
             allows = await request.state["authz"].check(
                 [
                     (
-                        f"user:{request.state['session'].user.id}",
+                        user_ref,
                         "can_view",
                         f"thread:{t.id}",
                     )
@@ -6324,7 +6334,7 @@ async def list_all_threads(
     else:
         logger.info("Using low-cardinality strategy for all_threads query")
         thread_ids = await request.state["authz"].list(
-            f"user:{request.state['session'].user.id}",
+            user_ref,
             "can_view",
             "thread",
         )
@@ -6346,7 +6356,7 @@ async def list_all_threads(
     is_supervisor_in_class_check = await request.state["authz"].check(
         [
             (
-                f"user:{request.state['session'].user.id}",
+                user_ref,
                 "supervisor",
                 f"class:{class_id}",
             )

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -192,6 +192,38 @@ async def test_delete_lti_class_accepts_harvard_lxp_lms_type(monkeypatch):
     assert captured["keep_users"] is True
 
 
+@pytest.mark.asyncio
+async def test_list_all_threads_uses_high_cardinality_strategy_for_institution_admin(
+    monkeypatch,
+):
+    authz = SimpleNamespace(
+        root="root:0",
+        test=AsyncMock(return_value=False),
+        list=AsyncMock(side_effect=[["11"]]),
+        check=AsyncMock(),
+    )
+    request = SimpleNamespace(
+        state={
+            "authz": authz,
+            "db": object(),
+            "session": SimpleNamespace(user=SimpleNamespace(id=123)),
+        }
+    )
+
+    get_n = AsyncMock(return_value=[])
+    get_n_by_id = AsyncMock(return_value=[])
+    monkeypatch.setattr(server_module.models.Thread, "get_n", get_n)
+    monkeypatch.setattr(server_module.models.Thread, "get_n_by_id", get_n_by_id)
+
+    response = await server_module.list_all_threads(request, limit=20)
+
+    assert response == {"threads": []}
+    authz.test.assert_awaited_once_with("user:123", "admin", "root:0")
+    authz.list.assert_awaited_once_with("user:123", "admin", "institution")
+    get_n.assert_awaited_once()
+    get_n_by_id.assert_not_awaited()
+
+
 @with_user(123)
 @with_institution(11, "Test Institution")
 @with_authz(grants=[("user:123", "can_create_class", "institution:99")])


### PR DESCRIPTION
## Thread Archive
### Resolved Issues
* Fixed: Institutional Admins with access to a large number of threads may not be able to view any threads in the Archive.

Resolves #1633.