### PR TITLE
fix(lv): overwrite manifest regeneration

### DIFF
--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -11254,23 +11254,26 @@ async def update_assistant(
                 current_lecture_video is not None
                 and current_lecture_video.id == lecture_video.id
             )
-            manual_manifest_takeover_only = (
-                overwrite_lecture_video_manifest
-                and overwrite_manifest_changed
-                and same_lecture_video
-                and not manifest_changed
-                and not needs_manifest_generation
-                and not regenerate_requested
-                and not voice_changed
+            lecture_video_selection_changed = (
+                current_lecture_video is None
+                or current_lecture_video.id != lecture_video.id
             )
-            should_touch_lecture_video = (
+            lecture_video_content_changed = (
                 manifest_changed
                 or needs_manifest_generation
                 or regenerate_requested
                 or voice_changed
-                or (overwrite_manifest_changed and not manual_manifest_takeover_only)
-                or (current_lecture_video is None)
-                or current_lecture_video.id != lecture_video.id
+            )
+            manual_manifest_takeover_only = (
+                overwrite_lecture_video_manifest
+                and overwrite_manifest_changed
+                and same_lecture_video
+                and not lecture_video_content_changed
+            )
+            should_touch_lecture_video = (
+                lecture_video_content_changed
+                or overwrite_manifest_changed
+                or lecture_video_selection_changed
             )
 
             if manual_manifest_takeover_only:
@@ -11280,9 +11283,17 @@ async def update_assistant(
                     schemas.LectureVideoProcessingCancelReason.MANUAL_MANIFEST_REPLACED,
                 )
                 lecture_video.manual_manifest = True
-                request.state["db"].add(lecture_video)
-
-            if should_touch_lecture_video:
+                if prompt_present:
+                    lecture_video.generation_prompt = lecture_video_generation_prompt
+                if video_description_duration_ms_present:
+                    if lecture_video_video_description_duration_ms is None:
+                        raise HTTPException(
+                            400, "Lecture video description duration is required."
+                        )
+                    lecture_video.video_description_duration_ms = (
+                        lecture_video_video_description_duration_ms
+                    )
+            elif should_touch_lecture_video:
                 if needs_manifest_generation and current_lecture_video is not None:
                     await lecture_video_processing.cancel_manifest_generation_processing_runs(
                         request.state["db"],

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -11254,15 +11254,33 @@ async def update_assistant(
                 current_lecture_video is not None
                 and current_lecture_video.id == lecture_video.id
             )
+            manual_manifest_takeover_only = (
+                overwrite_lecture_video_manifest
+                and overwrite_manifest_changed
+                and same_lecture_video
+                and not manifest_changed
+                and not needs_manifest_generation
+                and not regenerate_requested
+                and not voice_changed
+            )
             should_touch_lecture_video = (
                 manifest_changed
                 or needs_manifest_generation
                 or regenerate_requested
                 or voice_changed
-                or overwrite_manifest_changed
+                or (overwrite_manifest_changed and not manual_manifest_takeover_only)
                 or (current_lecture_video is None)
                 or current_lecture_video.id != lecture_video.id
             )
+
+            if manual_manifest_takeover_only:
+                await lecture_video_processing.cancel_manifest_generation_processing_runs(
+                    request.state["db"],
+                    lecture_video.id,
+                    schemas.LectureVideoProcessingCancelReason.MANUAL_MANIFEST_REPLACED,
+                )
+                lecture_video.manual_manifest = True
+                request.state["db"].add(lecture_video)
 
             if should_touch_lecture_video:
                 if needs_manifest_generation and current_lecture_video is not None:

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -8154,6 +8154,7 @@ async def test_update_assistant_generated_to_manual_same_manifest_does_not_renar
             "lecture_video_id": lecture_video.id,
             "lecture_video_manifest": manifest,
             "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+            "generation_prompt": "Use this prompt if generation is re-enabled.",
             "overwrite_manifest": True,
         },
         headers={"Authorization": f"Bearer {valid_user_token}"},
@@ -8165,6 +8166,11 @@ async def test_update_assistant_generated_to_manual_same_manifest_does_not_renar
     async with db.async_session() as session:
         refreshed_video = await models.LectureVideo.get_by_id_with_copy_context(
             session, lecture_video.id
+        )
+        generation_prompt = await session.scalar(
+            select(models.LectureVideo.generation_prompt).where(
+                models.LectureVideo.id == lecture_video.id
+            )
         )
         processing_run_count = await session.scalar(
             select(func.count()).select_from(models.LectureVideoProcessingRun)
@@ -8181,10 +8187,152 @@ async def test_update_assistant_generated_to_manual_same_manifest_does_not_renar
 
     assert refreshed_video is not None
     assert refreshed_video.manual_manifest is True
+    assert generation_prompt == "Use this prompt if generation is re-enabled."
     assert refreshed_video.questions[0].question_text == "Keep the existing audio?"
     assert processing_run_count == 0
     assert narration_statuses
     assert set(narration_statuses) == {schemas.LectureVideoNarrationStatus.READY}
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
+async def test_update_assistant_generated_to_manual_modified_manifest_renarrates(
+    api, db, institution, valid_user_token, monkeypatch
+):
+    patch_lecture_video_model_list(monkeypatch)
+    manifest = lecture_video_manifest(question_text="Original prompt?")
+
+    async with db.async_session() as session:
+        class_, lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            manifest=manifest,
+        )
+        assistant = await session.get(models.Assistant, 1)
+        assert assistant is not None
+        assistant.creator_id = 123
+        refreshed_video = await session.get(models.LectureVideo, lecture_video.id)
+        assert refreshed_video is not None
+        refreshed_video.manual_manifest = False
+        await create_lecture_video_copy_credentials(session, class_.id)
+        await session.commit()
+
+    update_response = api.put(
+        f"/api/v1/class/{class_.id}/assistant/1",
+        json={
+            "lecture_video_id": lecture_video.id,
+            "lecture_video_manifest": lecture_video_manifest(
+                question_text="Updated manual prompt?"
+            ),
+            "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+            "overwrite_manifest": True,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["lecture_video"]["id"] != lecture_video.id
+
+    async with db.async_session() as session:
+        assistant = await session.get(models.Assistant, 1)
+        assert assistant is not None
+        updated_video = await models.LectureVideo.get_by_id_with_copy_context(
+            session, assistant.lecture_video_id
+        )
+        processing_runs = list(
+            (
+                await session.scalars(
+                    select(models.LectureVideoProcessingRun).order_by(
+                        models.LectureVideoProcessingRun.id.asc()
+                    )
+                )
+            ).all()
+        )
+
+    assert updated_video is not None
+    assert updated_video.id != lecture_video.id
+    assert updated_video.manual_manifest is True
+    assert updated_video.questions[0].question_text == "Updated manual prompt?"
+    assert len(processing_runs) == 1
+    assert processing_runs[0].lecture_video_id_snapshot == updated_video.id
+    assert processing_runs[0].status == schemas.LectureVideoProcessingRunStatus.QUEUED
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
+async def test_update_assistant_generated_to_manual_different_voice_renarrates(
+    api, db, institution, valid_user_token, monkeypatch
+):
+    patch_lecture_video_model_list(monkeypatch)
+    manifest = lecture_video_manifest(question_text="Keep text, change voice?")
+
+    async with db.async_session() as session:
+        class_, lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            manifest=manifest,
+        )
+        assistant = await session.get(models.Assistant, 1)
+        assert assistant is not None
+        assistant.creator_id = 123
+        refreshed_video = await session.get(models.LectureVideo, lecture_video.id)
+        assert refreshed_video is not None
+        refreshed_video.manual_manifest = False
+        await create_lecture_video_copy_credentials(session, class_.id)
+        await session.commit()
+
+    update_response = api.put(
+        f"/api/v1/class/{class_.id}/assistant/1",
+        json={
+            "lecture_video_id": lecture_video.id,
+            "lecture_video_manifest": manifest,
+            "voice_id": "voice-updated",
+            "overwrite_manifest": True,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["lecture_video"]["id"] != lecture_video.id
+
+    async with db.async_session() as session:
+        assistant = await session.get(models.Assistant, 1)
+        assert assistant is not None
+        updated_video = await models.LectureVideo.get_by_id_with_copy_context(
+            session, assistant.lecture_video_id
+        )
+        processing_runs = list(
+            (
+                await session.scalars(
+                    select(models.LectureVideoProcessingRun).order_by(
+                        models.LectureVideoProcessingRun.id.asc()
+                    )
+                )
+            ).all()
+        )
+
+    assert updated_video is not None
+    assert updated_video.id != lecture_video.id
+    assert updated_video.manual_manifest is True
+    assert updated_video.voice_id == "voice-updated"
+    assert updated_video.questions[0].question_text == "Keep text, change voice?"
+    assert len(processing_runs) == 1
+    assert processing_runs[0].lecture_video_id_snapshot == updated_video.id
+    assert processing_runs[0].status == schemas.LectureVideoProcessingRunStatus.QUEUED
 
 
 @with_user(123)

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -8127,6 +8127,75 @@ async def test_update_assistant_with_same_lecture_video_config_is_a_no_op(
         ("user:123", "admin", "class:1"),
     ]
 )
+async def test_update_assistant_generated_to_manual_same_manifest_does_not_renarrate(
+    api, db, institution, valid_user_token, monkeypatch
+):
+    patch_lecture_video_model_list(monkeypatch)
+    manifest = lecture_video_manifest(question_text="Keep the existing audio?")
+
+    async with db.async_session() as session:
+        class_, lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            manifest=manifest,
+        )
+        assistant = await session.get(models.Assistant, 1)
+        assert assistant is not None
+        assistant.creator_id = 123
+        refreshed_video = await session.get(models.LectureVideo, lecture_video.id)
+        assert refreshed_video is not None
+        refreshed_video.manual_manifest = False
+        await create_lecture_video_copy_credentials(session, class_.id)
+        await session.commit()
+
+    update_response = api.put(
+        f"/api/v1/class/{class_.id}/assistant/1",
+        json={
+            "lecture_video_id": lecture_video.id,
+            "lecture_video_manifest": manifest,
+            "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+            "overwrite_manifest": True,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["lecture_video"]["id"] == lecture_video.id
+
+    async with db.async_session() as session:
+        refreshed_video = await models.LectureVideo.get_by_id_with_copy_context(
+            session, lecture_video.id
+        )
+        processing_run_count = await session.scalar(
+            select(func.count()).select_from(models.LectureVideoProcessingRun)
+        )
+        narration_statuses = list(
+            (
+                await session.scalars(
+                    select(models.LectureVideoNarration.status).order_by(
+                        models.LectureVideoNarration.id.asc()
+                    )
+                )
+            ).all()
+        )
+
+    assert refreshed_video is not None
+    assert refreshed_video.manual_manifest is True
+    assert refreshed_video.questions[0].question_text == "Keep the existing audio?"
+    assert processing_run_count == 0
+    assert narration_statuses
+    assert set(narration_statuses) == {schemas.LectureVideoNarrationStatus.READY}
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
 async def test_update_assistant_rejects_null_video_description_duration(
     api, db, institution, valid_user_token, monkeypatch
 ):

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -705,11 +705,7 @@
 			lastManifestRunFailed ||
 			!data.lectureVideoConfig?.lecture_video_manifest);
 	$: lectureVideoNarrationTriggeredByFormChanges =
-		isLectureMode &&
-		overwriteManifest &&
-		(lectureVideoManifestChanged ||
-			lectureVideoVoiceChanged ||
-			overwriteManifest !== originalOverwriteManifest);
+		isLectureMode && overwriteManifest && (lectureVideoManifestChanged || lectureVideoVoiceChanged);
 	$: lectureVideoRegenerationImpliedByFormChanges =
 		lectureVideoGenerationTriggeredByFormChanges || lectureVideoNarrationTriggeredByFormChanges;
 	$: canRegenerateLectureVideo = isLectureMode && !data.isCreating;


### PR DESCRIPTION
## Lecture Video (Preview)
### Resolved Issues
* Fixed: Audio may regenerate unnecessarily when switching a generated lecture video manifest to manual without making changes.