### PR TITLE
fix(lv): unstable state when changing playback quickly

### DIFF
--- a/web/pingpong/src/lib/api.test.ts
+++ b/web/pingpong/src/lib/api.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getThread, type Fetcher } from '$lib/api';
+import { resetAnonymousShareToken, setAnonymousShareToken } from '$lib/stores/anonymous';
+
+describe('getThread', () => {
+	afterEach(() => {
+		resetAnonymousShareToken();
+	});
+
+	it('sends the lecture video controller session header without dropping share tokens', async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({}), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		) as unknown as Fetcher;
+
+		setAnonymousShareToken('share-token');
+		const abortController = new AbortController();
+
+		await getThread(fetcher, 1, 2, 'controller-session', abortController.signal);
+
+		expect(fetcher).toHaveBeenCalledWith(
+			'/api/v1/class/1/thread/2',
+			expect.objectContaining({
+				method: 'GET',
+				headers: {
+					'X-Anonymous-Link-Share': 'share-token',
+					'X-Lecture-Video-Controller-Session': 'controller-session'
+				},
+				signal: abortController.signal
+			})
+		);
+	});
+});

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -200,7 +200,8 @@ const _fetch = async (
 	method: Method,
 	path: string,
 	headers?: Record<string, string>,
-	body?: string | FormData
+	body?: string | FormData,
+	signal?: AbortSignal
 ) => {
 	const full = fullPath(path);
 	const anonymousSessionToken = getAnonymousSessionToken();
@@ -225,7 +226,8 @@ const _fetch = async (
 		headers,
 		body,
 		credentials: 'include',
-		mode: 'cors'
+		mode: 'cors',
+		signal
 	});
 };
 
@@ -237,7 +239,8 @@ const _fetchJSON = async <R extends BaseData>(
 	method: Method,
 	path: string,
 	headers?: Record<string, string>,
-	body?: string | FormData
+	body?: string | FormData,
+	signal?: AbortSignal
 ): Promise<(R | Error | ValidationError) & BaseResponse> => {
 	const anonymousSessionToken = getAnonymousSessionToken();
 	if (anonymousSessionToken) {
@@ -247,7 +250,7 @@ const _fetchJSON = async <R extends BaseData>(
 			'X-Anonymous-Thread-Session': anonymousSessionToken
 		};
 	}
-	const res = await _fetch(f, method, path, headers, body);
+	const res = await _fetch(f, method, path, headers, body, signal);
 
 	let data: BaseData = {};
 
@@ -3409,12 +3412,15 @@ export type ThreadWithMeta = {
 
 /**
  * Get a thread by ID.
+ * Pass controllerSessionId from lecture-video playback control refreshes so the
+ * returned lecture_video_session reflects that this client still has control.
  */
 export const getThread = async (
 	f: Fetcher,
 	classId: number,
 	threadId: number,
-	controllerSessionId?: string
+	controllerSessionId?: string,
+	signal?: AbortSignal
 ) => {
 	const url = `class/${classId}/thread/${threadId}`;
 	const headers: Record<string, string> = {};
@@ -3429,7 +3435,9 @@ export const getThread = async (
 		f,
 		'GET',
 		url,
-		Object.keys(headers).length ? headers : undefined
+		Object.keys(headers).length ? headers : undefined,
+		undefined,
+		signal
 	);
 };
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -3410,9 +3410,27 @@ export type ThreadWithMeta = {
 /**
  * Get a thread by ID.
  */
-export const getThread = async (f: Fetcher, classId: number, threadId: number) => {
+export const getThread = async (
+	f: Fetcher,
+	classId: number,
+	threadId: number,
+	controllerSessionId?: string
+) => {
 	const url = `class/${classId}/thread/${threadId}`;
-	return await GET<never, ThreadWithMeta>(f, url);
+	const headers: Record<string, string> = {};
+	const anonymousShareToken = getAnonymousShareToken();
+	if (anonymousShareToken) {
+		headers['X-Anonymous-Link-Share'] = anonymousShareToken;
+	}
+	if (controllerSessionId) {
+		headers['X-Lecture-Video-Controller-Session'] = controllerSessionId;
+	}
+	return await _fetchJSON<ThreadWithMeta>(
+		f,
+		'GET',
+		url,
+		Object.keys(headers).length ? headers : undefined
+	);
 };
 
 export type CodeInterpreterMessages = {

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -116,6 +116,11 @@
 	let suppressPauseInteraction = false;
 	let suppressPlayInteraction = false;
 	let ignorePauseEventUntilMs = 0;
+	let playbackInteractionInFlight = false;
+	let queuedPlaybackInteraction: {
+		type: 'video_paused' | 'video_resumed';
+		offsetMs: number;
+	} | null = null;
 
 	// --- Lease renewal ---
 	let leaseInterval: ReturnType<typeof setInterval> | null = null;
@@ -393,6 +398,8 @@
 		suppressPauseInteraction = false;
 		suppressPlayInteraction = false;
 		ignorePauseEventUntilMs = 0;
+		playbackInteractionInFlight = false;
+		queuedPlaybackInteraction = null;
 		revokeNarrationResources();
 		clearPendingVideoRetry();
 		autoContinueInFlight = false;
@@ -444,6 +451,7 @@
 		resumeOffsetOnCanPlay = null;
 		stopNarrationPlayback();
 		autoContinueInFlight = false;
+		queuedPlaybackInteraction = null;
 
 		if (videoElement && !videoElement.paused) {
 			suppressPauseInteraction = true;
@@ -467,45 +475,102 @@
 		return true;
 	}
 
-	async function postPlaybackInteraction(type: 'video_paused' | 'video_resumed') {
-		const interactionControllerSessionId = controllerSessionId;
-		if (!interactionControllerSessionId || sessionState !== 'playing') {
-			return;
-		}
-
-		const expectedStateVersion = stateVersion;
-		const offsetMs = Math.round(currentTimeMs);
-
+	async function refreshLectureVideoSession(
+		controllerSessionIdForRequest: string
+	): Promise<boolean> {
 		try {
-			const response = await api.postLectureVideoInteraction(fetch, classId, threadId, {
-				type,
-				controller_session_id: interactionControllerSessionId,
-				expected_state_version: expectedStateVersion,
-				idempotency_key: crypto.randomUUID(),
-				offset_ms: offsetMs
-			});
-			if (controllerSessionId !== interactionControllerSessionId) {
-				return;
+			const response = await api.getThread(fetch, classId, threadId, controllerSessionIdForRequest);
+			if (controllerSessionId !== controllerSessionIdForRequest) {
+				return false;
 			}
 
 			const expanded = api.expandResponse(response);
-			if (failClosedOnConflict(`${type}-conflict`, expanded)) {
-				return;
-			}
 			if (expanded.error) {
-				failClosedControl(
-					expanded.error.detail ||
-						'Failed to sync lecture video playback. Please refresh to continue.'
-				);
-				return;
+				return false;
 			}
 
-			applySession(expanded.data.lecture_video_session);
-		} catch (error) {
-			if (controllerSessionId !== interactionControllerSessionId) {
-				return;
+			const refreshedSession = expanded.data.lecture_video_session;
+			if (!refreshedSession) {
+				return false;
 			}
-			failClosedControl(error instanceof Error ? error.message : String(error));
+
+			applySession(refreshedSession);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	function queuePlaybackInteraction(type: 'video_paused' | 'video_resumed') {
+		if (!controllerSessionId || sessionState !== 'playing') {
+			return;
+		}
+
+		queuedPlaybackInteraction = {
+			type,
+			offsetMs: Math.round(currentTimeMs)
+		};
+
+		if (!playbackInteractionInFlight) {
+			void drainPlaybackInteractionQueue();
+		}
+	}
+
+	async function drainPlaybackInteractionQueue() {
+		if (playbackInteractionInFlight) {
+			return;
+		}
+
+		playbackInteractionInFlight = true;
+		try {
+			while (queuedPlaybackInteraction) {
+				const interaction = queuedPlaybackInteraction;
+				queuedPlaybackInteraction = null;
+
+				const interactionControllerSessionId = controllerSessionId;
+				if (!interactionControllerSessionId || sessionState !== 'playing') {
+					return;
+				}
+
+				try {
+					const response = await api.postLectureVideoInteraction(fetch, classId, threadId, {
+						type: interaction.type,
+						controller_session_id: interactionControllerSessionId,
+						expected_state_version: stateVersion,
+						idempotency_key: crypto.randomUUID(),
+						offset_ms: interaction.offsetMs
+					});
+					if (controllerSessionId !== interactionControllerSessionId) {
+						return;
+					}
+
+					const expanded = api.expandResponse(response);
+					if (expanded.$status === 409) {
+						await refreshLectureVideoSession(interactionControllerSessionId);
+						continue;
+					}
+					if (expanded.error) {
+						failClosedControl(
+							expanded.error.detail ||
+								'Failed to sync lecture video playback. Please refresh to continue.'
+						);
+						return;
+					}
+
+					applySession(expanded.data.lecture_video_session);
+				} catch (error) {
+					if (controllerSessionId !== interactionControllerSessionId) {
+						return;
+					}
+					failClosedControl(error instanceof Error ? error.message : String(error));
+					return;
+				}
+			}
+		} finally {
+			playbackInteractionInFlight = false;
+			if (queuedPlaybackInteraction) {
+				void drainPlaybackInteractionQueue();
+			}
 		}
 	}
 
@@ -988,7 +1053,7 @@
 		}
 		if (playbackLocked) return;
 		if (!controllerSessionId || sessionState !== 'playing') return;
-		void postPlaybackInteraction('video_paused');
+		queuePlaybackInteraction('video_paused');
 	}
 
 	function handlePlay() {
@@ -1005,7 +1070,7 @@
 			return;
 		}
 		if (!controllerSessionId || sessionState !== 'playing') return;
-		void postPlaybackInteraction('video_resumed');
+		queuePlaybackInteraction('video_resumed');
 	}
 
 	async function handleSeek(toOffsetMs: number, fromOffsetMs: number) {

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -117,7 +117,10 @@
 	let suppressPlayInteraction = false;
 	let ignorePauseEventUntilMs = 0;
 	let playbackInteractionInFlight = false;
-	let queuedPlaybackInteraction: {
+	let playbackSessionRefreshController: AbortController | null = null;
+	// Playback pause/resume is latest-state telemetry, not a lossless event log.
+	// While a sync is in flight, keep only the newest desired browser playback state.
+	let latestPlaybackInteraction: {
 		type: 'video_paused' | 'video_resumed';
 		offsetMs: number;
 	} | null = null;
@@ -399,7 +402,9 @@
 		suppressPlayInteraction = false;
 		ignorePauseEventUntilMs = 0;
 		playbackInteractionInFlight = false;
-		queuedPlaybackInteraction = null;
+		playbackSessionRefreshController?.abort();
+		playbackSessionRefreshController = null;
+		latestPlaybackInteraction = null;
 		revokeNarrationResources();
 		clearPendingVideoRetry();
 		autoContinueInFlight = false;
@@ -451,7 +456,9 @@
 		resumeOffsetOnCanPlay = null;
 		stopNarrationPlayback();
 		autoContinueInFlight = false;
-		queuedPlaybackInteraction = null;
+		playbackSessionRefreshController?.abort();
+		playbackSessionRefreshController = null;
+		latestPlaybackInteraction = null;
 
 		if (videoElement && !videoElement.paused) {
 			suppressPauseInteraction = true;
@@ -478,9 +485,21 @@
 	async function refreshLectureVideoSession(
 		controllerSessionIdForRequest: string
 	): Promise<boolean> {
+		playbackSessionRefreshController?.abort();
+		const refreshController = new AbortController();
+		playbackSessionRefreshController = refreshController;
 		try {
-			const response = await api.getThread(fetch, classId, threadId, controllerSessionIdForRequest);
-			if (controllerSessionId !== controllerSessionIdForRequest) {
+			const response = await api.getThread(
+				fetch,
+				classId,
+				threadId,
+				controllerSessionIdForRequest,
+				refreshController.signal
+			);
+			if (
+				refreshController.signal.aborted ||
+				controllerSessionId !== controllerSessionIdForRequest
+			) {
 				return false;
 			}
 
@@ -496,8 +515,15 @@
 
 			applySession(refreshedSession);
 			return true;
-		} catch {
+		} catch (error) {
+			if (error instanceof DOMException && error.name === 'AbortError') {
+				return false;
+			}
 			return false;
+		} finally {
+			if (playbackSessionRefreshController === refreshController) {
+				playbackSessionRefreshController = null;
+			}
 		}
 	}
 
@@ -506,7 +532,7 @@
 			return;
 		}
 
-		queuedPlaybackInteraction = {
+		latestPlaybackInteraction = {
 			type,
 			offsetMs: Math.round(currentTimeMs)
 		};
@@ -523,12 +549,14 @@
 
 		playbackInteractionInFlight = true;
 		try {
-			while (queuedPlaybackInteraction) {
-				const interaction = queuedPlaybackInteraction;
-				queuedPlaybackInteraction = null;
+			while (latestPlaybackInteraction) {
+				const interaction = latestPlaybackInteraction;
+				latestPlaybackInteraction = null;
 
 				const interactionControllerSessionId = controllerSessionId;
 				if (!interactionControllerSessionId || sessionState !== 'playing') {
+					// Playback telemetry is only meaningful while video playback is active.
+					// If the session moved into a question/completion state, drop the stale desired state.
 					return;
 				}
 
@@ -546,7 +574,16 @@
 
 					const expanded = api.expandResponse(response);
 					if (expanded.$status === 409) {
-						await refreshLectureVideoSession(interactionControllerSessionId);
+						const refreshed = await refreshLectureVideoSession(interactionControllerSessionId);
+						if (!refreshed) {
+							if (controllerSessionId !== interactionControllerSessionId) {
+								return;
+							}
+							failClosedControl(
+								'Lecture video state changed and could not be refreshed. Please refresh to continue.'
+							);
+							return;
+						}
 						continue;
 					}
 					if (expanded.error) {
@@ -568,7 +605,9 @@
 			}
 		} finally {
 			playbackInteractionInFlight = false;
-			if (queuedPlaybackInteraction) {
+			if (latestPlaybackInteraction) {
+				// A new desired playback state may arrive while an earlier attempt exits early.
+				// Restart once after releasing the in-flight guard so that latest state is not stranded.
 				void drainPlaybackInteractionQueue();
 			}
 		}


### PR DESCRIPTION
## Lecture Video
### Updates & Improvements
* Playback interactions such as video paused or video started are serialized through a single in-flight slot.
* When a lecture video state conflict arises, the thread state manager will attempt to gracefully refresh the session and continue the experience.
### Resolved Issues
* Fixed: Trying to quickly change the playback state between playing and pausing may fail, with users seeing "Lecture video state is out of date. Refresh and try again."