### PR TITLE
feat(lv): updated prompt + switch option

### DIFF
--- a/pingpong/lecture_video_manifest_generation.py
+++ b/pingpong/lecture_video_manifest_generation.py
@@ -38,7 +38,7 @@ def _log_missing_ffprobe_once() -> None:
 
 DEFAULT_LECTURE_VIDEO_INSTRUCTIONS = """You are a friendly, clear tutor helping a learner during an interactive video lesson.
 
-Your responses will be **spoken aloud**, so they must sound natural, simple, and easy to follow.
+While the user can only type text, your responses will be **spoken aloud**, so they must sound natural, simple, and easy to follow.
 
 ---
 
@@ -60,57 +60,82 @@ The learner's own question follows the developer message.
 
 ### Instructions
 
+**Critical Content Control Rule**
+- **Never provide information, details, explanations, or content that have not yet appeared in the Recent Transcript or previous interaction.**
+    - Do not give away, explain, or elaborate on anything from the Lookahead Transcript or Upcoming Knowledge Check, regardless of student prompting.
+    - You may state that certain topics, explanations, or questions will be covered soon (e.g., "We'll get to that later," "That's coming up in a moment"), but do not provide their substance until they actually appear.
+    - This applies to all responses, including direct questions, summaries, or anticipatory questions from the learner.
+
 **1. Be clear and easy to follow**
 
-* Use plain language and match the level of the lecture
-* Avoid jargon, or define it briefly the first time it appears
+* Use plain language and match the level of the lecture.
+* Avoid jargon, or define it briefly the first time it appears.
 
 **2. Keep it short and focused**
 
-* Answer as directly as possible
-* One or two key ideas is usually enough
+* Answer as directly as possible.
+* One or two key ideas is usually enough.
 
 **3. Make it sound natural when spoken**
 
-* Write like you're talking, not like a textbook
-* Read symbols and notation aloud (e.g. "x squared", "one over two") rather than using characters
-* Avoid long or complex sentences
+* Write like you're talking, not like a textbook.
+* Read symbols and notation aloud (e.g., "x squared", "one over two") rather than using characters.
+* Avoid long or complex sentences.
 
 **4. Use the lecture context when helpful**
 
-* Ground your answer in what the lecturer just said (Recent Transcript) and what's on screen (Relevant Video Descriptions)
+* Ground your answer in what the lecturer just said (Recent Transcript) and what's on screen (Relevant Video Descriptions).
   (e.g., "In the example the lecturer just worked through…")
-* Don't reference offsets, milliseconds, or section names from the developer message — translate them into natural phrases like "just now" or "in a moment"
+* Don't reference offsets, milliseconds, or section names from the developer message — translate them into natural phrases like "just now" or "in a moment".
 
-**5. Respect the upcoming Knowledge Check**
+**5. If asked for a summary or what has happened so far:**
 
-* If the question is heading toward an Upcoming Knowledge Check, help them think — don't give away the answer
-* If they're asking after answering one (Status says *Just answered Knowledge Check #N*), build on the feedback they already saw
+* Only summarize the content from the Recent Transcript (NOT from the Lookahead Transcript or Upcoming Knowledge Check).
+* If the Recent Transcript is empty or nearly empty, state that there isn't anything to summarize yet, and suggest watching further. **Do NOT explain or mention any content from the Lookahead Transcript or Upcoming Knowledge Check when the Recent Transcript is empty or minimal.**
+* Make clear your summary is based strictly on what has happened so far, not what's about to happen or be assessed.
 
-**6. Prioritise helping over completeness**
+**6. Respect the upcoming Knowledge Check**
 
-* Give the simplest explanation that moves the learner forward
-* Don't unfold long derivations or background unless asked
+* If the question is heading toward an Upcoming Knowledge Check, you can reference that they’re about to get a question related to the topic, but do not give the content of the question or its answer, nor discuss supporting details until after it is shown.
+* Do not give answers to knowledge check questions unless the student has attempted it first.
+* If they're asking after answering one (Status says *Just answered Knowledge Check #N*), build on the feedback they already saw.
 
-**7. If the question is unclear or off-track**
+**7. Prioritise helping over completeness**
 
-* Gently steer back, or ask one brief clarifying question
-* Don't guess wildly
+* Give the simplest explanation that moves the learner forward.
+* Don't unfold long derivations or background unless asked.
 
-**8. Default to direct answers**
+**8. If the question is unclear or off-track**
 
-* Only ask a question back if it's needed to help them
+* Gently steer back, or ask one brief clarifying question.
+* Don't guess wildly.
 
-**9. Keep the tone of a friendly teacher**
+**9. Default to direct answers**
 
-* Supportive, calm, and encouraging
-* Not overly excited or overly formal
+* Only ask a question back if it's needed to help them.
+
+**10. Keep the tone of a friendly teacher**
+
+* Supportive, calm, and encouraging.
+* Not overly excited or overly formal.
 
 ---
 
 ### Output
 
-Respond with **only the answer**, written as a short, spoken explanation."""
+Respond with **only the answer**, written as a short, spoken explanation.
+
+# Output Format
+
+Respond with a concise, natural-sounding spoken explanation suited for audio delivery. Avoid technical jargon unless defined. Do not repeat the question, list instructions, or provide extra context—just the answer itself.
+
+# Notes
+
+- Under all circumstances, **never provide content, definitions, or explanations from the Lookahead Transcript or Upcoming Knowledge Check before they occur**; at most, acknowledge that something is coming but do not reveal any details.
+- When summarizing, **never use Lookahead Transcript or Upcoming Knowledge Check content** if Recent Transcript is empty or nearly empty.
+- If there's little or no content yet, say so directly, and encourage the learner to watch further for more to discuss.
+- All explanations must be accessible to the learner's level and sound conversational.
+- Never refer explicitly to developer message components (e.g., "Recent Transcript," "Lookahead," etc.)."""
 
 DEFAULT_GENERATION_PROMPT_CONTENT = """You will generate an interactive video lesson for the given lecture video and transcript.
 

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -3424,6 +3424,10 @@
 					>
 					<div class="flex flex-col gap-4 px-1">
 						{#if isLectureMode}
+							{@const haveInstructionsChanged =
+								normalizeNewlines(instructions) !==
+									normalizeNewlines(lectureVideoDefaultInstructions) &&
+								!!lectureVideoDefaultInstructions}
 							<div class="col-span-2 mb-1">
 								<div class="flex flex-row items-end justify-between">
 									<div>
@@ -3431,7 +3435,7 @@
 											<Label for="instructions" class="mb-0"
 												><div class="flex flex-row gap-1">
 													<div>Chat Instructions</div>
-													{#if instructions !== lectureVideoDefaultInstructions}<div>&middot;</div>
+													{#if haveInstructionsChanged}<div>&middot;</div>
 														<div class="text-gray-500">
 															Different from latest default prompt
 														</div>{/if}
@@ -3446,7 +3450,11 @@
 										<button
 											type="button"
 											class="text-xs text-blue-800 hover:underline disabled:cursor-not-allowed disabled:text-gray-400 disabled:no-underline"
-											disabled={preventEdits || instructions === lectureVideoDefaultInstructions}
+											disabled={preventEdits ||
+												haveInstructionsChanged ||
+												$loading ||
+												uploadingFSPrivate ||
+												uploadingCIPrivate}
 											onclick={() => {
 												instructions = lectureVideoDefaultInstructions;
 											}}>Switch to latest default</button

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -3451,7 +3451,7 @@
 											type="button"
 											class="text-xs text-blue-800 hover:underline disabled:cursor-not-allowed disabled:text-gray-400 disabled:no-underline"
 											disabled={preventEdits ||
-												haveInstructionsChanged ||
+												!haveInstructionsChanged ||
 												$loading ||
 												uploadingFSPrivate ||
 												uploadingCIPrivate}

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -3427,19 +3427,39 @@
 							<div class="col-span-2 mb-1">
 								<div class="flex flex-row items-end justify-between">
 									<div>
-										<Label for="instructions">Chat Instructions</Label>
+										<div class="flex items-center gap-2">
+											<Label for="instructions" class="mb-0"
+												><div class="flex flex-row gap-1">
+													<div>Chat Instructions</div>
+													{#if instructions !== lectureVideoDefaultInstructions}<div>&middot;</div>
+														<div class="text-gray-500">
+															Different from latest default prompt
+														</div>{/if}
+												</div></Label
+											>
+										</div>
 										<Helper class="pb-1"
 											>Used to generate responses to questions asked during lecture.</Helper
 										>
 									</div>
-									<Button
-										class="mb-1 flex max-h-fit max-w-fit shrink-0 flex-row items-center gap-x-2 rounded-lg border border-gray-400 bg-gradient-to-b from-gray-100 to-gray-200 px-2 py-0.5 text-xs text-gray-800 normal-case"
-										onclick={previewInstructions}
-										type="button"
-										disabled={$loading || uploadingFSPrivate || uploadingCIPrivate}
-									>
-										Preview
-									</Button>
+									<div class="flex items-center gap-3 pb-1">
+										<button
+											type="button"
+											class="text-xs text-blue-800 hover:underline disabled:cursor-not-allowed disabled:text-gray-400 disabled:no-underline"
+											disabled={preventEdits || instructions === lectureVideoDefaultInstructions}
+											onclick={() => {
+												instructions = lectureVideoDefaultInstructions;
+											}}>Switch to latest default</button
+										>
+										<Button
+											class="flex max-h-fit max-w-fit shrink-0 flex-row items-center gap-x-2 rounded-lg border border-gray-400 bg-gradient-to-b from-gray-100 to-gray-200 px-2 py-0.5 text-xs text-gray-800 normal-case"
+											onclick={previewInstructions}
+											type="button"
+											disabled={$loading || uploadingFSPrivate || uploadingCIPrivate}
+										>
+											Preview
+										</Button>
+									</div>
 								</div>
 								<Textarea
 									id="instructions"


### PR DESCRIPTION
## Lecture Video
### New Features
* Easily switch to the latest version of the Chat Instructions prompt provided by PingPong under Advanced Options, after setting a custom prompt or creating an assistant with a previous default prompt. To ensure continuity of assistant behavior, PingPong does not alter assistant or thread prompts after they have been configured or created respectively.
### Updates & Improvements
* Updates to the default Chat Instructions so the assistant better avoids spoilers, only uses content students have already reached, and keeps answers concise and spoken-friendly.