### PR TITLE
feat(lv): do not inject time & date in the prompt

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -8001,9 +8001,13 @@ async def send_message(
                 reasoning_effort=asst.reasoning_effort,
                 temperature=asst.temperature,
                 tools_available=thread.tools_available,
-                instructions=inject_timestamp_to_instructions(
-                    thread.instructions,
-                    data.timezone if data.timezone else thread.timezone,
+                instructions=(
+                    thread.instructions
+                    if thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
+                    else inject_timestamp_to_instructions(
+                        thread.instructions,
+                        data.timezone if data.timezone else thread.timezone,
+                    )
                 ),
                 verbosity=asst.verbosity,
                 messages=run_messages,

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -837,6 +837,8 @@ async def test_send_message_creates_lecture_chat_run_with_hidden_context(
     ordered_messages = sorted(run.messages, key=lambda item: item.output_index)
     assert run.model == "gpt-4o-mini"
     assert run.tools_available == thread.tools_available
+    assert run.instructions == thread.instructions
+    assert "The current date and time is" not in run.instructions
     assert [message.role for message in ordered_messages] == [
         schemas.MessageRole.DEVELOPER,
         schemas.MessageRole.USER,


### PR DESCRIPTION
## Lecture Video
### New Features
* **Experimental:** In an effort to increase cache hits, the current time and date are no longer injected in the system prompt. This change only affects Lecture Video mode conversations at this time, but may expand to other modes in the future.