### PR TITLE
feat(lv): continue video playback after chat

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -167,6 +167,15 @@
 	let liveLectureVideoSession: api.LectureVideoSession | null = null;
 	let lectureVideoSessionKey: string | null = null;
 	let startingReplacementLectureThread = false;
+	let lectureChatResumeIntent:
+		| {
+				id: number;
+				waitForTts: boolean;
+				streamComplete: boolean;
+				sawTtsPlayback: boolean;
+		  }
+		| null = null;
+	let lectureChatResumeIntentId = 0;
 	$: {
 		const nextKey = `${classId}:${threadId}:${lectureVideoSession?.state_version ?? 'none'}:${
 			lectureVideoSession?.state ?? 'none'
@@ -250,6 +259,19 @@
 	$: ttsPlaying = threadMgr.ttsPlaying;
 	$: if (data.threadInteractionMode === 'lecture_video') {
 		threadMgr.setTtsVolume(lecturePlayerVolume);
+	}
+	$: {
+		if (lectureChatResumeIntent?.waitForTts && $ttsPlaying) {
+			lectureChatResumeIntent.sawTtsPlayback = true;
+		}
+		if (
+			lectureChatResumeIntent?.waitForTts &&
+			lectureChatResumeIntent.streamComplete &&
+			lectureChatResumeIntent.sawTtsPlayback &&
+			!$ttsPlaying
+		) {
+			void resumeLectureVideoAfterChat(lectureChatResumeIntent.id);
+		}
 	}
 	$: loading = threadMgr.loading;
 	$: canFetchMore = threadMgr.canFetchMore;
@@ -714,16 +736,48 @@
 	};
 
 	const handleLectureChatSubmit = async (message: ChatInputMessage) => {
-		void lectureVideoViewRef?.pauseForChatSubmit();
+		const shouldResumeAfterChat = (await lectureVideoViewRef?.pauseForChatSubmit()) === true;
+		const resumeIntent = shouldResumeAfterChat
+			? {
+					id: ++lectureChatResumeIntentId,
+					waitForTts: lectureVideoTtsAvailable && !$ttsMuted,
+					streamComplete: false,
+					sawTtsPlayback: false
+				}
+			: null;
+		lectureChatResumeIntent = resumeIntent;
+
 		await postMessage(message);
+
+		if (!resumeIntent || lectureChatResumeIntent?.id !== resumeIntent.id) {
+			return;
+		}
+
+		resumeIntent.streamComplete = true;
+		lectureChatResumeIntent = resumeIntent;
+		if (!resumeIntent.waitForTts || !resumeIntent.sawTtsPlayback) {
+			void resumeLectureVideoAfterChat(resumeIntent.id);
+		}
 	};
 
 	const handleLectureSessionChange = (e: CustomEvent<api.LectureVideoSession>) => {
 		liveLectureVideoSession = e.detail;
+		if (e.detail.state !== 'playing') {
+			lectureChatResumeIntent = null;
+		}
 	};
 
 	const handleLecturePlaybackResumed = () => {
+		lectureChatResumeIntent = null;
 		threadMgr.interruptTts().catch(() => {});
+	};
+
+	const resumeLectureVideoAfterChat = async (intentId: number) => {
+		if (lectureChatResumeIntent?.id !== intentId) {
+			return;
+		}
+		lectureChatResumeIntent = null;
+		await lectureVideoViewRef?.resumeAfterChatResponse();
 	};
 
 	// Handle file upload

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
 	export type LectureVideoViewHandle = {
-		pauseForChatSubmit: () => Promise<void>;
+		pauseForChatSubmit: () => Promise<boolean>;
+		resumeAfterChatResponse: () => Promise<boolean>;
 	};
 </script>
 
@@ -1180,18 +1181,31 @@
 
 	export async function pauseForChatSubmit() {
 		if (!canParticipate || playbackLocked || sessionState !== 'playing') {
-			return;
+			return false;
 		}
 
-		if (paused || videoElement?.paused) {
-			return;
+		if (!videoElement || paused || videoElement.paused) {
+			return false;
 		}
 
-		videoElement?.pause();
+		videoElement.pause();
 
-		if (!(await ensureControllerSession())) {
-			return;
+		await ensureControllerSession();
+
+		return true;
+	}
+
+	export async function resumeAfterChatResponse() {
+		if (!canParticipate || playbackLocked || sessionState !== 'playing' || isVideoAtEnd()) {
+			return false;
 		}
+
+		const reacquireControlPromise = controllerSessionId ? null : ensureControllerSession();
+		if (reacquireControlPromise && !(await reacquireControlPromise)) {
+			return false;
+		}
+
+		return await tryPlayVideo({ queueRetryOnFailure: true });
 	}
 
 	// =========================================================================


### PR DESCRIPTION
## Lecture Video (Preview)
### Updates & Improvements
* Lecture videos now automatically resume after users ask a chat question, once the assistant finishes responding by voice or text.
* When chat voice feedback is muted or unavailable, lecture videos now resume after the written assistant response is complete.
