### PR TITLE
feat(lv): introducing manifest v4

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -625,14 +625,15 @@ async def build_response_input_item_list(
         if user_assistant_messages_only
         else None
     )
-    async for message in models.Thread.list_all_messages_gen(
-        session,
-        thread_id,
-        roles=message_roles,
-        include_current_run_developer_messages_for_run_id=(
-            current_run_id if user_assistant_messages_only else None
-        ),
-    ):
+    if user_assistant_messages_only and current_run_id is not None:
+        messages = models.Thread.list_user_assistant_messages_with_run_developer_gen(
+            session, thread_id, current_run_id
+        )
+    else:
+        messages = models.Thread.list_all_messages_gen(
+            session, thread_id, roles=message_roles
+        )
+    async for message in messages:
         phase = get_response_message_phase_value(message.phase)
         content_list: list[ResponseInputMessageContentListParam] = []
         for content in message.content:

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -602,7 +602,12 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
 
 
 async def build_response_input_item_list(
-    session: AsyncSession, thread_id: int, uses_reasoning: bool = False
+    session: AsyncSession,
+    thread_id: int,
+    uses_reasoning: bool = False,
+    *,
+    current_run_id: int | None = None,
+    filter_prior_hidden_messages: bool = False,
 ) -> list[ResponseInputItemParam]:
     """Build a list of ResponseInputItem from a thread run step."""
     response_input_items: list[ResponseInputItemParam] = []
@@ -616,6 +621,12 @@ async def build_response_input_item_list(
         return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
 
     async for message in models.Thread.list_all_messages_gen(session, thread_id):
+        if (
+            filter_prior_hidden_messages
+            and message.is_hidden
+            and message.run_id != current_run_id
+        ):
+            continue
         phase = get_response_message_phase_value(message.phase)
         content_list: list[ResponseInputMessageContentListParam] = []
         for content in message.content:
@@ -3512,6 +3523,7 @@ async def run_response(
     response_safety_identifier: str | None = None,
     tts_voice_id: str | None = None,
     tts_api_key: str | None = None,
+    filter_prior_hidden_messages: bool = False,
 ):
     is_canceled = False
     await config.authz.driver.init()
@@ -3558,6 +3570,8 @@ async def run_response(
                     session_,
                     thread_id=run.thread_id,
                     uses_reasoning=not isinstance(reasoning_settings, openai.NotGiven),
+                    current_run_id=run.id,
+                    filter_prior_hidden_messages=filter_prior_hidden_messages,
                 )
                 max_output_index = await models.Thread.get_max_output_sequence(
                     session_, run.thread_id

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -607,7 +607,7 @@ async def build_response_input_item_list(
     uses_reasoning: bool = False,
     *,
     current_run_id: int | None = None,
-    filter_prior_hidden_messages: bool = False,
+    user_assistant_messages_only: bool = False,
 ) -> list[ResponseInputItemParam]:
     """Build a list of ResponseInputItem from a thread run step."""
     response_input_items: list[ResponseInputItemParam] = []
@@ -620,13 +620,19 @@ async def build_response_input_item_list(
     def coerce_utc(value: datetime) -> datetime:
         return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
 
-    async for message in models.Thread.list_all_messages_gen(session, thread_id):
-        if (
-            filter_prior_hidden_messages
-            and message.is_hidden
-            and message.run_id != current_run_id
-        ):
-            continue
+    message_roles = (
+        [MessageRole.USER, MessageRole.ASSISTANT]
+        if user_assistant_messages_only
+        else None
+    )
+    async for message in models.Thread.list_all_messages_gen(
+        session,
+        thread_id,
+        roles=message_roles,
+        include_current_run_developer_messages_for_run_id=(
+            current_run_id if user_assistant_messages_only else None
+        ),
+    ):
         phase = get_response_message_phase_value(message.phase)
         content_list: list[ResponseInputMessageContentListParam] = []
         for content in message.content:
@@ -737,242 +743,245 @@ async def build_response_input_item_list(
             )
         )
 
-    async for tool_call in models.Thread.list_all_tool_calls_gen(session, thread_id):
-        if tool_call.status == ToolCallStatus.INCOMPLETE:
-            continue
-        match tool_call.type:
-            case ToolCallType.CODE_INTERPRETER:
-                tool_call_outputs: list[Output] = []
-                for output in tool_call.outputs:
-                    match output.output_type:
-                        case CodeInterpreterOutputType.LOGS:
-                            tool_call_outputs.append(
-                                OutputLogs(logs=output.logs, type="logs")
-                            )
-                        case CodeInterpreterOutputType.IMAGE:
-                            tool_call_outputs.append(
-                                OutputImage(url=output.url, type="image")
-                            )
-                response_input_items_with_time.append(
-                    (
-                        tool_call.created,
-                        tool_call.output_index,
-                        "code_interpreter_call",
-                        ResponseCodeInterpreterToolCallParam(
-                            id=tool_call.tool_call_id,
-                            code=tool_call.code,
-                            container_id=tool_call.container_id,
-                            outputs=tool_call_outputs,
-                            status=ToolCallStatus(tool_call.status).value,
-                            type="code_interpreter_call",
-                        ),
-                    )
-                )
-
-                existing_time = container_by_last_active_time.get(
-                    tool_call.container_id
-                )
-                candidates: list[datetime] = []
-                if existing_time is not None:
-                    candidates.append(coerce_utc(existing_time))
-                if tool_call.created is not None:
-                    candidates.append(coerce_utc(tool_call.created))
-                if getattr(tool_call, "completed", None) is not None:
-                    candidates.append(coerce_utc(tool_call.completed))
-                if candidates:
-                    container_by_last_active_time[tool_call.container_id] = max(
-                        candidates
-                    )
-
-            case ToolCallType.FILE_SEARCH:
-                file_search_results: list[Result] = []
-                for result in tool_call.results:
-                    file_search_results.append(
-                        Result(
-                            attributes=json.loads(result.attributes)
-                            if result.attributes
-                            else {},
-                            file_id=result.file_id,
-                            filename=result.filename,
-                            score=result.score,
-                            text=result.text,
+    if not user_assistant_messages_only:
+        async for tool_call in models.Thread.list_all_tool_calls_gen(
+            session, thread_id
+        ):
+            if tool_call.status == ToolCallStatus.INCOMPLETE:
+                continue
+            match tool_call.type:
+                case ToolCallType.CODE_INTERPRETER:
+                    tool_call_outputs: list[Output] = []
+                    for output in tool_call.outputs:
+                        match output.output_type:
+                            case CodeInterpreterOutputType.LOGS:
+                                tool_call_outputs.append(
+                                    OutputLogs(logs=output.logs, type="logs")
+                                )
+                            case CodeInterpreterOutputType.IMAGE:
+                                tool_call_outputs.append(
+                                    OutputImage(url=output.url, type="image")
+                                )
+                    response_input_items_with_time.append(
+                        (
+                            tool_call.created,
+                            tool_call.output_index,
+                            "code_interpreter_call",
+                            ResponseCodeInterpreterToolCallParam(
+                                id=tool_call.tool_call_id,
+                                code=tool_call.code,
+                                container_id=tool_call.container_id,
+                                outputs=tool_call_outputs,
+                                status=ToolCallStatus(tool_call.status).value,
+                                type="code_interpreter_call",
+                            ),
                         )
                     )
-                response_input_items_with_time.append(
-                    (
-                        tool_call.created,
-                        tool_call.output_index,
-                        "file_search_call",
-                        ResponseFileSearchToolCallParam(
-                            id=tool_call.tool_call_id,
-                            queries=json.loads(tool_call.queries)
-                            if tool_call.queries
-                            else [],
-                            status=ToolCallStatus(tool_call.status).value,
-                            results=file_search_results,
-                            type="file_search_call",
-                        ),
+
+                    existing_time = container_by_last_active_time.get(
+                        tool_call.container_id
                     )
-                )
+                    candidates: list[datetime] = []
+                    if existing_time is not None:
+                        candidates.append(coerce_utc(existing_time))
+                    if tool_call.created is not None:
+                        candidates.append(coerce_utc(tool_call.created))
+                    if getattr(tool_call, "completed", None) is not None:
+                        candidates.append(coerce_utc(tool_call.completed))
+                    if candidates:
+                        container_by_last_active_time[tool_call.container_id] = max(
+                            candidates
+                        )
 
-            case ToolCallType.WEB_SEARCH:
-                action_rec = (
-                    tool_call.web_search_actions[0]
-                    if tool_call.web_search_actions
-                    else None
-                )
-
-                action = None
-                if action_rec:
-                    match action_rec.type:
-                        case WebSearchActionType.SEARCH:
-                            action = ActionSearch(
-                                type="search",
-                                query=action_rec.query or "",
+                case ToolCallType.FILE_SEARCH:
+                    file_search_results: list[Result] = []
+                    for result in tool_call.results:
+                        file_search_results.append(
+                            Result(
+                                attributes=json.loads(result.attributes)
+                                if result.attributes
+                                else {},
+                                file_id=result.file_id,
+                                filename=result.filename,
+                                score=result.score,
+                                text=result.text,
                             )
-                        case WebSearchActionType.OPEN_PAGE:
-                            action = ActionOpenPage(
-                                type="open_page",
-                                url=action_rec.url or "",
-                            )
-                        case WebSearchActionType.FIND:
-                            action = ActionFind(
-                                type="find",
-                                pattern=action_rec.pattern or "",
-                                url=action_rec.url or "",
-                            )
-                        case _:
-                            action = None
-
-                response_input_items_with_time.append(
-                    (
-                        tool_call.created,
-                        tool_call.output_index,
-                        "web_search_call",
-                        ResponseFunctionWebSearchParam(
-                            id=tool_call.tool_call_id,
-                            action=action,
-                            status=ToolCallStatus(tool_call.status).value,
-                            type="web_search_call",
-                        ),
-                    )
-                )
-
-            case ToolCallType.MCP_SERVER:
-                server_label = tool_call.mcp_server_label or (
-                    tool_call.mcp_server_tool.server_label
-                    if tool_call.mcp_server_tool
-                    else None
-                )
-                if not server_label:
-                    logger.warning(
-                        "Skipping MCP tool call %s due to missing server label.",
-                        tool_call.tool_call_id,
-                    )
-                    continue
-                try:
-                    error = json.loads(tool_call.error) if tool_call.error else None
-                except json.JSONDecodeError:
-                    error = {"message": tool_call.error}
-                response_input_items_with_time.append(
-                    (
-                        tool_call.created,
-                        tool_call.output_index,
-                        "mcp_call",
-                        McpCallParam(
-                            id=tool_call.tool_call_id,
-                            arguments=tool_call.mcp_arguments,
-                            name=tool_call.mcp_tool_name,
-                            server_label=server_label,
-                            type="mcp_call",
-                            approval_request_id=None,
-                            error=error,
-                            output=tool_call.mcp_output,
-                            status=ToolCallStatus(tool_call.status).value,
-                        ),
-                    )
-                )
-            case ToolCallType.MCP_LIST_TOOLS:
-                server_label = tool_call.mcp_server_label or (
-                    tool_call.mcp_server_tool.server_label
-                    if tool_call.mcp_server_tool
-                    else None
-                )
-                if not server_label:
-                    logger.warning(
-                        "Skipping MCP list tools call %s due to missing server label.",
-                        tool_call.tool_call_id,
-                    )
-                    continue
-                mcp_tools: list[McpListToolsToolParam] = []
-                for tool in tool_call.mcp_tools_listed:
-                    mcp_tools.append(
-                        McpListToolsToolParam(
-                            input_schema=json.loads(tool.input_schema)
-                            if tool.input_schema
-                            else {},
-                            name=tool.name,
-                            description=tool.description,
-                            annotations=json.loads(tool.annotations)
-                            if tool.annotations
-                            else {},
+                        )
+                    response_input_items_with_time.append(
+                        (
+                            tool_call.created,
+                            tool_call.output_index,
+                            "file_search_call",
+                            ResponseFileSearchToolCallParam(
+                                id=tool_call.tool_call_id,
+                                queries=json.loads(tool_call.queries)
+                                if tool_call.queries
+                                else [],
+                                status=ToolCallStatus(tool_call.status).value,
+                                results=file_search_results,
+                                type="file_search_call",
+                            ),
                         )
                     )
-                try:
-                    error = json.loads(tool_call.error) if tool_call.error else None
-                except json.JSONDecodeError:
-                    error = {"message": tool_call.error}
 
-                response_input_items_with_time.append(
-                    (
-                        tool_call.created,
-                        tool_call.output_index,
-                        "mcp_list_tools",
-                        McpListToolsParam(
-                            id=tool_call.tool_call_id,
-                            server_label=server_label,
-                            tools=mcp_tools,
-                            type="mcp_list_tools",
-                            error=error,
-                        ),
+                case ToolCallType.WEB_SEARCH:
+                    action_rec = (
+                        tool_call.web_search_actions[0]
+                        if tool_call.web_search_actions
+                        else None
+                    )
+
+                    action = None
+                    if action_rec:
+                        match action_rec.type:
+                            case WebSearchActionType.SEARCH:
+                                action = ActionSearch(
+                                    type="search",
+                                    query=action_rec.query or "",
+                                )
+                            case WebSearchActionType.OPEN_PAGE:
+                                action = ActionOpenPage(
+                                    type="open_page",
+                                    url=action_rec.url or "",
+                                )
+                            case WebSearchActionType.FIND:
+                                action = ActionFind(
+                                    type="find",
+                                    pattern=action_rec.pattern or "",
+                                    url=action_rec.url or "",
+                                )
+                            case _:
+                                action = None
+
+                    response_input_items_with_time.append(
+                        (
+                            tool_call.created,
+                            tool_call.output_index,
+                            "web_search_call",
+                            ResponseFunctionWebSearchParam(
+                                id=tool_call.tool_call_id,
+                                action=action,
+                                status=ToolCallStatus(tool_call.status).value,
+                                type="web_search_call",
+                            ),
+                        )
+                    )
+
+                case ToolCallType.MCP_SERVER:
+                    server_label = tool_call.mcp_server_label or (
+                        tool_call.mcp_server_tool.server_label
+                        if tool_call.mcp_server_tool
+                        else None
+                    )
+                    if not server_label:
+                        logger.warning(
+                            "Skipping MCP tool call %s due to missing server label.",
+                            tool_call.tool_call_id,
+                        )
+                        continue
+                    try:
+                        error = json.loads(tool_call.error) if tool_call.error else None
+                    except json.JSONDecodeError:
+                        error = {"message": tool_call.error}
+                    response_input_items_with_time.append(
+                        (
+                            tool_call.created,
+                            tool_call.output_index,
+                            "mcp_call",
+                            McpCallParam(
+                                id=tool_call.tool_call_id,
+                                arguments=tool_call.mcp_arguments,
+                                name=tool_call.mcp_tool_name,
+                                server_label=server_label,
+                                type="mcp_call",
+                                approval_request_id=None,
+                                error=error,
+                                output=tool_call.mcp_output,
+                                status=ToolCallStatus(tool_call.status).value,
+                            ),
+                        )
+                    )
+                case ToolCallType.MCP_LIST_TOOLS:
+                    server_label = tool_call.mcp_server_label or (
+                        tool_call.mcp_server_tool.server_label
+                        if tool_call.mcp_server_tool
+                        else None
+                    )
+                    if not server_label:
+                        logger.warning(
+                            "Skipping MCP list tools call %s due to missing server label.",
+                            tool_call.tool_call_id,
+                        )
+                        continue
+                    mcp_tools: list[McpListToolsToolParam] = []
+                    for tool in tool_call.mcp_tools_listed:
+                        mcp_tools.append(
+                            McpListToolsToolParam(
+                                input_schema=json.loads(tool.input_schema)
+                                if tool.input_schema
+                                else {},
+                                name=tool.name,
+                                description=tool.description,
+                                annotations=json.loads(tool.annotations)
+                                if tool.annotations
+                                else {},
+                            )
+                        )
+                    try:
+                        error = json.loads(tool_call.error) if tool_call.error else None
+                    except json.JSONDecodeError:
+                        error = {"message": tool_call.error}
+
+                    response_input_items_with_time.append(
+                        (
+                            tool_call.created,
+                            tool_call.output_index,
+                            "mcp_list_tools",
+                            McpListToolsParam(
+                                id=tool_call.tool_call_id,
+                                server_label=server_label,
+                                tools=mcp_tools,
+                                type="mcp_list_tools",
+                                error=error,
+                            ),
+                        )
+                    )
+
+        async for reasoning in models.Thread.list_all_reasoning_steps_gen(
+            session, thread_id
+        ):
+            summary_array: list[Summary] = []
+            for summary_step in reasoning.summary_parts:
+                summary_array.append(
+                    Summary(
+                        text=summary_step.summary_text,
+                        type="summary_text",
                     )
                 )
 
-    async for reasoning in models.Thread.list_all_reasoning_steps_gen(
-        session, thread_id
-    ):
-        summary_array: list[Summary] = []
-        for summary_step in reasoning.summary_parts:
-            summary_array.append(
-                Summary(
-                    text=summary_step.summary_text,
-                    type="summary_text",
+            content_array: list[Content] = []
+            for content_step in reasoning.content_parts:
+                content_array.append(
+                    Content(
+                        text=content_step.content_text,
+                        type="reasoning_text",
+                    )
+                )
+
+            response_input_items_with_time.append(
+                (
+                    reasoning.created,
+                    reasoning.output_index,
+                    "reasoning",
+                    ResponseReasoningItemParam(
+                        id=reasoning.reasoning_id,
+                        content=content_array if content_array else None,
+                        summary=summary_array if summary_array else [],
+                        encrypted_content=reasoning.encrypted_content,
+                        type="reasoning",
+                    ),
                 )
             )
-
-        content_array: list[Content] = []
-        for content_step in reasoning.content_parts:
-            content_array.append(
-                Content(
-                    text=content_step.content_text,
-                    type="reasoning_text",
-                )
-            )
-
-        response_input_items_with_time.append(
-            (
-                reasoning.created,
-                reasoning.output_index,
-                "reasoning",
-                ResponseReasoningItemParam(
-                    id=reasoning.reasoning_id,
-                    content=content_array if content_array else None,
-                    summary=summary_array if summary_array else [],
-                    encrypted_content=reasoning.encrypted_content,
-                    type="reasoning",
-                ),
-            )
-        )
     # Sort by output index, falling back to created time for ties.
     response_input_items_with_time.sort(key=lambda x: (x[1], x[0]))
 
@@ -3523,7 +3532,7 @@ async def run_response(
     response_safety_identifier: str | None = None,
     tts_voice_id: str | None = None,
     tts_api_key: str | None = None,
-    filter_prior_hidden_messages: bool = False,
+    user_assistant_messages_only: bool = False,
 ):
     is_canceled = False
     await config.authz.driver.init()
@@ -3571,7 +3580,7 @@ async def run_response(
                     thread_id=run.thread_id,
                     uses_reasoning=not isinstance(reasoning_settings, openai.NotGiven),
                     current_run_id=run.id,
-                    filter_prior_hidden_messages=filter_prior_hidden_messages,
+                    user_assistant_messages_only=user_assistant_messages_only,
                 )
                 max_output_index = await models.Thread.get_max_output_sequence(
                     session_, run.thread_id

--- a/pingpong/lecture_video_chat.py
+++ b/pingpong/lecture_video_chat.py
@@ -39,14 +39,14 @@ class LectureChatContextBuildResult:
     text_message_parts: list[models.MessagePart]
     frame_message_parts: list[models.MessagePart]
     current_offset_ms: int
-    filter_prior_hidden_messages: bool = False
+    user_assistant_messages_only: bool = False
 
 
 @dataclass
 class LectureChatTurnPreparation:
     prepended_messages: list[models.Message]
     user_output_index: int
-    filter_prior_hidden_messages: bool = False
+    user_assistant_messages_only: bool = False
 
 
 def _apply_lecture_video_chat_metadata(thread: models.Thread) -> None:
@@ -543,7 +543,7 @@ def _build_context_text_v4_from_parts(
     answered_knowledge_checks: str | None,
 ) -> tuple[str, int]:
     playback_position_ms = max(0, lecture_video_playback_position_ms)
-    furthest_offset_ms = max(state.furthest_offset_ms, 0)
+    furthest_offset_ms = max(state.furthest_offset_ms, playback_position_ms, 0)
     summary_checkpoint = _select_summary_checkpoint(
         summary_checkpoints,
         furthest_offset_ms,
@@ -594,19 +594,12 @@ def _build_context_text_v4_from_parts(
 async def _validate_v4_playback_position(
     session: AsyncSession,
     state: models.LectureVideoThreadState,
-    lecture_video_playback_position_ms: Any | None,
+    lecture_video_playback_position_ms: int | None,
 ) -> int:
     if lecture_video_playback_position_ms is None:
         raise HTTPException(
             status_code=400,
             detail="lecture_video_playback_position_ms is required for this lecture video.",
-        )
-    if not isinstance(lecture_video_playback_position_ms, int) or isinstance(
-        lecture_video_playback_position_ms, bool
-    ):
-        raise HTTPException(
-            status_code=400,
-            detail="lecture_video_playback_position_ms must be an integer.",
         )
     if lecture_video_playback_position_ms < 0:
         raise HTTPException(
@@ -807,7 +800,7 @@ async def build_lecture_chat_context_message_parts(
     anonymous_user_auth: str | None,
     anonymous_session_id: int | None,
     anonymous_link_id: int | None,
-    lecture_video_playback_position_ms: Any | None = None,
+    lecture_video_playback_position_ms: int | None = None,
 ) -> LectureChatContextBuildResult:
     lecture_video = thread.lecture_video
     state = thread.lecture_video_state
@@ -856,8 +849,8 @@ async def build_lecture_chat_context_message_parts(
         context_text, current_offset_ms = _build_context_text_v4_from_parts(
             thread,
             state,
-            summary_checkpoints=chat_context.summary_checkpoints or [],
-            moment_contexts=chat_context.moment_contexts or [],
+            summary_checkpoints=chat_context.summary_checkpoints,
+            moment_contexts=chat_context.moment_contexts,
             lecture_video_playback_position_ms=playback_position_ms,
             answered_knowledge_checks=answered_knowledge_checks,
         )
@@ -870,7 +863,7 @@ async def build_lecture_chat_context_message_parts(
             text_message_parts=[text_part],
             frame_message_parts=[],
             current_offset_ms=current_offset_ms,
-            filter_prior_hidden_messages=True,
+            user_assistant_messages_only=True,
         )
 
     answered_knowledge_checks = await _build_answered_knowledge_checks_markdown(
@@ -917,7 +910,7 @@ async def prepare_lecture_chat_turn(
     thread: models.Thread,
     user_id: int,
     prev_output_sequence: int,
-    lecture_video_playback_position_ms: Any | None = None,
+    lecture_video_playback_position_ms: int | None = None,
 ) -> LectureChatTurnPreparation:
     lecture_thread = await models.Thread.get_by_id_for_class_with_lecture_video_context(
         request.state["db"], int(class_id), thread.id
@@ -990,5 +983,5 @@ async def prepare_lecture_chat_turn(
     return LectureChatTurnPreparation(
         prepended_messages=prepended_messages,
         user_output_index=next_output_index,
-        filter_prior_hidden_messages=context_result.filter_prior_hidden_messages,
+        user_assistant_messages_only=context_result.user_assistant_messages_only,
     )

--- a/pingpong/lecture_video_chat.py
+++ b/pingpong/lecture_video_chat.py
@@ -606,7 +606,7 @@ async def _validate_v4_playback_position(
             status_code=400,
             detail="lecture_video_playback_position_ms must be greater than or equal to 0.",
         )
-    plausible_offset_ms = await lecture_video_runtime._get_plausible_playback_offset_ms(
+    plausible_offset_ms = await lecture_video_runtime.get_plausible_playback_offset_ms(
         session,
         state,
         current_time=datetime.now(timezone.utc),

--- a/pingpong/lecture_video_chat.py
+++ b/pingpong/lecture_video_chat.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import logging
 import tempfile
 from pathlib import Path
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import pingpong.models as models
 import pingpong.schemas as schemas
+from pingpong import lecture_video_runtime
 from pingpong.config import config
 from pingpong.files import handle_create_file
 from pingpong.lecture_video_service import (
@@ -37,12 +39,14 @@ class LectureChatContextBuildResult:
     text_message_parts: list[models.MessagePart]
     frame_message_parts: list[models.MessagePart]
     current_offset_ms: int
+    filter_prior_hidden_messages: bool = False
 
 
 @dataclass
 class LectureChatTurnPreparation:
     prepended_messages: list[models.Message]
     user_output_index: int
+    filter_prior_hidden_messages: bool = False
 
 
 def _apply_lecture_video_chat_metadata(thread: models.Thread) -> None:
@@ -490,6 +494,138 @@ def _build_context_text_v3_from_parts(
     )
 
 
+def _select_summary_checkpoint(
+    checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    furthest_offset_ms: int,
+) -> schemas.LectureVideoManifestSummaryCheckpointV4 | None:
+    selected = None
+    for checkpoint in checkpoints:
+        if checkpoint.end_offset_ms <= furthest_offset_ms:
+            selected = checkpoint
+        else:
+            break
+    return selected
+
+
+def _select_moment_context(
+    moments: list[schemas.LectureVideoManifestMomentContextV4],
+    playback_position_ms: int,
+) -> schemas.LectureVideoManifestMomentContextV4 | None:
+    selected = None
+    for moment in moments:
+        if moment.center_offset_ms <= playback_position_ms:
+            selected = moment
+        else:
+            break
+    return selected
+
+
+def _format_v4_moment_context(
+    moment: schemas.LectureVideoManifestMomentContextV4,
+) -> str:
+    return (
+        f"Before this moment ({moment.start_offset_ms}-{moment.center_offset_ms}ms):\n"
+        f"{moment.before}\n\n"
+        f"At this moment ({moment.center_offset_ms}ms):\n"
+        f"{moment.at}\n\n"
+        f"After this moment ({moment.center_offset_ms}-{moment.end_offset_ms}ms):\n"
+        f"{moment.after}"
+    )
+
+
+def _build_context_text_v4_from_parts(
+    thread: models.Thread,
+    state: models.LectureVideoThreadState,
+    *,
+    summary_checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4],
+    lecture_video_playback_position_ms: int,
+    answered_knowledge_checks: str | None,
+) -> tuple[str, int]:
+    playback_position_ms = max(0, lecture_video_playback_position_ms)
+    furthest_offset_ms = max(state.furthest_offset_ms, 0)
+    summary_checkpoint = _select_summary_checkpoint(
+        summary_checkpoints,
+        furthest_offset_ms,
+    )
+    moment_context = _select_moment_context(moment_contexts, playback_position_ms)
+    current_question = _get_current_question(thread, state)
+
+    current_knowledge_check = None
+    if (
+        state.state == schemas.LectureVideoSessionState.AWAITING_ANSWER
+        and current_question is not None
+    ):
+        current_knowledge_check = _format_knowledge_check_prompt(current_question)
+
+    lines = [
+        "## Lecture Context",
+        "",
+        f"Status: {_lecture_context_status(state, current_question)}",
+        f"Current offset: {playback_position_ms}ms",
+        f"Furthest watched offset: {furthest_offset_ms}ms",
+    ]
+    _append_lecture_context_section(
+        lines,
+        "Lecture Summary So Far",
+        (
+            f"Through {summary_checkpoint.end_offset_ms}ms:\n"
+            f"{summary_checkpoint.summary}"
+            if summary_checkpoint is not None
+            else None
+        ),
+    )
+    _append_lecture_context_section(
+        lines,
+        "Current Moment Context",
+        _format_v4_moment_context(moment_context)
+        if moment_context is not None
+        else None,
+    )
+    _append_lecture_context_section(
+        lines, "Current Knowledge Check", current_knowledge_check
+    )
+    _append_lecture_context_section(
+        lines, "Knowledge Checks Answered", answered_knowledge_checks
+    )
+    return "\n".join(lines), playback_position_ms
+
+
+async def _validate_v4_playback_position(
+    session: AsyncSession,
+    state: models.LectureVideoThreadState,
+    lecture_video_playback_position_ms: Any | None,
+) -> int:
+    if lecture_video_playback_position_ms is None:
+        raise HTTPException(
+            status_code=400,
+            detail="lecture_video_playback_position_ms is required for this lecture video.",
+        )
+    if not isinstance(lecture_video_playback_position_ms, int) or isinstance(
+        lecture_video_playback_position_ms, bool
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="lecture_video_playback_position_ms must be an integer.",
+        )
+    if lecture_video_playback_position_ms < 0:
+        raise HTTPException(
+            status_code=400,
+            detail="lecture_video_playback_position_ms must be greater than or equal to 0.",
+        )
+    plausible_offset_ms = await lecture_video_runtime._get_plausible_playback_offset_ms(
+        session,
+        state,
+        current_time=datetime.now(timezone.utc),
+    )
+    if lecture_video_playback_position_ms > plausible_offset_ms:
+        raise HTTPException(
+            status_code=400,
+            detail="lecture_video_playback_position_ms is past your unlocked progress in this lecture video.",
+        )
+    return lecture_video_playback_position_ms
+
+
 async def _get_video_input_source(
     lecture_video: models.LectureVideo,
 ) -> VideoInputSource:
@@ -671,6 +807,7 @@ async def build_lecture_chat_context_message_parts(
     anonymous_user_auth: str | None,
     anonymous_session_id: int | None,
     anonymous_link_id: int | None,
+    lecture_video_playback_position_ms: Any | None = None,
 ) -> LectureChatContextBuildResult:
     lecture_video = thread.lecture_video
     state = thread.lecture_video_state
@@ -682,7 +819,7 @@ async def build_lecture_chat_context_message_parts(
     chat_context = lecture_video_chat_context_from_model(lecture_video)
     if chat_context is None:
         raise ValueError(
-            "Lecture chat requires a version 2 or 3 lecture video manifest."
+            "Lecture chat requires a version 2, 3, or 4 lecture video manifest."
         )
 
     if chat_context.version == 3:
@@ -705,6 +842,35 @@ async def build_lecture_chat_context_message_parts(
             text_message_parts=[text_part],
             frame_message_parts=[],
             current_offset_ms=current_offset_ms,
+        )
+
+    if chat_context.version == 4:
+        playback_position_ms = await _validate_v4_playback_position(
+            session,
+            state,
+            lecture_video_playback_position_ms,
+        )
+        answered_knowledge_checks = await _build_answered_knowledge_checks_markdown(
+            session, thread.id
+        )
+        context_text, current_offset_ms = _build_context_text_v4_from_parts(
+            thread,
+            state,
+            summary_checkpoints=chat_context.summary_checkpoints or [],
+            moment_contexts=chat_context.moment_contexts or [],
+            lecture_video_playback_position_ms=playback_position_ms,
+            answered_knowledge_checks=answered_knowledge_checks,
+        )
+        text_part = models.MessagePart(
+            part_index=0,
+            type=schemas.MessagePartType.INPUT_TEXT,
+            text=context_text,
+        )
+        return LectureChatContextBuildResult(
+            text_message_parts=[text_part],
+            frame_message_parts=[],
+            current_offset_ms=current_offset_ms,
+            filter_prior_hidden_messages=True,
         )
 
     answered_knowledge_checks = await _build_answered_knowledge_checks_markdown(
@@ -751,6 +917,7 @@ async def prepare_lecture_chat_turn(
     thread: models.Thread,
     user_id: int,
     prev_output_sequence: int,
+    lecture_video_playback_position_ms: Any | None = None,
 ) -> LectureChatTurnPreparation:
     lecture_thread = await models.Thread.get_by_id_for_class_with_lecture_video_context(
         request.state["db"], int(class_id), thread.id
@@ -789,6 +956,7 @@ async def prepare_lecture_chat_turn(
         anonymous_user_auth=request.state["anonymous_session_token_auth"],
         anonymous_session_id=request.state["anonymous_session_id"],
         anonymous_link_id=request.state["anonymous_link_id"],
+        lecture_video_playback_position_ms=lecture_video_playback_position_ms,
     )
 
     lecture_state.last_chat_context_end_ms = context_result.current_offset_ms
@@ -822,4 +990,5 @@ async def prepare_lecture_chat_turn(
     return LectureChatTurnPreparation(
         prepended_messages=prepended_messages,
         user_output_index=next_output_index,
+        filter_prior_hidden_messages=context_result.filter_prior_hidden_messages,
     )

--- a/pingpong/lecture_video_chat.py
+++ b/pingpong/lecture_video_chat.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException, UploadFile
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import pingpong.models as models
@@ -809,10 +810,22 @@ async def build_lecture_chat_context_message_parts(
             "Lecture video thread context must be loaded before building chat context."
         )
 
-    chat_context = lecture_video_chat_context_from_model(lecture_video)
+    try:
+        chat_context = lecture_video_chat_context_from_model(lecture_video)
+    except (ValidationError, ValueError) as exc:
+        logger.warning(
+            "Stored lecture video chat manifest is invalid. lecture_video_id=%s",
+            lecture_video.id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=LECTURE_VIDEO_CHAT_UNAVAILABLE_NOTE,
+        ) from exc
     if chat_context is None:
-        raise ValueError(
-            "Lecture chat requires a version 2, 3, or 4 lecture video manifest."
+        raise HTTPException(
+            status_code=409,
+            detail=LECTURE_VIDEO_CHAT_UNAVAILABLE_NOTE,
         )
 
     if chat_context.version == 3:

--- a/pingpong/lecture_video_manifest_generation.py
+++ b/pingpong/lecture_video_manifest_generation.py
@@ -258,6 +258,58 @@ class GeneratedVideoDescription(BaseModel):
     description: str = Field(description="Visual description for this video window.")
 
 
+class GeneratedSummaryCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    end_offset_ms: int = Field(
+        ge=0, description="Checkpoint end offset in milliseconds."
+    )
+    summary: str = Field(
+        description=(
+            "Cumulative summary from the relevant generation scope start "
+            "through end_offset_ms."
+        )
+    )
+
+
+class GeneratedMomentContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    center_offset_ms: int = Field(
+        ge=0, description="The center offset for this local context."
+    )
+    start_offset_ms: int = Field(
+        ge=0, description="The start offset of the local context window."
+    )
+    end_offset_ms: int = Field(
+        ge=0, description="The end offset of the local context window."
+    )
+    before: str = Field(description="What immediately leads into this moment.")
+    at: str = Field(description="What is happening at the center moment.")
+    after: str = Field(description="What immediately follows this moment.")
+
+
+class GeneratedQuizWithVideoContext(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    video_summary: str = Field(description="Brief summary of the lesson.")
+    questions: list[GeneratedQuestion] = Field(
+        min_length=1,
+        description="Generated comprehension checks.",
+    )
+    summary_checkpoints: list[GeneratedSummaryCheckpoint] = Field(
+        default_factory=list,
+        description=(
+            "Cumulative summaries from the relevant generation scope start "
+            "through increasing checkpoint offsets."
+        ),
+    )
+    moment_contexts: list[GeneratedMomentContext] = Field(
+        default_factory=list,
+        description="Local context windows centered on increasing offsets.",
+    )
+
+
 class GeneratedQuizWithVideo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -283,6 +335,83 @@ class ReconciledGeneratedQuiz(BaseModel):
 
 def _timestamp_to_ms(value: float | int) -> int:
     return int(round(float(value) * 1000))
+
+
+def _manifest_chunk_overlap_ms(video_description_window_ms: int) -> int:
+    return max(_MANIFEST_CHUNK_OVERLAP_MS, video_description_window_ms // 2)
+
+
+def _scheduled_summary_checkpoint_offsets(
+    *,
+    video_duration_ms: int | None,
+    generation_start_ms: int | None,
+    generation_end_ms: int | None,
+    video_description_window_ms: int,
+) -> list[int]:
+    if video_description_window_ms <= 0:
+        return []
+    effective_end_ms = (
+        generation_end_ms if generation_end_ms is not None else video_duration_ms
+    )
+    if effective_end_ms is None:
+        return []
+    effective_start_ms = max(generation_start_ms or 0, 0)
+    effective_end_ms = max(effective_end_ms, 0)
+    if effective_end_ms <= effective_start_ms:
+        return []
+    first_offset_ms = (
+        (effective_start_ms // video_description_window_ms) + 1
+    ) * video_description_window_ms
+    offsets = list(
+        range(first_offset_ms, effective_end_ms + 1, video_description_window_ms)
+    )
+    if not offsets or offsets[-1] != effective_end_ms:
+        offsets.append(effective_end_ms)
+    return offsets
+
+
+def _scheduled_moment_context_windows(
+    *,
+    video_duration_ms: int | None,
+    generation_start_ms: int | None,
+    generation_end_ms: int | None,
+    video_description_window_ms: int,
+) -> list[tuple[int, int, int]]:
+    if video_description_window_ms <= 0:
+        return []
+    effective_end_ms = (
+        generation_end_ms if generation_end_ms is not None else video_duration_ms
+    )
+    if effective_end_ms is None:
+        return []
+    effective_start_ms = max(generation_start_ms or 0, 0)
+    effective_end_ms = max(effective_end_ms, 0)
+    if effective_end_ms < effective_start_ms:
+        return []
+    if effective_start_ms == 0:
+        first_center_ms = 0
+    else:
+        first_center_ms = (
+            (effective_start_ms + video_description_window_ms - 1)
+            // video_description_window_ms
+        ) * video_description_window_ms
+    if first_center_ms > effective_end_ms:
+        return []
+    half_window_ms = video_description_window_ms // 2
+    duration_cap_ms = (
+        video_duration_ms if video_duration_ms is not None else effective_end_ms
+    )
+    windows: list[tuple[int, int, int]] = []
+    for center_offset_ms in range(
+        first_center_ms, effective_end_ms + 1, video_description_window_ms
+    ):
+        start_offset_ms = max(0, center_offset_ms - half_window_ms)
+        end_offset_ms = min(duration_cap_ms, center_offset_ms + half_window_ms)
+        windows.append((center_offset_ms, start_offset_ms, end_offset_ms))
+    if windows and windows[-1][0] != effective_end_ms:
+        start_offset_ms = max(0, effective_end_ms - half_window_ms)
+        windows.append((effective_end_ms, start_offset_ms, effective_end_ms))
+    return windows
 
 
 @dataclass(frozen=True)
@@ -887,50 +1016,99 @@ def build_generation_prompt(
 
     video_description_window_seconds = video_description_window_ms / 1000
     video_description_next_window_ms = video_description_window_ms * 2
+    video_description_half_window_ms = video_description_window_ms // 2
+    video_description_half_window_seconds = video_description_half_window_ms / 1000
     video_description_window_text = f"{video_description_window_seconds:g}"
+    video_description_half_window_text = f"{video_description_half_window_seconds:g}"
+    context_array_summary_scope = "0ms through each end_offset_ms"
+    summary_schedule_guidance = (
+        f"- Generate summary checkpoints exactly every {video_description_window_text} "
+        "seconds from the start of the video, plus the final video end if it is "
+        "not already on that cadence, using absolute millisecond offsets."
+    )
+    moment_schedule_guidance = (
+        f"- Generate moment contexts centered exactly every {video_description_window_text} "
+        "seconds from the start of the video, plus a final context centered on "
+        "the final video/request end if it is not already on that cadence, using "
+        "absolute millisecond offsets."
+    )
+    initial_moment_guidance = (
+        "- Always include an initial moment_context with start_offset_ms=0, "
+        "center_offset_ms=0, and end_offset_ms="
+        f"{video_description_half_window_ms}."
+    )
     duration_text = (
         f"\nThe video duration is {video_duration_ms} milliseconds."
         if video_duration_ms is not None
         else ""
     )
     generation_window_text = ""
-    video_description_scope = "the whole video"
-    video_description_start_rule = (
-        "Use consecutive millisecond ranges starting at 0: "
-        f"0-{video_description_window_ms}, "
-        f"{video_description_window_ms}-{video_description_next_window_ms}, "
-        "and so on through the full video."
+    context_array_scope = "the whole video"
+    chunk_moment_boundary_guidance = ""
+    context_offset_guidance = (
+        "- Use absolute millisecond offsets from the original video for every "
+        "summary end_offset_ms and every moment center_offset_ms, start_offset_ms, "
+        "and end_offset_ms."
     )
-    video_description_end_rule = (
-        "The final segment must end exactly at the video duration. It may be "
-        f"shorter than {video_description_window_text} seconds. Never set the "
-        "final end_offset_ms after the end of the video."
-    )
-    video_description_reminder = (
-        'The top-level "video_descriptions" array is REQUIRED for video-based '
-        "generation. It must be non-empty and must use contiguous millisecond "
-        "windows starting at 0. The final segment must end exactly at the video "
-        "duration, not after it."
+    context_array_reminder = (
+        'The top-level "summary_checkpoints" and "moment_contexts" arrays are '
+        "REQUIRED for video-based generation. They must be non-empty and use "
+        "absolute millisecond offsets from the original video."
     )
     if generation_start_ms is not None and generation_end_ms is not None:
-        video_description_scope = "the requested generation window"
-        video_description_start_rule = (
-            "Use consecutive millisecond ranges starting at the requested "
-            "generation window start. Use absolute offsets from the original "
-            "video, not clip-relative offsets."
+        context_array_scope = "the requested generation window"
+        context_array_summary_scope = (
+            f"{generation_start_ms}ms through each end_offset_ms"
         )
-        video_description_end_rule = (
-            "The final segment must end exactly at the requested generation "
-            "window end. It may be shorter than "
-            f"{video_description_window_text} seconds. Never set the final "
-            "end_offset_ms after the requested generation window end."
+        summary_schedule_guidance = (
+            f"- Generate summary checkpoints at the fixed {video_description_window_text}"
+            "-second cadence inside the requested generation window, plus the "
+            "request end if it is not already on that cadence, using absolute "
+            "millisecond offsets from the original video. The first checkpoint is "
+            f"the first cadence offset greater than {generation_start_ms}ms; do "
+            "not force a checkpoint at 0ms for a chunk that starts later."
         )
-        video_description_reminder = (
-            'The top-level "video_descriptions" array is REQUIRED for '
-            "video-based generation. It must be non-empty and must use "
-            "contiguous millisecond windows starting at the requested generation "
-            "window start. The final segment must end exactly at the requested "
-            "generation window end, not after it."
+        moment_schedule_guidance = (
+            f"- Generate moment contexts centered at the fixed {video_description_window_text}"
+            "-second cadence inside the requested generation window, plus a final "
+            "context centered on the request end if it is not already on that "
+            "cadence, using absolute millisecond offsets from the original video."
+        )
+        initial_moment_guidance = (
+            "- If the requested generation window starts at 0ms, include the "
+            "initial moment_context with start_offset_ms=0, center_offset_ms=0, "
+            f"and end_offset_ms={video_description_half_window_ms}. If the "
+            "requested generation window starts later, do not include a 0ms "
+            "moment_context; start with the first fixed-cadence center inside "
+            "the requested generation window."
+        )
+        if generation_start_ms == 0:
+            first_moment_center_ms = 0
+        else:
+            first_moment_center_ms = (
+                (generation_start_ms + video_description_window_ms - 1)
+                // video_description_window_ms
+            ) * video_description_window_ms
+        chunk_moment_boundary_guidance = (
+            "- For moment_contexts near the requested generation window boundaries, "
+            'use the surrounding clip context when writing "before" and "after". '
+            "The local context window may extend outside the generation window, "
+            "but center_offset_ms must stay inside the generation window.\n"
+            f"- The first required moment_context center is {first_moment_center_ms}ms. "
+            "Include it even when it equals generation_start_ms; boundary centers "
+            "are required, not optional."
+        )
+        context_offset_guidance = (
+            "- Use absolute millisecond offsets from the original video for every "
+            "summary end_offset_ms and every moment center_offset_ms, start_offset_ms, "
+            "and end_offset_ms. The provided media is a clipped excerpt, so do "
+            "not emit excerpt-relative offsets."
+        )
+        context_array_reminder = (
+            'The top-level "summary_checkpoints" and "moment_contexts" arrays '
+            "are REQUIRED for video-based generation. They must be non-empty, "
+            "must use absolute offsets from the original video, and should only "
+            "cover the requested generation window."
         )
         context_window_text = (
             f" The provided video clip covers absolute offsets "
@@ -945,8 +1123,7 @@ This is one chunk from a longer lecture video.{context_window_text}
 Clip time 0 corresponds to absolute offset {context_start_ms or 0}ms in the original video.
 Use the whole clip as context, but generate output ONLY for the generation window from {generation_start_ms}ms through {generation_end_ms}ms.
 Do not create questions with pause points before {generation_start_ms}ms or after {generation_end_ms}ms.
-Generate "video_descriptions" starting exactly at {generation_start_ms}ms and ending exactly at {generation_end_ms}ms.
-Every non-final video description segment inside this generation window must be exactly {video_description_window_ms}ms long.
+Generate "summary_checkpoints" and "moment_contexts" for offsets inside {generation_start_ms}ms through {generation_end_ms}ms.
 """
 
     return f"""You are an expert educational content designer specializing in interactive video lessons. You speak as the teacher in first person, directly to the student.
@@ -963,23 +1140,38 @@ To ensure high confidence in analyzing the lesson, watch the video along with th
 YOUR TASK:
 Analyze the provided lesson materials to identify natural pause points where a multiple-choice comprehension check can be inserted. At each pause point, the video will stop, a question will be displayed as text on screen, and a voice clone of the teacher will introduce the question out loud. After the student selects an answer, the voice clone will give spoken feedback, and the video will resume. The resume point may differ depending on which answer the student chose.
 
-Also create a top-level "video_descriptions" array that describes what is visibly happening in fixed {video_description_window_text}-second windows across {video_description_scope}.
+Also create two top-level context arrays across {context_array_scope}:
+- "summary_checkpoints": cumulative summaries over {context_array_summary_scope}, ordered by increasing end_offset_ms.
+- "moment_contexts": local context windows centered on increasing center_offset_ms values, with separate "before", "at", and "after" fields.
 
-VISUAL DESCRIPTION GUIDELINES:
-- {video_description_start_rule}
-- Every segment except the final segment must be exactly {video_description_window_text} seconds long.
-- {video_description_end_rule}
-- Each segment description should be concise and general-purpose, usually 1-2 sentences.
-- Focus only on observable teaching state: screen or board contents, written text, diagrams, values, equations, cursor movement, gesture emphasis, and meaningful visual changes.
-- Do not infer concepts from visuals alone. Tie visual details to what can actually be seen.
-- If the visual state is mostly unchanged from the prior window, briefly say what remains visible and note any small meaningful changes.
+CONTEXT ARRAY GROUNDING:
+- Use a {video_description_window_text}-second context cadence ({video_description_window_ms}ms): summary checkpoints and moment_context centers follow this cadence.
+{context_offset_guidance}
+- Do not choose semantically interesting offsets instead of the fixed cadence.
+- Use the provided transcript and visible video content as the source of truth. You may combine spoken content with observable teaching state, but make conceptual claims only when they are supported by the transcript, visible text, or clearly visible teaching action.
+
+SUMMARY CHECKPOINT GUIDELINES:
+{summary_schedule_guidance}
+- Do not skip the first required checkpoint for this generation scope.
+- Each summary must be cumulative over {context_array_summary_scope}. For a chunked request, summarize from the requested generation start through end_offset_ms; do not claim to summarize unseen earlier video content.
+
+MOMENT CONTEXT GUIDELINES:
+{moment_schedule_guidance}
+- Moment context windows must extend half the context cadence on each side of the center: start_offset_ms = center_offset_ms - {video_description_half_window_text} seconds, end_offset_ms = center_offset_ms + {video_description_half_window_text} seconds, clamped to 0ms and the video duration.
+- For example, with a 5-second context cadence, center_offset_ms=10000 must use start_offset_ms=7500 and end_offset_ms=12500.
+{initial_moment_guidance}
+{chunk_moment_boundary_guidance}
+- For every moment_context, enforce start_offset_ms <= center_offset_ms <= end_offset_ms.
+- "before" should explain what immediately leads into the center moment.
+- "at" should explain what is happening at the center moment.
+- "after" should explain what immediately follows the center moment.
+- Context text should combine spoken content and observable teaching state where useful: screen or board contents, written text, diagrams, values, equations, cursor movement, gesture emphasis, and meaningful visual changes.
 
 IMPORTANT CONTEXT:
-- The student sees subtitles/captions during playback, so they both hear and read what the teacher says. For your purposes, that means attention-based questions are not useful here.
 - The voice-over feedback is spoken by a clone of the teacher's voice. It must sound like the teacher is speaking directly to the student in first person — not a separate narrator or tutor commenting from the outside.
 - The feedback voice-over is spliced into the lecture audio. When the video resumes, the teacher's voice continues seamlessly. Your feedback must flow naturally into whatever the teacher says at the determined resume point — as if it were all one continuous spoken experience.
 
-EDITABLE GENERATION GUIDANCE:
+GENERATION GUIDANCE SPECIFIC TO THIS VIDEO:
 {content_section.strip() or DEFAULT_GENERATION_PROMPT_CONTENT}
 
 GUIDELINES FOR VOICE AND PERSPECTIVE:
@@ -1040,16 +1232,32 @@ Return a single JSON object. Do not include any text outside the JSON.
 ```json
 {{
   "video_summary": "Brief description of the video topic",
-  "video_descriptions": [
+  "summary_checkpoints": [
     {{
-      "start_offset_ms": 0,
       "end_offset_ms": {video_description_window_ms},
-      "description": "The teacher's screen shows a slide with a title and two bullet points. A cursor circles the first bullet while the speaker emphasizes the main idea."
+      "summary": "From the start through this point, the teacher introduces the main idea and works through the first example."
     }},
     {{
-      "start_offset_ms": {video_description_window_ms},
       "end_offset_ms": {video_description_next_window_ms},
-      "description": "The same slide remains visible while a short example is added underneath the bullets. The cursor moves between the example and the earlier text to connect them."
+      "summary": "From the start through this point, the teacher introduces the main idea, works through the first example, and connects it to the next step."
+    }}
+  ],
+  "moment_contexts": [
+    {{
+      "center_offset_ms": 0,
+      "start_offset_ms": 0,
+      "end_offset_ms": {video_description_half_window_ms},
+      "before": "The lesson is just beginning.",
+      "at": "The teacher introduces the topic and the first visible teaching materials.",
+      "after": "The teacher begins the first example."
+    }},
+    {{
+      "center_offset_ms": {video_description_window_ms},
+      "start_offset_ms": {video_description_half_window_ms},
+      "end_offset_ms": {video_description_window_ms + video_description_half_window_ms},
+      "before": "The teacher has introduced the main idea.",
+      "at": "The teacher is working through the next step of the example.",
+      "after": "The teacher connects the example back to the main concept."
     }}
   ],
   "questions": [
@@ -1137,16 +1345,22 @@ FIELD DEFINITIONS:
   - "resume_at_word_id": The "id" of the first word the student hears when the video resumes after this choice. Copied exactly from the transcript.
   - "resume_at_word": The "word" text of that transcript entry. Copied exactly.
   - "resume_at": The "start" timestamp of the resume word. Copied exactly from the transcript — do not round or modify.
-- "video_descriptions": Array of contiguous visual segments covering the whole video. Each non-final segment is {video_description_window_text} seconds; the final segment ends exactly at the video duration and may be shorter. Each segment contains:
-  - "start_offset_ms": Integer millisecond offset where this visual window starts.
-  - "end_offset_ms": Integer millisecond offset where this visual window ends. This must be exactly {video_description_window_ms}ms after start_offset_ms except for the final segment, which must equal the video duration.
-  - "description": Concise observable description of the teaching visuals in that window.
+- "summary_checkpoints": Array of cumulative summaries. Each entry contains:
+  - "end_offset_ms": Integer millisecond offset through which this summary applies.
+  - "summary": Non-empty cumulative summary from the relevant generation scope start through end_offset_ms.
+- "moment_contexts": Array of local context windows. Each entry contains:
+  - "center_offset_ms": Integer millisecond offset used to select this local context.
+  - "start_offset_ms": Integer millisecond offset where the local window starts.
+  - "end_offset_ms": Integer millisecond offset where the local window ends.
+  - "before": Non-empty local context before center_offset_ms.
+  - "at": Non-empty local context at center_offset_ms.
+  - "after": Non-empty local context after center_offset_ms.
 
 IMPORTANT REMINDERS:
 - ALL word IDs and timestamps must come directly from the transcript entries. Look up each word's actual "id" field — do not count or guess. Copy "word", "start", and "end" exactly.
 - For teacher-posed questions: let them ask it, pause after the question, and resume into the teacher's own answer — do NOT skip past it.
 - For "generated" questions, voice_over_intro MUST include both a pause cue and the question spoken aloud. The student needs to hear it, not just read it.
-- {video_description_reminder}
+- {context_array_reminder}
 
 REDUNDANCY CHECK:
 - Before finalizing each voice_over, read it concatenated with the teacher's words starting at the resume point. If any fact, number, or concept appears in both your feedback AND the teacher's next sentence, remove it from your feedback. The combined audio must never say the same thing twice.
@@ -1485,32 +1699,203 @@ def _normalize_video_descriptions_to_windows(
     ]
 
 
+def _fallback_summary_checkpoints(
+    video_duration_ms: int | None,
+) -> list[schemas.LectureVideoManifestSummaryCheckpointV4]:
+    return [
+        schemas.LectureVideoManifestSummaryCheckpointV4(
+            end_offset_ms=max(video_duration_ms or 0, 0),
+            summary="A cumulative lecture summary was unavailable for this generation pass.",
+        )
+    ]
+
+
+def _fallback_moment_contexts() -> list[schemas.LectureVideoManifestMomentContextV4]:
+    return [
+        schemas.LectureVideoManifestMomentContextV4(
+            center_offset_ms=0,
+            start_offset_ms=0,
+            end_offset_ms=0,
+            before="No earlier local lecture context is available.",
+            at="Local lecture context was unavailable for this generation pass.",
+            after="No later local lecture context is available.",
+        )
+    ]
+
+
+def _generated_summary_checkpoints_to_manifest(
+    checkpoints: list[GeneratedSummaryCheckpoint],
+) -> list[schemas.LectureVideoManifestSummaryCheckpointV4]:
+    return [
+        schemas.LectureVideoManifestSummaryCheckpointV4.model_validate(
+            checkpoint.model_dump()
+        )
+        for checkpoint in checkpoints
+    ]
+
+
+def _generated_moment_contexts_to_manifest(
+    moments: list[GeneratedMomentContext],
+) -> list[schemas.LectureVideoManifestMomentContextV4]:
+    return [
+        schemas.LectureVideoManifestMomentContextV4.model_validate(moment.model_dump())
+        for moment in moments
+    ]
+
+
+def _normalize_v4_context_arrays(
+    *,
+    summary_checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4],
+    video_duration_ms: int | None,
+    generation_start_ms: int | None = None,
+    generation_end_ms: int | None = None,
+    video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
+) -> tuple[
+    list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    list[schemas.LectureVideoManifestMomentContextV4],
+]:
+    summary_checkpoint_by_offset = {
+        checkpoint.end_offset_ms: checkpoint for checkpoint in summary_checkpoints
+    }
+    required_summary_offsets = _scheduled_summary_checkpoint_offsets(
+        video_duration_ms=video_duration_ms,
+        generation_start_ms=generation_start_ms,
+        generation_end_ms=generation_end_ms,
+        video_description_window_ms=video_description_window_ms,
+    )
+    if required_summary_offsets:
+        summary_checkpoints = []
+        for end_offset_ms in required_summary_offsets:
+            checkpoint = summary_checkpoint_by_offset.get(end_offset_ms)
+            if checkpoint is not None:
+                summary_checkpoints.append(checkpoint)
+                continue
+            logger.warning(
+                "Generated summary_checkpoints missing required offset %sms; "
+                "falling back to unavailable summary for that checkpoint.",
+                end_offset_ms,
+            )
+            summary_checkpoints.append(
+                schemas.LectureVideoManifestSummaryCheckpointV4(
+                    end_offset_ms=end_offset_ms,
+                    summary=(
+                        "A cumulative lecture summary was unavailable for this "
+                        "checkpoint."
+                    ),
+                )
+            )
+    else:
+        summary_checkpoints = sorted(
+            summary_checkpoint_by_offset.values(),
+            key=lambda item: item.end_offset_ms,
+        )
+
+    moment_context_by_center = {
+        moment.center_offset_ms: moment for moment in moment_contexts
+    }
+    required_moment_windows = _scheduled_moment_context_windows(
+        video_duration_ms=video_duration_ms,
+        generation_start_ms=generation_start_ms,
+        generation_end_ms=generation_end_ms,
+        video_description_window_ms=video_description_window_ms,
+    )
+    if required_moment_windows:
+        moment_contexts = []
+        for center_offset_ms, start_offset_ms, end_offset_ms in required_moment_windows:
+            moment = moment_context_by_center.get(center_offset_ms)
+            if moment is None:
+                logger.warning(
+                    "Generated moment_contexts missing required center %sms; "
+                    "falling back to unavailable local context for that moment.",
+                    center_offset_ms,
+                )
+                moment_contexts.append(
+                    schemas.LectureVideoManifestMomentContextV4(
+                        center_offset_ms=center_offset_ms,
+                        start_offset_ms=start_offset_ms,
+                        end_offset_ms=end_offset_ms,
+                        before="No earlier local lecture context is available.",
+                        at=("Local lecture context was unavailable for this moment."),
+                        after="No later local lecture context is available.",
+                    )
+                )
+                continue
+            moment_contexts.append(
+                schemas.LectureVideoManifestMomentContextV4(
+                    center_offset_ms=center_offset_ms,
+                    start_offset_ms=start_offset_ms,
+                    end_offset_ms=end_offset_ms,
+                    before=moment.before,
+                    at=moment.at,
+                    after=moment.after,
+                )
+            )
+    else:
+        moment_contexts = sorted(
+            moment_context_by_center.values(),
+            key=lambda item: item.center_offset_ms,
+        )
+    if not summary_checkpoints:
+        logger.warning(
+            "Generated summary_checkpoints was empty; falling back to unavailable summary."
+        )
+        summary_checkpoints = _fallback_summary_checkpoints(video_duration_ms)
+    if not moment_contexts:
+        logger.warning(
+            "Generated moment_contexts was empty; falling back to unavailable moment context."
+        )
+        moment_contexts = _fallback_moment_contexts()
+    return summary_checkpoints, moment_contexts
+
+
 def _quiz_to_manifest(
-    quiz: GeneratedQuizWithVideo,
+    quiz: GeneratedQuizWithVideoContext | GeneratedQuizWithVideo,
     transcript: list[schemas.LectureVideoManifestWordV3],
     *,
     video_duration_ms: int | None,
     video_description_start_offset_ms: int = 0,
     video_description_end_offset_ms: int | None = None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV3 | schemas.LectureVideoManifestV4:
     transcript_word_index = _transcript_word_index(transcript)
-    video_descriptions = _video_descriptions_to_manifest_video_descriptions(
-        quiz.video_descriptions
-    )
-    video_descriptions = _validated_or_fallback_video_descriptions(
-        video_descriptions,
-        start_offset_ms=video_description_start_offset_ms,
-        end_offset_ms=(
-            video_description_end_offset_ms
-            if video_description_end_offset_ms is not None
-            else video_duration_ms
+    if isinstance(quiz, GeneratedQuizWithVideo):
+        video_descriptions = _video_descriptions_to_manifest_video_descriptions(
+            quiz.video_descriptions
+        )
+        video_descriptions = _validated_or_fallback_video_descriptions(
+            video_descriptions,
+            start_offset_ms=video_description_start_offset_ms,
+            end_offset_ms=(
+                video_description_end_offset_ms
+                if video_description_end_offset_ms is not None
+                else video_duration_ms
+            ),
+            video_description_window_ms=video_description_window_ms,
+        )
+        return schemas.LectureVideoManifestV3(
+            word_level_transcription=transcript,
+            video_descriptions=video_descriptions,
+            questions=[
+                _question_to_manifest_question(question, transcript_word_index)
+                for question in quiz.questions
+            ],
+        )
+
+    summary_checkpoints, moment_contexts = _normalize_v4_context_arrays(
+        summary_checkpoints=_generated_summary_checkpoints_to_manifest(
+            quiz.summary_checkpoints
         ),
+        moment_contexts=_generated_moment_contexts_to_manifest(quiz.moment_contexts),
+        video_duration_ms=video_duration_ms or video_description_end_offset_ms,
+        generation_start_ms=video_description_start_offset_ms,
+        generation_end_ms=video_description_end_offset_ms,
         video_description_window_ms=video_description_window_ms,
     )
-    return schemas.LectureVideoManifestV3(
+    return schemas.LectureVideoManifestV4(
         word_level_transcription=transcript,
-        video_descriptions=video_descriptions,
+        summary_checkpoints=summary_checkpoints,
+        moment_contexts=moment_contexts,
         questions=[
             _question_to_manifest_question(question, transcript_word_index)
             for question in quiz.questions
@@ -1573,7 +1958,7 @@ def _reconciliation_prompt(generation_prompt_content: str) -> str:
 You will be given:
 - The instructor's generation guidance.
 - The full word-level transcript for the complete video.
-- The final merged video_descriptions for the complete video.
+- The final merged summary_checkpoints and moment_contexts for the complete video.
 - Candidate questions generated independently from video chunks.
 
 Your task is to create the final question list for the complete video.
@@ -1599,8 +1984,9 @@ INSTRUCTOR GENERATION GUIDANCE:
 def _reconciliation_payload(
     *,
     transcript: list[schemas.LectureVideoManifestWordV3],
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    chunk_manifests: list[schemas.LectureVideoManifestV3],
+    summary_checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4],
+    chunk_manifests: list[schemas.LectureVideoManifestV4],
     video_duration_ms: int | None,
 ) -> str:
     payload = {
@@ -1609,9 +1995,10 @@ def _reconciliation_payload(
             _word_to_generation_word(word, index)
             for index, word in enumerate(transcript)
         ],
-        "video_descriptions": [
-            description.model_dump() for description in video_descriptions
+        "summary_checkpoints": [
+            checkpoint.model_dump() for checkpoint in summary_checkpoints
         ],
+        "moment_contexts": [moment.model_dump() for moment in moment_contexts],
         "candidate_question_groups": [
             {
                 "candidate_group_index": index,
@@ -1642,8 +2029,9 @@ async def _reconcile_chunk_questions(
     gemini_client: AsyncClient,
     generation_prompt_content: str,
     transcript: list[schemas.LectureVideoManifestWordV3],
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    chunk_manifests: list[schemas.LectureVideoManifestV3],
+    summary_checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4],
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4],
+    chunk_manifests: list[schemas.LectureVideoManifestV4],
     video_duration_ms: int | None,
     model: str,
 ) -> list[schemas.LectureVideoManifestQuestionV1]:
@@ -1655,7 +2043,8 @@ async def _reconcile_chunk_questions(
             types.Part.from_text(
                 text=_reconciliation_payload(
                     transcript=transcript,
-                    video_descriptions=video_descriptions,
+                    summary_checkpoints=summary_checkpoints,
+                    moment_contexts=moment_contexts,
                     chunk_manifests=chunk_manifests,
                     video_duration_ms=video_duration_ms,
                 )
@@ -1672,67 +2061,108 @@ async def _merge_chunk_manifests(
     gemini_client: AsyncClient,
     generation_prompt_content: str,
     model: str,
-    chunk_manifests: list[schemas.LectureVideoManifestV3],
+    chunk_manifests: list[schemas.LectureVideoManifestV4],
     full_transcript: list[schemas.LectureVideoManifestWordV3],
     video_duration_ms: int | None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
-    if video_duration_ms is None:
-        video_descriptions = [
-            description
+) -> schemas.LectureVideoManifestV3 | schemas.LectureVideoManifestV4:
+    if all(
+        isinstance(manifest, schemas.LectureVideoManifestV3)
+        for manifest in chunk_manifests
+    ):
+        v3_chunk_manifests = [
+            manifest
             for manifest in chunk_manifests
-            for description in manifest.video_descriptions
+            if isinstance(manifest, schemas.LectureVideoManifestV3)
         ]
-        video_descriptions = _validated_or_fallback_video_descriptions(
-            video_descriptions,
-            end_offset_ms=video_duration_ms,
-            video_description_window_ms=video_description_window_ms,
-        )
-    else:
-        video_descriptions = []
-        expected_start_offset_ms = 0
-        for index, manifest in enumerate(chunk_manifests):
-            chunk_end_offset_ms = (
-                video_duration_ms
-                if index == len(chunk_manifests) - 1
-                else max(
-                    manifest.video_descriptions[-1].end_offset_ms,
-                    expected_start_offset_ms + 1,
-                )
-            )
-            chunk_descriptions = _validated_or_fallback_chunk_video_descriptions(
-                manifest.video_descriptions,
-                chunk_index=index,
-                start_offset_ms=expected_start_offset_ms,
-                end_offset_ms=chunk_end_offset_ms,
+        if video_duration_ms is None:
+            video_descriptions = [
+                description
+                for manifest in v3_chunk_manifests
+                for description in manifest.video_descriptions
+            ]
+            video_descriptions = _validated_or_fallback_video_descriptions(
+                video_descriptions,
+                end_offset_ms=video_duration_ms,
                 video_description_window_ms=video_description_window_ms,
             )
-            video_descriptions.extend(chunk_descriptions)
-            expected_start_offset_ms = chunk_descriptions[-1].end_offset_ms
-        if expected_start_offset_ms < video_duration_ms:
-            video_descriptions.extend(
-                _fallback_video_descriptions(
-                    video_duration_ms,
-                    start_offset_ms=expected_start_offset_ms,
+        else:
+            video_descriptions = []
+            expected_start_offset_ms = 0
+            for index, manifest in enumerate(v3_chunk_manifests):
+                chunk_end_offset_ms = (
+                    video_duration_ms
+                    if index == len(v3_chunk_manifests) - 1
+                    else max(
+                        manifest.video_descriptions[-1].end_offset_ms,
+                        expected_start_offset_ms + 1,
+                    )
                 )
+                chunk_descriptions = _validated_or_fallback_chunk_video_descriptions(
+                    manifest.video_descriptions,
+                    chunk_index=index,
+                    start_offset_ms=expected_start_offset_ms,
+                    end_offset_ms=chunk_end_offset_ms,
+                    video_description_window_ms=video_description_window_ms,
+                )
+                video_descriptions.extend(chunk_descriptions)
+                expected_start_offset_ms = chunk_descriptions[-1].end_offset_ms
+            if expected_start_offset_ms < video_duration_ms:
+                video_descriptions.extend(
+                    _fallback_video_descriptions(
+                        video_duration_ms,
+                        start_offset_ms=expected_start_offset_ms,
+                    )
+                )
+            video_descriptions = _normalize_video_descriptions_to_windows(
+                video_descriptions,
+                video_duration_ms=video_duration_ms,
+                video_description_window_ms=video_description_window_ms,
             )
-        video_descriptions = _normalize_video_descriptions_to_windows(
-            video_descriptions,
+        questions = await _reconcile_chunk_questions(
+            gemini_client=gemini_client,
+            generation_prompt_content=generation_prompt_content,
+            transcript=full_transcript,
+            summary_checkpoints=_fallback_summary_checkpoints(video_duration_ms),
+            moment_contexts=_fallback_moment_contexts(),
+            chunk_manifests=v3_chunk_manifests,  # type: ignore[arg-type]
             video_duration_ms=video_duration_ms,
-            video_description_window_ms=video_description_window_ms,
+            model=model,
         )
+        return schemas.LectureVideoManifestV3(
+            word_level_transcription=full_transcript,
+            video_descriptions=video_descriptions,
+            questions=questions,
+        )
+
+    summary_checkpoints, moment_contexts = _normalize_v4_context_arrays(
+        summary_checkpoints=[
+            checkpoint
+            for manifest in chunk_manifests
+            for checkpoint in manifest.summary_checkpoints
+        ],
+        moment_contexts=[
+            moment
+            for manifest in chunk_manifests
+            for moment in manifest.moment_contexts
+        ],
+        video_duration_ms=video_duration_ms,
+        video_description_window_ms=video_description_window_ms,
+    )
     questions = await _reconcile_chunk_questions(
         gemini_client=gemini_client,
         generation_prompt_content=generation_prompt_content,
         transcript=full_transcript,
-        video_descriptions=video_descriptions,
+        summary_checkpoints=summary_checkpoints,
+        moment_contexts=moment_contexts,
         chunk_manifests=chunk_manifests,
         video_duration_ms=video_duration_ms,
         model=model,
     )
-    return schemas.LectureVideoManifestV3(
+    return schemas.LectureVideoManifestV4(
         word_level_transcription=full_transcript,
-        video_descriptions=video_descriptions,
+        summary_checkpoints=summary_checkpoints,
+        moment_contexts=moment_contexts,
         questions=questions,
     )
 
@@ -1751,7 +2181,7 @@ async def _generate_manifest_from_gemini_file(
     context_start_ms: int | None = None,
     context_end_ms: int | None = None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV4:
     prompt = build_generation_prompt(
         generation_prompt_content,
         transcript,
@@ -1775,7 +2205,7 @@ async def _generate_manifest_from_gemini_file(
         model=model,
         prompt=prompt,
         contents=_gemini_contents_for_file(gemini_file),
-        response_model=GeneratedQuizWithVideo,
+        response_model=GeneratedQuizWithVideoContext,
         request_label=request_label,
     )
     return _quiz_to_manifest(
@@ -1797,7 +2227,7 @@ async def generate_manifest(
     transcript: list[schemas.LectureVideoManifestWordV3],
     model: str = _GEMINI_MODEL,
     video_description_duration_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV4:
     video_duration_ms = await _ffprobe_duration_ms(video_path)
     video_description_window_ms = video_description_duration_ms
     try:
@@ -1834,7 +2264,7 @@ async def _upload_and_generate_whole_manifest(
     video_duration_ms: int | None,
     model: str,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV4:
     gemini_file_name: str | None = None
     try:
         logger.info("Uploading full lecture video to Gemini for manifest generation.")
@@ -1887,7 +2317,7 @@ async def _upload_and_generate_manifest_chunk(
     temp_dir: str,
     model: str,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV4:
     chunk_transcript = _transcript_for_window(
         transcript,
         start_offset_ms=chunk.context_start_ms,
@@ -1972,7 +2402,8 @@ async def _upload_and_generate_manifest_chunks(
     temp_dir: str,
     model: str,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> list[schemas.LectureVideoManifestV3]:
+    overlap_ms: int = _MANIFEST_CHUNK_OVERLAP_MS,
+) -> list[schemas.LectureVideoManifestV4]:
     try:
         return [
             await _upload_and_generate_manifest_chunk(
@@ -1996,6 +2427,7 @@ async def _upload_and_generate_manifest_chunks(
         child_chunks = _split_manifest_generation_chunk(
             chunk,
             video_duration_ms=video_duration_ms,
+            overlap_ms=overlap_ms,
             alignment_ms=video_description_window_ms,
         )
         logger.info(
@@ -2005,7 +2437,7 @@ async def _upload_and_generate_manifest_chunks(
             chunk.generation_end_ms,
             child_chunks[0].generation_end_ms,
         )
-        chunk_manifests: list[schemas.LectureVideoManifestV3] = []
+        chunk_manifests: list[schemas.LectureVideoManifestV4] = []
         for child_chunk in child_chunks:
             chunk_manifests.extend(
                 await _upload_and_generate_manifest_chunks(
@@ -2018,6 +2450,7 @@ async def _upload_and_generate_manifest_chunks(
                     temp_dir=temp_dir,
                     model=model,
                     video_description_window_ms=video_description_window_ms,
+                    overlap_ms=overlap_ms,
                 )
             )
         return chunk_manifests
@@ -2032,7 +2465,7 @@ async def upload_and_generate_manifest(
     temp_dir: str,
     model: str = _GEMINI_MODEL,
     video_description_duration_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3:
+) -> schemas.LectureVideoManifestV4:
     video_duration_ms = await _ffprobe_duration_ms(video_path)
     if video_duration_ms is None:
         raise RuntimeError(
@@ -2040,8 +2473,10 @@ async def upload_and_generate_manifest(
             "manifest generation requires a valid video duration."
         )
     video_description_window_ms = video_description_duration_ms
+    overlap_ms = _manifest_chunk_overlap_ms(video_description_window_ms)
     chunks = _plan_manifest_generation_chunks(
         video_duration_ms,
+        overlap_ms=overlap_ms,
         alignment_ms=video_description_window_ms,
     )
     if len(chunks) == 1:
@@ -2065,6 +2500,7 @@ async def upload_and_generate_manifest(
             chunks = _split_manifest_generation_chunk(
                 chunks[0],
                 video_duration_ms=video_duration_ms,
+                overlap_ms=overlap_ms,
                 alignment_ms=video_description_window_ms,
             )
 
@@ -2074,7 +2510,7 @@ async def upload_and_generate_manifest(
         video_duration_ms,
         len(chunks),
     )
-    chunk_manifests: list[schemas.LectureVideoManifestV3] = []
+    chunk_manifests: list[schemas.LectureVideoManifestV4] = []
     for chunk in chunks:
         chunk_manifests.extend(
             await _upload_and_generate_manifest_chunks(
@@ -2087,6 +2523,7 @@ async def upload_and_generate_manifest(
                 temp_dir=temp_dir,
                 model=model,
                 video_description_window_ms=video_description_window_ms,
+                overlap_ms=overlap_ms,
             )
         )
     return await _merge_chunk_manifests(

--- a/pingpong/lecture_video_manifest_generation.py
+++ b/pingpong/lecture_video_manifest_generation.py
@@ -250,14 +250,6 @@ class GeneratedQuestion(BaseModel):
     )
 
 
-class GeneratedVideoDescription(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    start_offset_ms: int = Field(ge=0, description="Start offset in milliseconds.")
-    end_offset_ms: int = Field(ge=1, description="End offset in milliseconds.")
-    description: str = Field(description="Visual description for this video window.")
-
-
 class GeneratedSummaryCheckpoint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -307,20 +299,6 @@ class GeneratedQuizWithVideoContext(BaseModel):
     moment_contexts: list[GeneratedMomentContext] = Field(
         default_factory=list,
         description="Local context windows centered on increasing offsets.",
-    )
-
-
-class GeneratedQuizWithVideo(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    video_summary: str = Field(description="Brief summary of the lesson.")
-    questions: list[GeneratedQuestion] = Field(
-        min_length=1,
-        description="Generated comprehension checks.",
-    )
-    video_descriptions: list[GeneratedVideoDescription] = Field(
-        min_length=1,
-        description="Contiguous visual descriptions covering the source video.",
     )
 
 
@@ -1019,6 +997,7 @@ def build_generation_prompt(
     video_description_half_window_ms = video_description_window_ms // 2
     video_description_half_window_seconds = video_description_half_window_ms / 1000
     video_description_window_text = f"{video_description_window_seconds:g}"
+    video_description_window_unit_text = f"{video_description_window_text}-second"
     video_description_half_window_text = f"{video_description_half_window_seconds:g}"
     context_array_summary_scope = "0ms through each end_offset_ms"
     summary_schedule_guidance = (
@@ -1061,16 +1040,16 @@ def build_generation_prompt(
             f"{generation_start_ms}ms through each end_offset_ms"
         )
         summary_schedule_guidance = (
-            f"- Generate summary checkpoints at the fixed {video_description_window_text}"
-            "-second cadence inside the requested generation window, plus the "
+            f"- Generate summary checkpoints at the fixed {video_description_window_unit_text} "
+            "cadence inside the requested generation window, plus the "
             "request end if it is not already on that cadence, using absolute "
             "millisecond offsets from the original video. The first checkpoint is "
             f"the first cadence offset greater than {generation_start_ms}ms; do "
             "not force a checkpoint at 0ms for a chunk that starts later."
         )
         moment_schedule_guidance = (
-            f"- Generate moment contexts centered at the fixed {video_description_window_text}"
-            "-second cadence inside the requested generation window, plus a final "
+            f"- Generate moment contexts centered at the fixed {video_description_window_unit_text} "
+            "cadence inside the requested generation window, plus a final "
             "context centered on the request end if it is not already on that "
             "cadence, using absolute millisecond offsets from the original video."
         )
@@ -1145,7 +1124,7 @@ Also create two top-level context arrays across {context_array_scope}:
 - "moment_contexts": local context windows centered on increasing center_offset_ms values, with separate "before", "at", and "after" fields.
 
 CONTEXT ARRAY GROUNDING:
-- Use a {video_description_window_text}-second context cadence ({video_description_window_ms}ms): summary checkpoints and moment_context centers follow this cadence.
+- Use a {video_description_window_unit_text} context cadence ({video_description_window_ms}ms): summary checkpoints and moment_context centers follow this cadence.
 {context_offset_guidance}
 - Do not choose semantically interesting offsets instead of the fixed cadence.
 - Use the provided transcript and visible video content as the source of truth. You may combine spoken content with observable teaching state, but make conceptual claims only when they are supported by the transcript, visible text, or clearly visible teaching action.
@@ -1492,213 +1471,6 @@ def _question_to_manifest_question(
     )
 
 
-def _fallback_video_descriptions(
-    video_duration_ms: int | None,
-    *,
-    start_offset_ms: int = 0,
-) -> list[schemas.LectureVideoManifestVideoDescriptionV3]:
-    end_offset_ms = max(video_duration_ms or 1, start_offset_ms + 1)
-    return [
-        schemas.LectureVideoManifestVideoDescriptionV3(
-            start_offset_ms=start_offset_ms,
-            end_offset_ms=end_offset_ms,
-            description="Visual descriptions were unavailable for this transcript-only generation pass.",
-        )
-    ]
-
-
-def _video_descriptions_to_manifest_video_descriptions(
-    video_descriptions: list[GeneratedVideoDescription],
-) -> list[schemas.LectureVideoManifestVideoDescriptionV3]:
-    return [
-        schemas.LectureVideoManifestVideoDescriptionV3.model_validate(
-            description.model_dump()
-        )
-        for description in video_descriptions
-    ]
-
-
-def _validate_manifest_video_descriptions(
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    *,
-    start_offset_ms: int = 0,
-    end_offset_ms: int | None,
-    video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> str | None:
-    if len(video_descriptions) == 0:
-        return "video_descriptions is empty"
-    if end_offset_ms is None:
-        return None
-
-    expected_start_offset_ms = start_offset_ms
-    for index, description in enumerate(video_descriptions):
-        if description.start_offset_ms != expected_start_offset_ms:
-            return (
-                f"video_descriptions[{index}] starts at "
-                f"{description.start_offset_ms}ms; expected "
-                f"{expected_start_offset_ms}ms"
-            )
-
-        segment_duration_ms = description.end_offset_ms - description.start_offset_ms
-        is_final_segment = index == len(video_descriptions) - 1
-        if not is_final_segment and segment_duration_ms != video_description_window_ms:
-            return (
-                f"video_descriptions[{index}] duration is "
-                f"{segment_duration_ms}ms; expected "
-                f"{video_description_window_ms}ms"
-            )
-        if is_final_segment and segment_duration_ms > video_description_window_ms:
-            return (
-                f"final video description duration is {segment_duration_ms}ms; "
-                f"expected at most {video_description_window_ms}ms"
-            )
-
-        expected_start_offset_ms = description.end_offset_ms
-
-    final_end_offset_ms = video_descriptions[-1].end_offset_ms
-    if final_end_offset_ms != end_offset_ms:
-        return (
-            f"final video description ends at {final_end_offset_ms}ms; "
-            f"expected video duration {end_offset_ms}ms"
-        )
-    return None
-
-
-def _validated_or_fallback_video_descriptions(
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    *,
-    start_offset_ms: int = 0,
-    end_offset_ms: int | None,
-    video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> list[schemas.LectureVideoManifestVideoDescriptionV3]:
-    validation_error = _validate_manifest_video_descriptions(
-        video_descriptions,
-        start_offset_ms=start_offset_ms,
-        end_offset_ms=end_offset_ms,
-        video_description_window_ms=video_description_window_ms,
-    )
-    if validation_error is None:
-        return video_descriptions
-
-    logger.warning(
-        "Generated video_descriptions failed structural validation: %s. "
-        "Falling back to transcript-only visual description.",
-        validation_error,
-    )
-    return _fallback_video_descriptions(
-        end_offset_ms,
-        start_offset_ms=start_offset_ms,
-    )
-
-
-def _validated_or_fallback_chunk_video_descriptions(
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    *,
-    chunk_index: int,
-    start_offset_ms: int,
-    end_offset_ms: int,
-    video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> list[schemas.LectureVideoManifestVideoDescriptionV3]:
-    validation_error = _validate_manifest_video_descriptions(
-        video_descriptions,
-        start_offset_ms=start_offset_ms,
-        end_offset_ms=end_offset_ms,
-        video_description_window_ms=video_description_window_ms,
-    )
-    if validation_error is None:
-        return video_descriptions
-
-    logger.warning(
-        "Generated chunk video_descriptions failed structural validation: %s. "
-        "chunk_index=%s Falling back for this chunk only.",
-        validation_error,
-        chunk_index,
-    )
-    return _fallback_video_descriptions(
-        end_offset_ms,
-        start_offset_ms=start_offset_ms,
-    )
-
-
-def _normalize_video_descriptions_to_windows(
-    video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3],
-    *,
-    video_duration_ms: int,
-    video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> list[schemas.LectureVideoManifestVideoDescriptionV3]:
-    if video_description_window_ms <= 0:
-        return video_descriptions
-
-    normalized_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3] = []
-    for start_offset_ms in range(0, video_duration_ms, video_description_window_ms):
-        end_offset_ms = min(
-            start_offset_ms + video_description_window_ms,
-            video_duration_ms,
-        )
-        exact_description = next(
-            (
-                description
-                for description in video_descriptions
-                if description.start_offset_ms == start_offset_ms
-                and description.end_offset_ms == end_offset_ms
-            ),
-            None,
-        )
-        if exact_description is not None:
-            normalized_descriptions.append(exact_description)
-            continue
-
-        overlapping_descriptions = [
-            description
-            for description in video_descriptions
-            if description.start_offset_ms < end_offset_ms
-            and description.end_offset_ms > start_offset_ms
-        ]
-        if len(overlapping_descriptions) == 0:
-            normalized_descriptions.extend(
-                _fallback_video_descriptions(
-                    end_offset_ms,
-                    start_offset_ms=start_offset_ms,
-                )
-            )
-            continue
-
-        normalized_descriptions.append(
-            schemas.LectureVideoManifestVideoDescriptionV3(
-                start_offset_ms=start_offset_ms,
-                end_offset_ms=end_offset_ms,
-                description=" ".join(
-                    description.description.strip()
-                    for description in overlapping_descriptions
-                    if description.description.strip()
-                )
-                or "Visual descriptions were unavailable for this transcript-only generation pass.",
-            )
-        )
-
-    validation_error = _validate_manifest_video_descriptions(
-        normalized_descriptions,
-        end_offset_ms=video_duration_ms,
-        video_description_window_ms=video_description_window_ms,
-    )
-    if validation_error is None:
-        return normalized_descriptions
-
-    logger.warning(
-        "Merged video_descriptions failed structural validation after window "
-        "normalization: %s. Falling back to transcript-only visual descriptions.",
-        validation_error,
-    )
-    return [
-        description
-        for start_offset_ms in range(0, video_duration_ms, video_description_window_ms)
-        for description in _fallback_video_descriptions(
-            min(start_offset_ms + video_description_window_ms, video_duration_ms),
-            start_offset_ms=start_offset_ms,
-        )
-    ]
-
-
 def _fallback_summary_checkpoints(
     video_duration_ms: int | None,
 ) -> list[schemas.LectureVideoManifestSummaryCheckpointV4]:
@@ -1710,12 +1482,15 @@ def _fallback_summary_checkpoints(
     ]
 
 
-def _fallback_moment_contexts() -> list[schemas.LectureVideoManifestMomentContextV4]:
+def _fallback_moment_contexts(
+    video_duration_ms: int | None = None,
+) -> list[schemas.LectureVideoManifestMomentContextV4]:
+    end_offset_ms = max(video_duration_ms or 0, 0)
     return [
         schemas.LectureVideoManifestMomentContextV4(
             center_offset_ms=0,
             start_offset_ms=0,
-            end_offset_ms=0,
+            end_offset_ms=end_offset_ms,
             before="No earlier local lecture context is available.",
             at="Local lecture context was unavailable for this generation pass.",
             after="No later local lecture context is available.",
@@ -1845,43 +1620,20 @@ def _normalize_v4_context_arrays(
         logger.warning(
             "Generated moment_contexts was empty; falling back to unavailable moment context."
         )
-        moment_contexts = _fallback_moment_contexts()
+        moment_contexts = _fallback_moment_contexts(video_duration_ms)
     return summary_checkpoints, moment_contexts
 
 
 def _quiz_to_manifest(
-    quiz: GeneratedQuizWithVideoContext | GeneratedQuizWithVideo,
+    quiz: GeneratedQuizWithVideoContext,
     transcript: list[schemas.LectureVideoManifestWordV3],
     *,
     video_duration_ms: int | None,
     video_description_start_offset_ms: int = 0,
     video_description_end_offset_ms: int | None = None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3 | schemas.LectureVideoManifestV4:
+) -> schemas.LectureVideoManifestV4:
     transcript_word_index = _transcript_word_index(transcript)
-    if isinstance(quiz, GeneratedQuizWithVideo):
-        video_descriptions = _video_descriptions_to_manifest_video_descriptions(
-            quiz.video_descriptions
-        )
-        video_descriptions = _validated_or_fallback_video_descriptions(
-            video_descriptions,
-            start_offset_ms=video_description_start_offset_ms,
-            end_offset_ms=(
-                video_description_end_offset_ms
-                if video_description_end_offset_ms is not None
-                else video_duration_ms
-            ),
-            video_description_window_ms=video_description_window_ms,
-        )
-        return schemas.LectureVideoManifestV3(
-            word_level_transcription=transcript,
-            video_descriptions=video_descriptions,
-            questions=[
-                _question_to_manifest_question(question, transcript_word_index)
-                for question in quiz.questions
-            ],
-        )
-
     summary_checkpoints, moment_contexts = _normalize_v4_context_arrays(
         summary_checkpoints=_generated_summary_checkpoints_to_manifest(
             quiz.summary_checkpoints
@@ -2065,76 +1817,7 @@ async def _merge_chunk_manifests(
     full_transcript: list[schemas.LectureVideoManifestWordV3],
     video_duration_ms: int | None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
-) -> schemas.LectureVideoManifestV3 | schemas.LectureVideoManifestV4:
-    if all(
-        isinstance(manifest, schemas.LectureVideoManifestV3)
-        for manifest in chunk_manifests
-    ):
-        v3_chunk_manifests = [
-            manifest
-            for manifest in chunk_manifests
-            if isinstance(manifest, schemas.LectureVideoManifestV3)
-        ]
-        if video_duration_ms is None:
-            video_descriptions = [
-                description
-                for manifest in v3_chunk_manifests
-                for description in manifest.video_descriptions
-            ]
-            video_descriptions = _validated_or_fallback_video_descriptions(
-                video_descriptions,
-                end_offset_ms=video_duration_ms,
-                video_description_window_ms=video_description_window_ms,
-            )
-        else:
-            video_descriptions = []
-            expected_start_offset_ms = 0
-            for index, manifest in enumerate(v3_chunk_manifests):
-                chunk_end_offset_ms = (
-                    video_duration_ms
-                    if index == len(v3_chunk_manifests) - 1
-                    else max(
-                        manifest.video_descriptions[-1].end_offset_ms,
-                        expected_start_offset_ms + 1,
-                    )
-                )
-                chunk_descriptions = _validated_or_fallback_chunk_video_descriptions(
-                    manifest.video_descriptions,
-                    chunk_index=index,
-                    start_offset_ms=expected_start_offset_ms,
-                    end_offset_ms=chunk_end_offset_ms,
-                    video_description_window_ms=video_description_window_ms,
-                )
-                video_descriptions.extend(chunk_descriptions)
-                expected_start_offset_ms = chunk_descriptions[-1].end_offset_ms
-            if expected_start_offset_ms < video_duration_ms:
-                video_descriptions.extend(
-                    _fallback_video_descriptions(
-                        video_duration_ms,
-                        start_offset_ms=expected_start_offset_ms,
-                    )
-                )
-            video_descriptions = _normalize_video_descriptions_to_windows(
-                video_descriptions,
-                video_duration_ms=video_duration_ms,
-                video_description_window_ms=video_description_window_ms,
-            )
-        questions = await _reconcile_chunk_questions(
-            gemini_client=gemini_client,
-            generation_prompt_content=generation_prompt_content,
-            transcript=full_transcript,
-            summary_checkpoints=_fallback_summary_checkpoints(video_duration_ms),
-            moment_contexts=_fallback_moment_contexts(),
-            chunk_manifests=v3_chunk_manifests,  # type: ignore[arg-type]
-            video_duration_ms=video_duration_ms,
-            model=model,
-        )
-        return schemas.LectureVideoManifestV3(
-            word_level_transcription=full_transcript,
-            video_descriptions=video_descriptions,
-            questions=questions,
-        )
-
+) -> schemas.LectureVideoManifestV4:
     summary_checkpoints, moment_contexts = _normalize_v4_context_arrays(
         summary_checkpoints=[
             checkpoint

--- a/pingpong/lecture_video_manifest_generation.py
+++ b/pingpong/lecture_video_manifest_generation.py
@@ -258,8 +258,8 @@ class GeneratedSummaryCheckpoint(BaseModel):
     )
     summary: str = Field(
         description=(
-            "Cumulative summary from the relevant generation scope start "
-            "through end_offset_ms."
+            "Cumulative summary through end_offset_ms, extending any supplied "
+            "prior cumulative summary."
         )
     )
 
@@ -282,7 +282,7 @@ class GeneratedMomentContext(BaseModel):
 
 
 class GeneratedQuizWithVideoContext(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     video_summary: str = Field(description="Brief summary of the lesson.")
     questions: list[GeneratedQuestion] = Field(
@@ -319,6 +319,25 @@ def _manifest_chunk_overlap_ms(video_description_window_ms: int) -> int:
     return max(_MANIFEST_CHUNK_OVERLAP_MS, video_description_window_ms // 2)
 
 
+def _resolve_context_schedule_bounds(
+    *,
+    video_duration_ms: int | None,
+    generation_start_ms: int | None,
+    generation_end_ms: int | None,
+    video_description_window_ms: int,
+) -> tuple[int, int] | None:
+    if video_description_window_ms <= 0:
+        return None
+    effective_end_ms = (
+        generation_end_ms if generation_end_ms is not None else video_duration_ms
+    )
+    if effective_end_ms is None:
+        return None
+    effective_start_ms = max(generation_start_ms or 0, 0)
+    effective_end_ms = max(effective_end_ms, 0)
+    return effective_start_ms, effective_end_ms
+
+
 def _scheduled_summary_checkpoint_offsets(
     *,
     video_duration_ms: int | None,
@@ -326,15 +345,15 @@ def _scheduled_summary_checkpoint_offsets(
     generation_end_ms: int | None,
     video_description_window_ms: int,
 ) -> list[int]:
-    if video_description_window_ms <= 0:
-        return []
-    effective_end_ms = (
-        generation_end_ms if generation_end_ms is not None else video_duration_ms
+    bounds = _resolve_context_schedule_bounds(
+        video_duration_ms=video_duration_ms,
+        generation_start_ms=generation_start_ms,
+        generation_end_ms=generation_end_ms,
+        video_description_window_ms=video_description_window_ms,
     )
-    if effective_end_ms is None:
+    if bounds is None:
         return []
-    effective_start_ms = max(generation_start_ms or 0, 0)
-    effective_end_ms = max(effective_end_ms, 0)
+    effective_start_ms, effective_end_ms = bounds
     if effective_end_ms <= effective_start_ms:
         return []
     first_offset_ms = (
@@ -355,15 +374,15 @@ def _scheduled_moment_context_windows(
     generation_end_ms: int | None,
     video_description_window_ms: int,
 ) -> list[tuple[int, int, int]]:
-    if video_description_window_ms <= 0:
-        return []
-    effective_end_ms = (
-        generation_end_ms if generation_end_ms is not None else video_duration_ms
+    bounds = _resolve_context_schedule_bounds(
+        video_duration_ms=video_duration_ms,
+        generation_start_ms=generation_start_ms,
+        generation_end_ms=generation_end_ms,
+        video_description_window_ms=video_description_window_ms,
     )
-    if effective_end_ms is None:
+    if bounds is None:
         return []
-    effective_start_ms = max(generation_start_ms or 0, 0)
-    effective_end_ms = max(effective_end_ms, 0)
+    effective_start_ms, effective_end_ms = bounds
     if effective_end_ms < effective_start_ms:
         return []
     if effective_start_ms == 0:
@@ -969,6 +988,8 @@ def build_generation_prompt(
     context_start_ms: int | None = None,
     context_end_ms: int | None = None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
+    previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+    | None = None,
 ) -> str:
     if compact:
         transcript_text = "\n".join(
@@ -1022,8 +1043,12 @@ def build_generation_prompt(
         else ""
     )
     generation_window_text = ""
+    previous_summary_text = ""
     context_array_scope = "the whole video"
     chunk_moment_boundary_guidance = ""
+    summary_cumulative_guidance = (
+        f"- Each summary must be cumulative over {context_array_summary_scope}."
+    )
     context_offset_guidance = (
         "- Use absolute millisecond offsets from the original video for every "
         "summary end_offset_ms and every moment center_offset_ms, start_offset_ms, "
@@ -1038,6 +1063,11 @@ def build_generation_prompt(
         context_array_scope = "the requested generation window"
         context_array_summary_scope = (
             f"{generation_start_ms}ms through each end_offset_ms"
+        )
+        summary_cumulative_guidance = (
+            "- Each summary must be cumulative from the requested generation start "
+            "through end_offset_ms; do not claim to summarize unseen earlier video "
+            "content."
         )
         summary_schedule_guidance = (
             f"- Generate summary checkpoints at the fixed {video_description_window_unit_text} "
@@ -1089,6 +1119,25 @@ def build_generation_prompt(
             "must use absolute offsets from the original video, and should only "
             "cover the requested generation window."
         )
+        if previous_summary_checkpoint is not None:
+            context_array_summary_scope = (
+                "the full lecture so far at each end_offset_ms"
+            )
+            previous_summary_text = (
+                "\nPRIOR CUMULATIVE SUMMARY:\n"
+                "The previous generated chunk summarized the lecture through "
+                f"{previous_summary_checkpoint.end_offset_ms}ms:\n"
+                f"{previous_summary_checkpoint.summary}\n\n"
+                "Use this as the only source for lecture content before "
+                f"{generation_start_ms}ms. Do not invent or infer earlier content "
+                "beyond this prior summary.\n"
+            )
+            summary_cumulative_guidance = (
+                "- Each summary must be cumulative for the full lecture so far: "
+                "start from the supplied prior cumulative summary, then add only "
+                "content supported by this chunk's transcript/video through "
+                "end_offset_ms."
+            )
         context_window_text = (
             f" The provided video clip covers absolute offsets "
             f"{context_start_ms}ms through {context_end_ms}ms."
@@ -1109,6 +1158,7 @@ Generate "summary_checkpoints" and "moment_contexts" for offsets inside {generat
 
 You will be given a lecture video and a word-level transcript. {transcript_description}{duration_text}
 {generation_window_text}
+{previous_summary_text}
 
 Here's the WORD-LEVEL TRANSCRIPT:
 {transcript_text}
@@ -1132,7 +1182,7 @@ CONTEXT ARRAY GROUNDING:
 SUMMARY CHECKPOINT GUIDELINES:
 {summary_schedule_guidance}
 - Do not skip the first required checkpoint for this generation scope.
-- Each summary must be cumulative over {context_array_summary_scope}. For a chunked request, summarize from the requested generation start through end_offset_ms; do not claim to summarize unseen earlier video content.
+{summary_cumulative_guidance}
 
 MOMENT CONTEXT GUIDELINES:
 {moment_schedule_guidance}
@@ -1326,7 +1376,7 @@ FIELD DEFINITIONS:
   - "resume_at": The "start" timestamp of the resume word. Copied exactly from the transcript — do not round or modify.
 - "summary_checkpoints": Array of cumulative summaries. Each entry contains:
   - "end_offset_ms": Integer millisecond offset through which this summary applies.
-  - "summary": Non-empty cumulative summary from the relevant generation scope start through end_offset_ms.
+  - "summary": Non-empty cumulative summary through end_offset_ms, extending any supplied prior cumulative summary.
 - "moment_contexts": Array of local context windows. Each entry contains:
   - "center_offset_ms": Integer millisecond offset used to select this local context.
   - "start_offset_ms": Integer millisecond offset where the local window starts.
@@ -1704,6 +1754,20 @@ def _manifest_question_to_reconciliation_candidate(
     }
 
 
+def _latest_summary_checkpoint(
+    manifests: list[schemas.LectureVideoManifestV4],
+    fallback: schemas.LectureVideoManifestSummaryCheckpointV4 | None = None,
+) -> schemas.LectureVideoManifestSummaryCheckpointV4 | None:
+    checkpoints = [
+        checkpoint
+        for manifest in manifests
+        for checkpoint in manifest.summary_checkpoints
+    ]
+    if not checkpoints:
+        return fallback
+    return max(checkpoints, key=lambda checkpoint: checkpoint.end_offset_ms)
+
+
 def _reconciliation_prompt(generation_prompt_content: str) -> str:
     return f"""You are an expert educational content designer reconciling independently generated interactive question candidates from chunks of one lecture video.
 
@@ -1864,6 +1928,8 @@ async def _generate_manifest_from_gemini_file(
     context_start_ms: int | None = None,
     context_end_ms: int | None = None,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
+    previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+    | None = None,
 ) -> schemas.LectureVideoManifestV4:
     prompt = build_generation_prompt(
         generation_prompt_content,
@@ -1875,6 +1941,7 @@ async def _generate_manifest_from_gemini_file(
         context_start_ms=context_start_ms,
         context_end_ms=context_end_ms,
         video_description_window_ms=video_description_window_ms,
+        previous_summary_checkpoint=previous_summary_checkpoint,
     )
     request_label = (
         "manifest_chunk_compact"
@@ -2000,6 +2067,8 @@ async def _upload_and_generate_manifest_chunk(
     temp_dir: str,
     model: str,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
+    previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+    | None = None,
 ) -> schemas.LectureVideoManifestV4:
     chunk_transcript = _transcript_for_window(
         transcript,
@@ -2040,6 +2109,7 @@ async def _upload_and_generate_manifest_chunk(
                 context_start_ms=chunk.context_start_ms,
                 context_end_ms=chunk.context_end_ms,
                 video_description_window_ms=video_description_window_ms,
+                previous_summary_checkpoint=previous_summary_checkpoint,
             )
         except Exception as exc:
             if not _is_context_limit_error(exc):
@@ -2057,6 +2127,7 @@ async def _upload_and_generate_manifest_chunk(
                 context_start_ms=chunk.context_start_ms,
                 context_end_ms=chunk.context_end_ms,
                 video_description_window_ms=video_description_window_ms,
+                previous_summary_checkpoint=previous_summary_checkpoint,
             )
         manifest.questions = _filter_questions_for_window(
             manifest.questions,
@@ -2086,6 +2157,8 @@ async def _upload_and_generate_manifest_chunks(
     model: str,
     video_description_window_ms: int = DEFAULT_VIDEO_DESCRIPTION_DURATION_MS,
     overlap_ms: int = _MANIFEST_CHUNK_OVERLAP_MS,
+    previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+    | None = None,
 ) -> list[schemas.LectureVideoManifestV4]:
     try:
         return [
@@ -2099,6 +2172,7 @@ async def _upload_and_generate_manifest_chunks(
                 temp_dir=temp_dir,
                 model=model,
                 video_description_window_ms=video_description_window_ms,
+                previous_summary_checkpoint=previous_summary_checkpoint,
             )
         ]
     except Exception as exc:
@@ -2121,20 +2195,25 @@ async def _upload_and_generate_manifest_chunks(
             child_chunks[0].generation_end_ms,
         )
         chunk_manifests: list[schemas.LectureVideoManifestV4] = []
+        current_summary_checkpoint = previous_summary_checkpoint
         for child_chunk in child_chunks:
-            chunk_manifests.extend(
-                await _upload_and_generate_manifest_chunks(
-                    video_path=video_path,
-                    gemini_client=gemini_client,
-                    generation_prompt_content=generation_prompt_content,
-                    transcript=transcript,
-                    video_duration_ms=video_duration_ms,
-                    chunk=child_chunk,
-                    temp_dir=temp_dir,
-                    model=model,
-                    video_description_window_ms=video_description_window_ms,
-                    overlap_ms=overlap_ms,
-                )
+            child_manifests = await _upload_and_generate_manifest_chunks(
+                video_path=video_path,
+                gemini_client=gemini_client,
+                generation_prompt_content=generation_prompt_content,
+                transcript=transcript,
+                video_duration_ms=video_duration_ms,
+                chunk=child_chunk,
+                temp_dir=temp_dir,
+                model=model,
+                video_description_window_ms=video_description_window_ms,
+                overlap_ms=overlap_ms,
+                previous_summary_checkpoint=current_summary_checkpoint,
+            )
+            chunk_manifests.extend(child_manifests)
+            current_summary_checkpoint = _latest_summary_checkpoint(
+                child_manifests,
+                current_summary_checkpoint,
             )
         return chunk_manifests
 
@@ -2194,20 +2273,27 @@ async def upload_and_generate_manifest(
         len(chunks),
     )
     chunk_manifests: list[schemas.LectureVideoManifestV4] = []
+    current_summary_checkpoint: (
+        schemas.LectureVideoManifestSummaryCheckpointV4 | None
+    ) = None
     for chunk in chunks:
-        chunk_manifests.extend(
-            await _upload_and_generate_manifest_chunks(
-                video_path=video_path,
-                gemini_client=gemini_client,
-                generation_prompt_content=generation_prompt_content,
-                transcript=transcript,
-                video_duration_ms=video_duration_ms or chunk.generation_end_ms,
-                chunk=chunk,
-                temp_dir=temp_dir,
-                model=model,
-                video_description_window_ms=video_description_window_ms,
-                overlap_ms=overlap_ms,
-            )
+        generated_chunk_manifests = await _upload_and_generate_manifest_chunks(
+            video_path=video_path,
+            gemini_client=gemini_client,
+            generation_prompt_content=generation_prompt_content,
+            transcript=transcript,
+            video_duration_ms=video_duration_ms or chunk.generation_end_ms,
+            chunk=chunk,
+            temp_dir=temp_dir,
+            model=model,
+            video_description_window_ms=video_description_window_ms,
+            overlap_ms=overlap_ms,
+            previous_summary_checkpoint=current_summary_checkpoint,
+        )
+        chunk_manifests.extend(generated_chunk_manifests)
+        current_summary_checkpoint = _latest_summary_checkpoint(
+            generated_chunk_manifests,
+            current_summary_checkpoint,
         )
     return await _merge_chunk_manifests(
         gemini_client=gemini_client,

--- a/pingpong/lecture_video_processing.py
+++ b/pingpong/lecture_video_processing.py
@@ -604,7 +604,7 @@ async def _write_video_to_temp_path(
 async def _complete_manifest_generation_run(
     run_id: int,
     lease_token: str,
-    manifest: schemas.LectureVideoManifestV3,
+    manifest: schemas.LectureVideoManifestV4,
 ) -> None:
     async with config.db.driver.async_session() as session:
         run = await models.LectureVideoProcessingRun.get_by_id(session, run_id)
@@ -903,11 +903,13 @@ async def _upload_and_generate_manifest(
             return
         logger.info(
             "Lecture video manifest generated. run_id=%s "
-            "lecture_video_id=%s question_count=%s video_description_count=%s",
+            "lecture_video_id=%s question_count=%s summary_checkpoint_count=%s "
+            "moment_context_count=%s",
             run_id,
             lecture_video_id,
             len(manifest.questions),
-            len(manifest.video_descriptions),
+            len(manifest.summary_checkpoints),
+            len(manifest.moment_contexts),
         )
         logger.info(
             "Lecture video manifest persisting. run_id=%s lecture_video_id=%s",

--- a/pingpong/lecture_video_runtime.py
+++ b/pingpong/lecture_video_runtime.py
@@ -335,7 +335,7 @@ def _normalize_interaction_time(timestamp: datetime | None) -> datetime | None:
     return timestamp
 
 
-async def _get_plausible_playback_offset_ms(
+async def get_plausible_playback_offset_ms(
     session: AsyncSession,
     state: models.LectureVideoThreadState,
     *,
@@ -738,7 +738,7 @@ async def _handle_question_presented(
             "Question presentation must occur at the configured stop offset."
         )
 
-    plausible_offset_ms = await _get_plausible_playback_offset_ms(
+    plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, current_time=current_time
     )
     if request.offset_ms > plausible_offset_ms:
@@ -810,7 +810,7 @@ async def _handle_resumed(
         schemas.LectureVideoSessionState.PLAYING,
         schemas.LectureVideoSessionState.COMPLETED,
     }:
-        plausible_offset_ms = await _get_plausible_playback_offset_ms(
+        plausible_offset_ms = await get_plausible_playback_offset_ms(
             session, state, current_time=current_time
         )
         if request.offset_ms > plausible_offset_ms:
@@ -881,7 +881,7 @@ async def _handle_paused(
     current_time: datetime,
 ) -> None:
     _require_playing_state_for_playback_event(state)
-    plausible_offset_ms = await _get_plausible_playback_offset_ms(
+    plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, current_time=current_time
     )
     if request.offset_ms > plausible_offset_ms:
@@ -908,7 +908,7 @@ async def _handle_seeked(
     current_time: datetime,
 ) -> None:
     _require_playing_state_for_playback_event(state)
-    plausible_offset_ms = await _get_plausible_playback_offset_ms(
+    plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, current_time=current_time
     )
     if request.to_offset_ms > plausible_offset_ms:
@@ -941,7 +941,7 @@ async def _handle_ended(
     current_time: datetime,
 ) -> None:
     _require_playing_state_for_playback_event(state)
-    plausible_offset_ms = await _get_plausible_playback_offset_ms(
+    plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, current_time=current_time
     )
     if request.offset_ms > plausible_offset_ms:

--- a/pingpong/lecture_video_service.py
+++ b/pingpong/lecture_video_service.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 from dataclasses import dataclass
+from typing import Literal
 
 import humanize
 from fastapi import HTTPException, UploadFile
@@ -31,14 +32,29 @@ _V3_TRANSCRIPT_ADAPTER = TypeAdapter(list[schemas.LectureVideoManifestWordV3])
 
 
 @dataclass(frozen=True)
-class LectureVideoChatContext:
-    version: int
+class LectureVideoChatContextV2:
+    version: Literal[2]
+    word_level_transcription: list[schemas.LectureVideoManifestWordV3]
+
+
+@dataclass(frozen=True)
+class LectureVideoChatContextV3:
+    version: Literal[3]
     word_level_transcription: list[schemas.LectureVideoManifestWordV3]
     video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3]
-    summary_checkpoints: (
-        list[schemas.LectureVideoManifestSummaryCheckpointV4] | None
-    ) = None
-    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4] | None = None
+
+
+@dataclass(frozen=True)
+class LectureVideoChatContextV4:
+    version: Literal[4]
+    word_level_transcription: list[schemas.LectureVideoManifestWordV3]
+    summary_checkpoints: list[schemas.LectureVideoManifestSummaryCheckpointV4]
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4]
+
+
+LectureVideoChatContext = (
+    LectureVideoChatContextV2 | LectureVideoChatContextV3 | LectureVideoChatContextV4
+)
 
 
 def get_upload_size(upload: UploadFile) -> int:
@@ -297,15 +313,15 @@ def lecture_video_manifest_from_model(
         return base_manifest
 
     manifest_context = _hydrate_stored_manifest_context(lecture_video)
-    if manifest_context is None or manifest_context.version == 1:
+    if manifest_context is None:
         return base_manifest
 
     if manifest_context.version == 4:
         return schemas.LectureVideoManifestV4(
             questions=base_manifest.questions,
             word_level_transcription=manifest_context.word_level_transcription,
-            summary_checkpoints=manifest_context.summary_checkpoints or [],
-            moment_contexts=manifest_context.moment_contexts or [],
+            summary_checkpoints=manifest_context.summary_checkpoints,
+            moment_contexts=manifest_context.moment_contexts,
         )
 
     if manifest_context.version == 3:
@@ -448,10 +464,9 @@ def _hydrate_stored_manifest_context(
         if version == 1:
             return None
         if version == 2 and transcript is not None:
-            return LectureVideoChatContext(
+            return LectureVideoChatContextV2(
                 version=2,
                 word_level_transcription=transcript,
-                video_descriptions=[],
             )
         if version == 3 and transcript is not None:
             video_descriptions = [
@@ -460,7 +475,7 @@ def _hydrate_stored_manifest_context(
                 )
                 for description in manifest_data.get("video_descriptions") or []
             ]
-            return LectureVideoChatContext(
+            return LectureVideoChatContextV3(
                 version=3,
                 word_level_transcription=transcript,
                 video_descriptions=video_descriptions,
@@ -476,10 +491,9 @@ def _hydrate_stored_manifest_context(
                 schemas.LectureVideoManifestMomentContextV4.model_validate(moment)
                 for moment in manifest_data.get("moment_contexts") or []
             ]
-            return LectureVideoChatContext(
+            return LectureVideoChatContextV4(
                 version=4,
                 word_level_transcription=transcript,
-                video_descriptions=[],
                 summary_checkpoints=summary_checkpoints,
                 moment_contexts=moment_contexts,
             )
@@ -491,23 +505,21 @@ def _hydrate_stored_manifest_context(
     if legacy_transcript is None:
         return None
     if isinstance(manifest, schemas.LectureVideoManifestV3):
-        return LectureVideoChatContext(
+        return LectureVideoChatContextV3(
             version=3,
             word_level_transcription=legacy_transcript,
             video_descriptions=manifest.video_descriptions,
         )
     if isinstance(manifest, schemas.LectureVideoManifestV4):
-        return LectureVideoChatContext(
+        return LectureVideoChatContextV4(
             version=4,
             word_level_transcription=legacy_transcript,
-            video_descriptions=[],
             summary_checkpoints=manifest.summary_checkpoints,
             moment_contexts=manifest.moment_contexts,
         )
-    return LectureVideoChatContext(
+    return LectureVideoChatContextV2(
         version=2,
         word_level_transcription=legacy_transcript,
-        video_descriptions=[],
     )
 
 

--- a/pingpong/lecture_video_service.py
+++ b/pingpong/lecture_video_service.py
@@ -491,6 +491,12 @@ def _hydrate_stored_manifest_context(
                 schemas.LectureVideoManifestMomentContextV4.model_validate(moment)
                 for moment in manifest_data.get("moment_contexts") or []
             ]
+            summary_checkpoints, moment_contexts = (
+                schemas.normalize_lecture_video_manifest_v4_context_arrays(
+                    summary_checkpoints,
+                    moment_contexts,
+                )
+            )
             return LectureVideoChatContextV4(
                 version=4,
                 word_level_transcription=transcript,

--- a/pingpong/lecture_video_service.py
+++ b/pingpong/lecture_video_service.py
@@ -23,7 +23,7 @@ LECTURE_VIDEO_ALREADY_ASSIGNED_DETAIL = (
     "Upload a new lecture video or copy the assistant instead."
 )
 LECTURE_VIDEO_CHAT_UNAVAILABLE_NOTE = (
-    "Lecture chat is only available for lecture videos with a version 2 or 3 manifest "
+    "Lecture chat is only available for lecture videos with a version 2, 3, or 4 manifest "
     "that includes word-level transcription."
 )
 
@@ -35,6 +35,10 @@ class LectureVideoChatContext:
     version: int
     word_level_transcription: list[schemas.LectureVideoManifestWordV3]
     video_descriptions: list[schemas.LectureVideoManifestVideoDescriptionV3]
+    summary_checkpoints: (
+        list[schemas.LectureVideoManifestSummaryCheckpointV4] | None
+    ) = None
+    moment_contexts: list[schemas.LectureVideoManifestMomentContextV4] | None = None
 
 
 def get_upload_size(upload: UploadFile) -> int:
@@ -296,6 +300,14 @@ def lecture_video_manifest_from_model(
     if manifest_context is None or manifest_context.version == 1:
         return base_manifest
 
+    if manifest_context.version == 4:
+        return schemas.LectureVideoManifestV4(
+            questions=base_manifest.questions,
+            word_level_transcription=manifest_context.word_level_transcription,
+            summary_checkpoints=manifest_context.summary_checkpoints or [],
+            moment_contexts=manifest_context.moment_contexts or [],
+        )
+
     if manifest_context.version == 3:
         return schemas.LectureVideoManifestV3(
             questions=base_manifest.questions,
@@ -346,7 +358,9 @@ def _v3_manifest_words_to_v2(
 def _manifest_transcript_as_v3(
     manifest: schemas.LectureVideoManifest,
 ) -> list[schemas.LectureVideoManifestWordV3] | None:
-    if isinstance(manifest, schemas.LectureVideoManifestV3):
+    if isinstance(
+        manifest, (schemas.LectureVideoManifestV3, schemas.LectureVideoManifestV4)
+    ):
         return manifest.word_level_transcription
     if isinstance(manifest, schemas.LectureVideoManifestV2):
         return _v2_manifest_words_to_v3(manifest.word_level_transcription)
@@ -391,6 +405,17 @@ def _stored_manifest_extras(
             "video_descriptions": [
                 description.model_dump(mode="json")
                 for description in manifest.video_descriptions
+            ],
+        }
+    if isinstance(manifest, schemas.LectureVideoManifestV4):
+        return {
+            "version": 4,
+            "summary_checkpoints": [
+                checkpoint.model_dump(mode="json")
+                for checkpoint in manifest.summary_checkpoints
+            ],
+            "moment_contexts": [
+                moment.model_dump(mode="json") for moment in manifest.moment_contexts
             ],
         }
     return {"version": manifest.version}
@@ -440,6 +465,24 @@ def _hydrate_stored_manifest_context(
                 word_level_transcription=transcript,
                 video_descriptions=video_descriptions,
             )
+        if version == 4 and transcript is not None:
+            summary_checkpoints = [
+                schemas.LectureVideoManifestSummaryCheckpointV4.model_validate(
+                    checkpoint
+                )
+                for checkpoint in manifest_data.get("summary_checkpoints") or []
+            ]
+            moment_contexts = [
+                schemas.LectureVideoManifestMomentContextV4.model_validate(moment)
+                for moment in manifest_data.get("moment_contexts") or []
+            ]
+            return LectureVideoChatContext(
+                version=4,
+                word_level_transcription=transcript,
+                video_descriptions=[],
+                summary_checkpoints=summary_checkpoints,
+                moment_contexts=moment_contexts,
+            )
 
     manifest = schemas.validate_lecture_video_manifest(manifest_data)
     if manifest is None or manifest.version == 1:
@@ -452,6 +495,14 @@ def _hydrate_stored_manifest_context(
             version=3,
             word_level_transcription=legacy_transcript,
             video_descriptions=manifest.video_descriptions,
+        )
+    if isinstance(manifest, schemas.LectureVideoManifestV4):
+        return LectureVideoChatContext(
+            version=4,
+            word_level_transcription=legacy_transcript,
+            video_descriptions=[],
+            summary_checkpoints=manifest.summary_checkpoints,
+            moment_contexts=manifest.moment_contexts,
         )
     return LectureVideoChatContext(
         version=2,
@@ -472,7 +523,7 @@ def lecture_video_chat_metadata(
     if lecture_video is None:
         return False
 
-    if lecture_video.manifest_version not in {2, 3}:
+    if lecture_video.manifest_version not in {2, 3, 4}:
         return False
 
     return lecture_video.lecture_video_chat_available
@@ -905,7 +956,11 @@ async def persist_manifest(
     lecture_video.lecture_video_chat_available = (
         isinstance(
             lecture_video_manifest,
-            (schemas.LectureVideoManifestV2, schemas.LectureVideoManifestV3),
+            (
+                schemas.LectureVideoManifestV2,
+                schemas.LectureVideoManifestV3,
+                schemas.LectureVideoManifestV4,
+            ),
         )
         and transcript is not None
         and len(transcript) > 0

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -8161,21 +8161,41 @@ class Thread(Base):
         session: AsyncSession,
         thread_id: int,
         roles: Collection[schemas.MessageRole] | None = None,
-        include_current_run_developer_messages_for_run_id: int | None = None,
     ) -> AsyncGenerator["Message", None]:
         filters = [Message.thread_id == thread_id]
         if roles is not None:
-            role_filter = Message.role.in_(roles)
-            if include_current_run_developer_messages_for_run_id is not None:
-                role_filter = or_(
-                    role_filter,
-                    and_(
-                        Message.run_id
-                        == include_current_run_developer_messages_for_run_id,
-                        Message.role == schemas.MessageRole.DEVELOPER,
-                    ),
-                )
-            filters.append(role_filter)
+            filters.append(Message.role.in_(roles))
+        async for message in cls._list_messages_with_filters_gen(session, filters):
+            yield message
+
+    @classmethod
+    async def list_user_assistant_messages_with_run_developer_gen(
+        cls,
+        session: AsyncSession,
+        thread_id: int,
+        run_id: int,
+    ) -> AsyncGenerator["Message", None]:
+        filters = [
+            Message.thread_id == thread_id,
+            or_(
+                Message.role.in_(
+                    [schemas.MessageRole.USER, schemas.MessageRole.ASSISTANT]
+                ),
+                and_(
+                    Message.run_id == run_id,
+                    Message.role == schemas.MessageRole.DEVELOPER,
+                ),
+            ),
+        ]
+        async for message in cls._list_messages_with_filters_gen(session, filters):
+            yield message
+
+    @classmethod
+    async def _list_messages_with_filters_gen(
+        cls,
+        session: AsyncSession,
+        filters: Sequence[Any],
+    ) -> AsyncGenerator["Message", None]:
         stmt = (
             select(Message)
             .where(*filters)

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -8160,10 +8160,25 @@ class Thread(Base):
         cls,
         session: AsyncSession,
         thread_id: int,
+        roles: Collection[schemas.MessageRole] | None = None,
+        include_current_run_developer_messages_for_run_id: int | None = None,
     ) -> AsyncGenerator["Message", None]:
+        filters = [Message.thread_id == thread_id]
+        if roles is not None:
+            role_filter = Message.role.in_(roles)
+            if include_current_run_developer_messages_for_run_id is not None:
+                role_filter = or_(
+                    role_filter,
+                    and_(
+                        Message.run_id
+                        == include_current_run_developer_messages_for_run_id,
+                        Message.role == schemas.MessageRole.DEVELOPER,
+                    ),
+                )
+            filters.append(role_filter)
         stmt = (
             select(Message)
-            .where(Message.thread_id == thread_id)
+            .where(*filters)
             .options(
                 selectinload(Message.content).selectinload(MessagePart.annotations),
                 selectinload(Message.file_search_attachments),

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1611,7 +1611,7 @@ class NewThreadMessage(BaseModel):
     vision_image_descriptions: list[ImageProxy] = Field([])
     timezone: str | None = None
     generate_speech: bool | None = None
-    lecture_video_playback_position_ms: Any | None = None
+    lecture_video_playback_position_ms: int | None = None
 
     _file_check = model_validator(mode="after")(file_validator)
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -615,6 +615,30 @@ class LectureVideoManifestMomentContextV4(BaseModel):
         return self
 
 
+def normalize_lecture_video_manifest_v4_context_arrays(
+    summary_checkpoints: list[LectureVideoManifestSummaryCheckpointV4],
+    moment_contexts: list[LectureVideoManifestMomentContextV4],
+) -> tuple[
+    list[LectureVideoManifestSummaryCheckpointV4],
+    list[LectureVideoManifestMomentContextV4],
+]:
+    summary_checkpoints = sorted(
+        {
+            checkpoint.end_offset_ms: checkpoint for checkpoint in summary_checkpoints
+        }.values(),
+        key=lambda item: item.end_offset_ms,
+    )
+    moment_contexts = sorted(
+        {moment.center_offset_ms: moment for moment in moment_contexts}.values(),
+        key=lambda item: item.center_offset_ms,
+    )
+    if not summary_checkpoints:
+        raise ValueError("summary_checkpoints must not be empty")
+    if not moment_contexts:
+        raise ValueError("moment_contexts must not be empty")
+    return summary_checkpoints, moment_contexts
+
+
 class LectureVideoManifestV3(LectureVideoManifestBase):
     version: Literal[3] = 3
     word_level_transcription: list[LectureVideoManifestWordV3] = Field(
@@ -647,23 +671,12 @@ class LectureVideoManifestV4(LectureVideoManifestBase):
 
     @model_validator(mode="after")
     def normalize_context_arrays(self) -> "LectureVideoManifestV4":
-        self.summary_checkpoints = sorted(
-            {
-                checkpoint.end_offset_ms: checkpoint
-                for checkpoint in self.summary_checkpoints
-            }.values(),
-            key=lambda item: item.end_offset_ms,
+        self.summary_checkpoints, self.moment_contexts = (
+            normalize_lecture_video_manifest_v4_context_arrays(
+                self.summary_checkpoints,
+                self.moment_contexts,
+            )
         )
-        self.moment_contexts = sorted(
-            {
-                moment.center_offset_ms: moment for moment in self.moment_contexts
-            }.values(),
-            key=lambda item: item.center_offset_ms,
-        )
-        if not self.summary_checkpoints:
-            raise ValueError("summary_checkpoints must not be empty")
-        if not self.moment_contexts:
-            raise ValueError("moment_contexts must not be empty")
         return self
 
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -577,6 +577,44 @@ class LectureVideoManifestVideoDescriptionV3(BaseModel):
         return self
 
 
+class LectureVideoManifestSummaryCheckpointV4(BaseModel):
+    end_offset_ms: int = Field(..., ge=0)
+    summary: str = Field(..., min_length=1)
+
+    @field_validator("summary")
+    @classmethod
+    def strip_summary(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("summary must not be empty")
+        return value
+
+
+class LectureVideoManifestMomentContextV4(BaseModel):
+    center_offset_ms: int = Field(..., ge=0)
+    start_offset_ms: int = Field(..., ge=0)
+    end_offset_ms: int = Field(..., ge=0)
+    before: str = Field(..., min_length=1)
+    at: str = Field(..., min_length=1)
+    after: str = Field(..., min_length=1)
+
+    @field_validator("before", "at", "after")
+    @classmethod
+    def strip_text(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("context text must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "LectureVideoManifestMomentContextV4":
+        if not self.start_offset_ms <= self.center_offset_ms <= self.end_offset_ms:
+            raise ValueError(
+                "start_offset_ms <= center_offset_ms <= end_offset_ms is required"
+            )
+        return self
+
+
 class LectureVideoManifestV3(LectureVideoManifestBase):
     version: Literal[3] = 3
     word_level_transcription: list[LectureVideoManifestWordV3] = Field(
@@ -595,9 +633,50 @@ class LectureVideoManifestV3(LectureVideoManifestBase):
         return self
 
 
+class LectureVideoManifestV4(LectureVideoManifestBase):
+    version: Literal[4] = 4
+    word_level_transcription: list[LectureVideoManifestWordV3] = Field(
+        ..., min_length=1
+    )
+    summary_checkpoints: list[LectureVideoManifestSummaryCheckpointV4] = Field(
+        ..., min_length=1
+    )
+    moment_contexts: list[LectureVideoManifestMomentContextV4] = Field(
+        ..., min_length=1
+    )
+
+    @model_validator(mode="after")
+    def normalize_context_arrays(self) -> "LectureVideoManifestV4":
+        self.summary_checkpoints = sorted(
+            {
+                checkpoint.end_offset_ms: checkpoint
+                for checkpoint in self.summary_checkpoints
+            }.values(),
+            key=lambda item: item.end_offset_ms,
+        )
+        self.moment_contexts = sorted(
+            {
+                moment.center_offset_ms: moment for moment in self.moment_contexts
+            }.values(),
+            key=lambda item: item.center_offset_ms,
+        )
+        if not self.summary_checkpoints:
+            raise ValueError("summary_checkpoints must not be empty")
+        if not self.moment_contexts:
+            raise ValueError("moment_contexts must not be empty")
+        return self
+
+
 LectureVideoManifest: TypeAlias = (
-    LectureVideoManifestV1 | LectureVideoManifestV2 | LectureVideoManifestV3
+    LectureVideoManifestV1
+    | LectureVideoManifestV2
+    | LectureVideoManifestV3
+    | LectureVideoManifestV4
 )
+
+
+def _looks_like_lecture_video_manifest_v4(value: dict[str, Any]) -> bool:
+    return "summary_checkpoints" in value or "moment_contexts" in value
 
 
 def _looks_like_lecture_video_manifest_v3(value: dict[str, Any]) -> bool:
@@ -628,7 +707,12 @@ def validate_lecture_video_manifest(
 ) -> LectureVideoManifest | None:
     if lecture_video_manifest is None or isinstance(
         lecture_video_manifest,
-        (LectureVideoManifestV1, LectureVideoManifestV2, LectureVideoManifestV3),
+        (
+            LectureVideoManifestV1,
+            LectureVideoManifestV2,
+            LectureVideoManifestV3,
+            LectureVideoManifestV4,
+        ),
     ):
         return lecture_video_manifest
     try:
@@ -637,6 +721,14 @@ def validate_lecture_video_manifest(
             if isinstance(lecture_video_manifest, dict)
             else None
         )
+        if version == 4 or (
+            version is None
+            # V4 is inferred only from V4-only context fields. Explicit
+            # versioned payloads still validate against their own contract.
+            and isinstance(lecture_video_manifest, dict)
+            and _looks_like_lecture_video_manifest_v4(lecture_video_manifest)
+        ):
+            return LectureVideoManifestV4.model_validate(lecture_video_manifest)
         if version == 3 or (
             version is None
             # Only infer V3 for legacy manifests without an explicit version;
@@ -1519,6 +1611,7 @@ class NewThreadMessage(BaseModel):
     vision_image_descriptions: list[ImageProxy] = Field([])
     timezone: str | None = None
     generate_speech: bool | None = None
+    lecture_video_playback_position_ms: Any | None = None
 
     _file_check = model_validator(mode="after")(file_validator)
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -8101,8 +8101,8 @@ async def send_message(
                 response_safety_identifier=request.state["response_safety_identifier"],
                 tts_voice_id=tts_voice_id,
                 tts_api_key=tts_api_key,
-                filter_prior_hidden_messages=(
-                    lecture_chat_prep.filter_prior_hidden_messages
+                user_assistant_messages_only=(
+                    lecture_chat_prep.user_assistant_messages_only
                     if lecture_chat_prep is not None
                     else False
                 ),

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -7941,6 +7941,9 @@ async def send_message(
                     thread=thread,
                     user_id=request.state["session"].user.id,
                     prev_output_sequence=prev_output_sequence,
+                    lecture_video_playback_position_ms=(
+                        data.lecture_video_playback_position_ms
+                    ),
                 )
 
             # Resolve TTS credentials for lecture-video chat audio streaming.
@@ -8098,6 +8101,11 @@ async def send_message(
                 response_safety_identifier=request.state["response_safety_identifier"],
                 tts_voice_id=tts_voice_id,
                 tts_api_key=tts_api_key,
+                filter_prior_hidden_messages=(
+                    lecture_chat_prep.filter_prior_hidden_messages
+                    if lecture_chat_prep is not None
+                    else False
+                ),
             )
         else:
             raise HTTPException(

--- a/pingpong/test_ai_build_response_input_item_list.py
+++ b/pingpong/test_ai_build_response_input_item_list.py
@@ -419,7 +419,7 @@ async def test_build_response_input_item_list_replays_developer_and_system_messa
 
 
 @pytest.mark.asyncio
-async def test_build_response_input_item_list_can_filter_prior_hidden_messages(
+async def test_build_response_input_item_list_can_build_user_assistant_messages_only(
     db,
 ):
     async with db.async_session() as session:
@@ -513,11 +513,13 @@ async def test_build_response_input_item_list_can_filter_prior_hidden_messages(
             session,
             thread_id=thread_id,
             current_run_id=current_run_id,
-            filter_prior_hidden_messages=True,
+            user_assistant_messages_only=True,
         )
 
-    assert [item["role"] for item in items] == ["developer", "user"]
+    assert [item["role"] for item in items] == ["developer", "user", "user"]
     assert items[0]["content"][0]["text"] == "Current lecture context"
+    assert items[1]["content"][0]["type"] == "input_image"
+    assert items[2]["content"][0]["text"] == "What is happening here?"
 
 
 def test_get_known_response_message_phase_returns_known_phase_only():

--- a/pingpong/test_ai_build_response_input_item_list.py
+++ b/pingpong/test_ai_build_response_input_item_list.py
@@ -418,6 +418,108 @@ async def test_build_response_input_item_list_replays_developer_and_system_messa
     assert items[4]["content"][0]["type"] == "output_text"
 
 
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_can_filter_prior_hidden_messages(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(thread_id="thread_v4_context_filter", version=3)
+        session.add(thread)
+        await session.flush()
+
+        prior_run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        current_run = models.Run(status=schemas.RunStatus.PENDING, thread_id=thread.id)
+        session.add_all([prior_run, current_run])
+        await session.flush()
+
+        prior_developer_message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=prior_run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.DEVELOPER,
+            is_hidden=True,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.INPUT_TEXT,
+                    text="Prior lecture context",
+                )
+            ],
+            created=utcnow() - timedelta(minutes=3),
+        )
+        current_developer_message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=current_run.id,
+            thread_id=thread.id,
+            output_index=2,
+            role=schemas.MessageRole.DEVELOPER,
+            is_hidden=True,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.INPUT_TEXT,
+                    text="Current lecture context",
+                )
+            ],
+            created=utcnow() - timedelta(minutes=2),
+        )
+        prior_hidden_image_message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=prior_run.id,
+            thread_id=thread.id,
+            output_index=3,
+            role=schemas.MessageRole.USER,
+            is_hidden=True,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.INPUT_IMAGE,
+                    input_image_file_id="prior-frame-file-id",
+                )
+            ],
+            created=utcnow() - timedelta(minutes=1, seconds=30),
+        )
+        user_message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=current_run.id,
+            thread_id=thread.id,
+            output_index=4,
+            role=schemas.MessageRole.USER,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.INPUT_TEXT,
+                    text="What is happening here?",
+                )
+            ],
+            created=utcnow() - timedelta(minutes=1),
+        )
+        session.add_all(
+            [
+                prior_developer_message,
+                current_developer_message,
+                prior_hidden_image_message,
+                user_message,
+            ]
+        )
+        await session.commit()
+
+        thread_id = thread.id
+        current_run_id = current_run.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(
+            session,
+            thread_id=thread_id,
+            current_run_id=current_run_id,
+            filter_prior_hidden_messages=True,
+        )
+
+    assert [item["role"] for item in items] == ["developer", "user"]
+    assert items[0]["content"][0]["text"] == "Current lecture context"
+
+
 def test_get_known_response_message_phase_returns_known_phase_only():
     assert (
         ai.get_known_response_message_phase("commentary")

--- a/pingpong/test_lecture_video_chat.py
+++ b/pingpong/test_lecture_video_chat.py
@@ -13,6 +13,7 @@ from pingpong.lecture_video_chat import (
     _build_frame_message_parts,
     _build_context_text_from_transcript,
     _build_context_text_v3_from_parts,
+    _build_context_text_v4_from_parts,
     _extract_frame,
     _serialize_transcript_words_v3,
 )
@@ -95,6 +96,36 @@ def _build_manifest_v3_dict() -> dict:
             ).model_dump(mode="json"),
         ],
     }
+
+
+def _build_manifest_v4_dict() -> dict:
+    manifest = _build_manifest_v3_dict()
+    manifest.pop("video_descriptions")
+    manifest["version"] = 4
+    manifest["summary_checkpoints"] = [
+        {"end_offset_ms": 550, "summary": "Later cumulative summary."},
+        {"end_offset_ms": 450, "summary": "Earlier cumulative summary."},
+        {"end_offset_ms": 450, "summary": "Earlier cumulative summary replacement."},
+    ]
+    manifest["moment_contexts"] = [
+        {
+            "center_offset_ms": 550,
+            "start_offset_ms": 500,
+            "end_offset_ms": 700,
+            "before": "Before later.",
+            "at": "At later.",
+            "after": "After later.",
+        },
+        {
+            "center_offset_ms": 450,
+            "start_offset_ms": 400,
+            "end_offset_ms": 500,
+            "before": " Before earlier. ",
+            "at": " At earlier. ",
+            "after": " After earlier. ",
+        },
+    ]
+    return manifest
 
 
 def test_validate_lecture_video_manifest_accepts_omitted_version_v3():
@@ -212,6 +243,83 @@ def test_validate_lecture_video_manifest_rejects_empty_v3_video_descriptions():
         schemas.validate_lecture_video_manifest(payload)
 
 
+def test_validate_lecture_video_manifest_accepts_explicit_v4_and_normalizes_contexts():
+    manifest = schemas.validate_lecture_video_manifest(_build_manifest_v4_dict())
+
+    assert isinstance(manifest, schemas.LectureVideoManifestV4)
+    assert manifest.version == 4
+    assert not hasattr(manifest, "frames")
+    assert not hasattr(manifest, "video_descriptions")
+    assert [
+        checkpoint.end_offset_ms for checkpoint in manifest.summary_checkpoints
+    ] == [
+        450,
+        550,
+    ]
+    assert manifest.summary_checkpoints[0].summary == (
+        "Earlier cumulative summary replacement."
+    )
+    assert [moment.center_offset_ms for moment in manifest.moment_contexts] == [
+        450,
+        550,
+    ]
+    assert manifest.moment_contexts[0].before == "Before earlier."
+
+
+def test_validate_lecture_video_manifest_infers_versionless_v4_only_from_v4_fields():
+    payload = _build_manifest_v4_dict()
+    payload.pop("version")
+
+    manifest = schemas.validate_lecture_video_manifest(payload)
+
+    assert isinstance(manifest, schemas.LectureVideoManifestV4)
+
+
+@pytest.mark.parametrize(
+    "payload_update",
+    [
+        {"summary_checkpoints": [{"end_offset_ms": 450, "summary": "   "}]},
+        {
+            "moment_contexts": [
+                {
+                    "center_offset_ms": 500,
+                    "start_offset_ms": 600,
+                    "end_offset_ms": 700,
+                    "before": "Before.",
+                    "at": "At.",
+                    "after": "After.",
+                }
+            ]
+        },
+        {
+            "moment_contexts": [
+                {
+                    "center_offset_ms": 500,
+                    "start_offset_ms": 400,
+                    "end_offset_ms": 700,
+                    "before": "",
+                    "at": "At.",
+                    "after": "After.",
+                }
+            ]
+        },
+    ],
+)
+def test_validate_lecture_video_manifest_rejects_invalid_v4_contexts(payload_update):
+    payload = {**_build_manifest_v4_dict(), **payload_update}
+
+    with pytest.raises(ValueError, match="Invalid lecture video manifest"):
+        schemas.validate_lecture_video_manifest(payload)
+
+
+def test_validate_lecture_video_manifest_keeps_explicit_v3_authoritative():
+    payload = _build_manifest_v4_dict()
+    payload["version"] = 3
+
+    with pytest.raises(ValueError, match="video_descriptions"):
+        schemas.validate_lecture_video_manifest(payload)
+
+
 def test_v2_manifest_words_to_v3_treats_start_end_as_seconds():
     words = [
         schemas.LectureVideoManifestWordV2(
@@ -319,6 +427,106 @@ def test_build_context_text_caps_initial_transcript_context_window():
     assert "(older transcript omitted)" in context_text
     assert "intro" not in context_text
     assert "recent now" in context_text
+
+
+def test_build_context_text_v4_selects_floor_summary_and_moment_context():
+    thread = SimpleNamespace(lecture_video=SimpleNamespace(questions=[]))
+    state = SimpleNamespace(
+        last_known_offset_ms=500,
+        furthest_offset_ms=500,
+        last_chat_context_end_ms=0,
+        current_question=None,
+        current_question_id=None,
+        state=SimpleNamespace(value="active"),
+    )
+
+    context_text, current_offset_ms = _build_context_text_v4_from_parts(
+        thread,
+        state,
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=450,
+                summary="Summary through 450.",
+            ),
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=550,
+                summary="Summary through 550.",
+            ),
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=450,
+                start_offset_ms=400,
+                end_offset_ms=500,
+                before="Before 450.",
+                at="At 450.",
+                after="After 450.",
+            ),
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=550,
+                start_offset_ms=500,
+                end_offset_ms=600,
+                before="Before 550.",
+                at="At 550.",
+                after="After 550.",
+            ),
+        ],
+        lecture_video_playback_position_ms=500,
+        answered_knowledge_checks=None,
+    )
+
+    assert current_offset_ms == 500
+    assert "Summary through 450." in context_text
+    assert "Summary through 550." not in context_text
+    assert "Before this moment (400-450ms):" in context_text
+    assert "At this moment (450ms):" in context_text
+    assert "At 450." in context_text
+    assert "After this moment (450-500ms):" in context_text
+    assert "At 550." not in context_text
+    assert "Before:" not in context_text
+    assert "At:" not in context_text
+    assert "After:" not in context_text
+    assert "Recent Transcript" not in context_text
+    assert "Lookahead Transcript" not in context_text
+    assert "Relevant Video Descriptions" not in context_text
+
+
+def test_build_context_text_v4_omits_unavailable_floor_context_sections():
+    thread = SimpleNamespace(lecture_video=SimpleNamespace(questions=[]))
+    state = SimpleNamespace(
+        last_known_offset_ms=100,
+        furthest_offset_ms=100,
+        last_chat_context_end_ms=0,
+        current_question=None,
+        current_question_id=None,
+        state=SimpleNamespace(value="active"),
+    )
+
+    context_text, _current_offset_ms = _build_context_text_v4_from_parts(
+        thread,
+        state,
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=450,
+                summary="Summary through 450.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=450,
+                start_offset_ms=400,
+                end_offset_ms=500,
+                before="Before 450.",
+                at="At 450.",
+                after="After 450.",
+            )
+        ],
+        lecture_video_playback_position_ms=100,
+        answered_knowledge_checks=None,
+    )
+
+    assert "### Lecture Summary So Far" not in context_text
+    assert "### Current Moment Context" not in context_text
 
 
 def test_build_context_text_caps_transcript_since_last_chat():

--- a/pingpong/test_lecture_video_chat.py
+++ b/pingpong/test_lecture_video_chat.py
@@ -266,6 +266,37 @@ def test_validate_lecture_video_manifest_accepts_explicit_v4_and_normalizes_cont
     assert manifest.moment_contexts[0].before == "Before earlier."
 
 
+def test_lecture_video_chat_context_from_split_v4_storage_normalizes_contexts():
+    manifest_data = _build_manifest_v4_dict()
+    lecture_video = SimpleNamespace(
+        manifest_data={
+            "version": 4,
+            "summary_checkpoints": manifest_data["summary_checkpoints"],
+            "moment_contexts": manifest_data["moment_contexts"],
+        },
+        transcript_data={
+            "word_level_transcription": manifest_data["word_level_transcription"],
+        },
+    )
+
+    context = lecture_video_service.lecture_video_chat_context_from_model(lecture_video)
+
+    assert context is not None
+    assert context.version == 4
+    assert [checkpoint.end_offset_ms for checkpoint in context.summary_checkpoints] == [
+        450,
+        550,
+    ]
+    assert context.summary_checkpoints[0].summary == (
+        "Earlier cumulative summary replacement."
+    )
+    assert [moment.center_offset_ms for moment in context.moment_contexts] == [
+        450,
+        550,
+    ]
+    assert context.moment_contexts[0].before == "Before earlier."
+
+
 def test_validate_lecture_video_manifest_infers_versionless_v4_only_from_v4_fields():
     payload = _build_manifest_v4_dict()
     payload.pop("version")

--- a/pingpong/test_lecture_video_chat.py
+++ b/pingpong/test_lecture_video_chat.py
@@ -491,6 +491,54 @@ def test_build_context_text_v4_selects_floor_summary_and_moment_context():
     assert "Relevant Video Descriptions" not in context_text
 
 
+def test_build_context_text_v4_uses_live_playback_position_for_summary():
+    thread = SimpleNamespace(lecture_video=SimpleNamespace(questions=[]))
+    state = SimpleNamespace(
+        last_known_offset_ms=500,
+        furthest_offset_ms=500,
+        last_chat_context_end_ms=0,
+        current_question=None,
+        current_question_id=None,
+        state=SimpleNamespace(value="active"),
+    )
+
+    context_text, current_offset_ms = _build_context_text_v4_from_parts(
+        thread,
+        state,
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=500,
+                summary="Summary through persisted progress.",
+            ),
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=1000,
+                summary="Summary through live playback.",
+            ),
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=1500,
+                summary="Summary past playback.",
+            ),
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=1000,
+                start_offset_ms=500,
+                end_offset_ms=1500,
+                before="Before live playback.",
+                at="At live playback.",
+                after="After live playback.",
+            )
+        ],
+        lecture_video_playback_position_ms=1000,
+        answered_knowledge_checks=None,
+    )
+
+    assert current_offset_ms == 1000
+    assert "Summary through live playback." in context_text
+    assert "Summary through persisted progress." not in context_text
+    assert "Summary past playback." not in context_text
+
+
 def test_build_context_text_v4_omits_unavailable_floor_context_sections():
     thread = SimpleNamespace(lecture_video=SimpleNamespace(questions=[]))
     state = SimpleNamespace(

--- a/pingpong/test_lecture_video_chat.py
+++ b/pingpong/test_lecture_video_chat.py
@@ -2,6 +2,7 @@ import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from fastapi import HTTPException
 import pytest
 
 import pingpong.models as models
@@ -349,6 +350,49 @@ def test_validate_lecture_video_manifest_keeps_explicit_v3_authoritative():
 
     with pytest.raises(ValueError, match="video_descriptions"):
         schemas.validate_lecture_video_manifest(payload)
+
+
+@pytest.mark.asyncio
+async def test_build_lecture_chat_context_message_parts_returns_409_for_invalid_v4_context():
+    manifest_data = _build_manifest_v4_dict()
+    lecture_video = SimpleNamespace(
+        id=123,
+        manifest_data={
+            "version": 4,
+            "summary_checkpoints": [],
+            "moment_contexts": manifest_data["moment_contexts"],
+        },
+        transcript_data={
+            "word_level_transcription": manifest_data["word_level_transcription"],
+        },
+    )
+    thread = SimpleNamespace(
+        id=456,
+        lecture_video=lecture_video,
+        lecture_video_state=SimpleNamespace(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await build_lecture_chat_context_message_parts(
+            SimpleNamespace(),
+            SimpleNamespace(),
+            SimpleNamespace(),
+            thread=thread,
+            class_id=1,
+            uploader_id=1,
+            user_auth=None,
+            anonymous_link_auth=None,
+            anonymous_user_auth=None,
+            anonymous_session_id=None,
+            anonymous_link_id=None,
+            lecture_video_playback_position_ms=450,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert (
+        exc_info.value.detail
+        == lecture_video_service.LECTURE_VIDEO_CHAT_UNAVAILABLE_NOTE
+    )
 
 
 def test_v2_manifest_words_to_v3_treats_start_end_as_seconds():

--- a/pingpong/test_lecture_video_manifest_generation.py
+++ b/pingpong/test_lecture_video_manifest_generation.py
@@ -279,6 +279,147 @@ def test_quiz_to_manifest_converts_generated_video_descriptions() -> None:
     )
 
 
+def test_quiz_to_manifest_converts_generated_v4_context_arrays() -> None:
+    quiz = manifest_generation.GeneratedQuizWithVideoContext(
+        video_summary="A short algebra lesson.",
+        summary_checkpoints=[
+            manifest_generation.GeneratedSummaryCheckpoint(
+                end_offset_ms=30000,
+                summary="The teacher introduces the expression.",
+            )
+        ],
+        moment_contexts=[
+            manifest_generation.GeneratedMomentContext(
+                center_offset_ms=0,
+                start_offset_ms=0,
+                end_offset_ms=30000,
+                before="The lesson is starting.",
+                at="The teacher writes an expression on the board.",
+                after="The teacher prepares the next step.",
+            )
+        ],
+        questions=[_generated_question()],
+    )
+
+    manifest = manifest_generation._quiz_to_manifest(
+        quiz,
+        _transcript(),
+        video_duration_ms=30000,
+    )
+
+    assert isinstance(manifest, schemas.LectureVideoManifestV4)
+    assert manifest.summary_checkpoints[0].summary == (
+        "The teacher introduces the expression."
+    )
+    assert manifest.moment_contexts[0].at == (
+        "The teacher writes an expression on the board."
+    )
+    assert not hasattr(manifest, "video_descriptions")
+
+
+def test_quiz_to_manifest_falls_back_for_missing_v4_context_arrays(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    quiz = manifest_generation.GeneratedQuizWithVideoContext(
+        video_summary="A short algebra lesson.",
+        questions=[_generated_question()],
+    )
+
+    with caplog.at_level("WARNING", logger=manifest_generation.logger.name):
+        manifest = manifest_generation._quiz_to_manifest(
+            quiz,
+            _transcript(),
+            video_duration_ms=30000,
+        )
+
+    assert isinstance(manifest, schemas.LectureVideoManifestV4)
+    assert [
+        checkpoint.end_offset_ms for checkpoint in manifest.summary_checkpoints
+    ] == [30000]
+    assert [moment.center_offset_ms for moment in manifest.moment_contexts] == [
+        0,
+        30000,
+    ]
+    assert [moment.start_offset_ms for moment in manifest.moment_contexts] == [
+        0,
+        15000,
+    ]
+    assert [moment.end_offset_ms for moment in manifest.moment_contexts] == [
+        15000,
+        30000,
+    ]
+    assert "missing required offset 30000ms" in caplog.text
+    assert "missing required center 0ms" in caplog.text
+
+
+def test_quiz_to_manifest_normalizes_v4_context_arrays_to_description_cadence() -> None:
+    quiz = manifest_generation.GeneratedQuizWithVideoContext(
+        video_summary="A short algebra lesson.",
+        summary_checkpoints=[
+            manifest_generation.GeneratedSummaryCheckpoint(
+                end_offset_ms=30000,
+                summary="The teacher has reached thirty seconds.",
+            ),
+            manifest_generation.GeneratedSummaryCheckpoint(
+                end_offset_ms=10000,
+                summary="The teacher has reached ten seconds.",
+            ),
+        ],
+        moment_contexts=[
+            manifest_generation.GeneratedMomentContext(
+                center_offset_ms=10000,
+                start_offset_ms=0,
+                end_offset_ms=20000,
+                before="Before ten seconds.",
+                at="At ten seconds.",
+                after="After ten seconds.",
+            ),
+            manifest_generation.GeneratedMomentContext(
+                center_offset_ms=0,
+                start_offset_ms=0,
+                end_offset_ms=5000,
+                before="Before start.",
+                at="At start.",
+                after="After start.",
+            ),
+        ],
+        questions=[_generated_question()],
+    )
+
+    manifest = manifest_generation._quiz_to_manifest(
+        quiz,
+        _transcript(),
+        video_duration_ms=184166,
+        video_description_window_ms=5000,
+    )
+
+    assert [checkpoint.end_offset_ms for checkpoint in manifest.summary_checkpoints][
+        :6
+    ] == [
+        5000,
+        10000,
+        15000,
+        20000,
+        25000,
+        30000,
+    ]
+    assert manifest.summary_checkpoints[-1].end_offset_ms == 184166
+    assert [moment.center_offset_ms for moment in manifest.moment_contexts[:4]] == [
+        0,
+        5000,
+        10000,
+        15000,
+    ]
+    assert manifest.moment_contexts[-1].center_offset_ms == 184166
+    assert manifest.moment_contexts[-1].start_offset_ms == 181666
+    assert manifest.moment_contexts[-1].end_offset_ms == 184166
+    assert manifest.moment_contexts[0].start_offset_ms == 0
+    assert manifest.moment_contexts[0].end_offset_ms == 2500
+    assert manifest.moment_contexts[2].start_offset_ms == 7500
+    assert manifest.moment_contexts[2].end_offset_ms == 12500
+    assert manifest.moment_contexts[2].at == "At ten seconds."
+
+
 @pytest.mark.parametrize(
     ("video_descriptions", "video_duration_ms", "expected_log"),
     [
@@ -440,9 +581,59 @@ def test_build_generation_prompt_uses_custom_video_description_window() -> None:
         video_description_window_ms=10000,
     )
 
-    assert "fixed 10-second windows" in prompt
-    assert "0-10000, 10000-20000" in prompt
-    assert "exactly 10000ms" in prompt
+    assert (
+        "Use a 10-second context cadence (10000ms): summary checkpoints and "
+        "moment_context centers follow this cadence."
+    ) in prompt
+    assert "exactly every 10 seconds" in prompt
+    assert "plus a final context centered on the final video/request end" in prompt
+    assert "do not emit clip-relative offsets" not in prompt
+    assert "REQUIRED summary_checkpoints end_offset_ms values" not in prompt
+    assert "REQUIRED moment_contexts center/start/end triples" not in prompt
+
+
+def test_build_generation_prompt_warns_against_clip_relative_offsets_for_chunks() -> (
+    None
+):
+    prompt = manifest_generation.build_generation_prompt(
+        "Ask one question.",
+        _transcript(),
+        video_duration_ms=30000,
+        generation_start_ms=10000,
+        generation_end_ms=20000,
+        context_start_ms=5000,
+        context_end_ms=25000,
+        video_description_window_ms=10000,
+    )
+
+    assert (
+        "The provided media is a clipped excerpt, so do not emit "
+        "excerpt-relative offsets."
+    ) in prompt
+    assert (
+        'use the surrounding clip context when writing "before" and "after"'
+    ) in prompt
+    assert (
+        "The first required moment_context center is 10000ms. Include it even "
+        "when it equals generation_start_ms; boundary centers are required, "
+        "not optional."
+    ) in prompt
+
+
+def test_build_generation_prompt_uses_half_window_moment_context_bounds() -> None:
+    prompt = manifest_generation.build_generation_prompt(
+        "Ask one question.",
+        _transcript(),
+        video_duration_ms=20000,
+        video_description_window_ms=5000,
+    )
+
+    assert (
+        "with a 5-second context cadence, center_offset_ms=10000 "
+        "must use start_offset_ms=7500 and end_offset_ms=12500"
+    ) in prompt
+    assert "REQUIRED summary_checkpoints end_offset_ms values" not in prompt
+    assert "REQUIRED moment_contexts center/start/end triples" not in prompt
 
 
 def test_plan_manifest_generation_chunks_rebalances_short_tail() -> None:
@@ -496,6 +687,35 @@ def test_plan_manifest_generation_chunks_aligns_custom_window_boundaries() -> No
         (490_000, 700_000),
     ]
     assert all(chunk.generation_end_ms % 35_000 == 0 for chunk in chunks[:-1])
+
+
+def test_manifest_chunk_overlap_scales_to_half_context_cadence() -> None:
+    assert manifest_generation._manifest_chunk_overlap_ms(30_000) == 30_000
+    assert manifest_generation._manifest_chunk_overlap_ms(120_000) == 60_000
+
+
+def test_plan_manifest_generation_chunks_can_use_scaled_context_overlap() -> None:
+    video_description_window_ms = 120_000
+    chunks = manifest_generation._plan_manifest_generation_chunks(
+        700_000,
+        overlap_ms=manifest_generation._manifest_chunk_overlap_ms(
+            video_description_window_ms
+        ),
+        alignment_ms=video_description_window_ms,
+    )
+
+    assert [
+        (chunk.generation_start_ms, chunk.generation_end_ms) for chunk in chunks
+    ] == [
+        (0, 240_000),
+        (240_000, 480_000),
+        (480_000, 700_000),
+    ]
+    assert [(chunk.context_start_ms, chunk.context_end_ms) for chunk in chunks] == [
+        (0, 300_000),
+        (180_000, 540_000),
+        (420_000, 700_000),
+    ]
 
 
 def test_plan_manifest_generation_chunks_uses_single_chunk_under_limit() -> None:
@@ -737,6 +957,127 @@ async def test_merge_chunk_manifests_reconciles_questions_with_gemini(
     assert [
         description.end_offset_ms for description in manifest.video_descriptions
     ] == [30000, 60000]
+
+
+async def test_merge_chunk_manifests_dedupes_and_sorts_v4_context_arrays(
+    monkeypatch,
+) -> None:
+    candidate_question = schemas.LectureVideoManifestQuestionV1(
+        type=schemas.LectureVideoQuestionType.SINGLE_SELECT,
+        question_text="Candidate?",
+        intro_text="Try this.",
+        stop_offset_ms=1000,
+        options=[
+            schemas.LectureVideoManifestOptionV1(
+                option_text="Combine like terms",
+                post_answer_text="Right.",
+                continue_offset_ms=1500,
+                correct=True,
+            ),
+            schemas.LectureVideoManifestOptionV1(
+                option_text="Change every variable",
+                post_answer_text="Not quite.",
+                continue_offset_ms=1500,
+                correct=False,
+            ),
+        ],
+    )
+    chunk_one = schemas.LectureVideoManifestV4(
+        word_level_transcription=_transcript(),
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=60000,
+                summary="Later summary.",
+            ),
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=30000,
+                summary="First summary.",
+            ),
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=60000,
+                start_offset_ms=55000,
+                end_offset_ms=65000,
+                before="Before later.",
+                at="At later.",
+                after="After later.",
+            )
+        ],
+        questions=[candidate_question],
+    )
+    chunk_two = schemas.LectureVideoManifestV4(
+        word_level_transcription=_transcript(),
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=30000,
+                summary="First summary replacement.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=0,
+                start_offset_ms=0,
+                end_offset_ms=5000,
+                before="Before start.",
+                at="At start.",
+                after="After start.",
+            ),
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=60000,
+                start_offset_ms=55000,
+                end_offset_ms=65000,
+                before="Before later replacement.",
+                at="At later replacement.",
+                after="After later replacement.",
+            ),
+        ],
+        questions=[candidate_question],
+    )
+
+    async def fake_generate_manifest_quiz(
+        _client,
+        *,
+        model,
+        prompt,
+        contents,
+        response_model,
+    ):  # type: ignore[no-untyped-def]
+        return manifest_generation.ReconciledGeneratedQuiz(
+            questions=[_generated_question()]
+        )
+
+    monkeypatch.setattr(
+        manifest_generation.gemini_helpers,
+        "generate_manifest_quiz",
+        fake_generate_manifest_quiz,
+    )
+
+    manifest = await manifest_generation._merge_chunk_manifests(
+        gemini_client=object(),  # type: ignore[arg-type]
+        generation_prompt_content="Ask only 1 question.",
+        model="gemini-test",
+        chunk_manifests=[chunk_one, chunk_two],
+        full_transcript=_transcript(),
+        video_duration_ms=60000,
+    )
+
+    assert isinstance(manifest, schemas.LectureVideoManifestV4)
+    assert [
+        checkpoint.end_offset_ms for checkpoint in manifest.summary_checkpoints
+    ] == [
+        30000,
+        60000,
+    ]
+    assert manifest.summary_checkpoints[0].summary == "First summary replacement."
+    assert [moment.center_offset_ms for moment in manifest.moment_contexts] == [
+        0,
+        30000,
+        60000,
+    ]
+    assert manifest.moment_contexts[2].at == "At later replacement."
+    assert manifest.moment_contexts[2].start_offset_ms == 45000
+    assert manifest.moment_contexts[2].end_offset_ms == 60000
 
 
 async def test_merge_chunk_manifests_falls_back_only_for_invalid_chunk(

--- a/pingpong/test_lecture_video_manifest_generation.py
+++ b/pingpong/test_lecture_video_manifest_generation.py
@@ -243,39 +243,12 @@ async def test_transcribe_video_words_skips_empty_words_with_context_warning(
     ) in caplog.text
 
 
-def _quiz_with_video_descriptions(
-    video_descriptions: list[manifest_generation.GeneratedVideoDescription],
-) -> manifest_generation.GeneratedQuizWithVideo:
-    return manifest_generation.GeneratedQuizWithVideo(
+def _quiz_with_context(
+    questions: list[manifest_generation.GeneratedQuestion] | None = None,
+) -> manifest_generation.GeneratedQuizWithVideoContext:
+    return manifest_generation.GeneratedQuizWithVideoContext(
         video_summary="A short algebra lesson.",
-        video_descriptions=video_descriptions,
-        questions=[_generated_question()],
-    )
-
-
-def test_quiz_to_manifest_converts_generated_video_descriptions() -> None:
-    quiz = _quiz_with_video_descriptions(
-        [
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ]
-    )
-
-    manifest = manifest_generation._quiz_to_manifest(
-        quiz,
-        _transcript(),
-        video_duration_ms=30000,
-    )
-
-    assert isinstance(
-        manifest.video_descriptions[0],
-        schemas.LectureVideoManifestVideoDescriptionV3,
-    )
-    assert manifest.video_descriptions[0].description == (
-        "The teacher writes an expression on the board."
+        questions=questions or [_generated_question()],
     )
 
 
@@ -352,6 +325,14 @@ def test_quiz_to_manifest_falls_back_for_missing_v4_context_arrays(
     assert "missing required center 0ms" in caplog.text
 
 
+def test_fallback_moment_context_clamps_to_known_video_duration() -> None:
+    [moment] = manifest_generation._fallback_moment_contexts(video_duration_ms=30000)
+
+    assert moment.center_offset_ms == 0
+    assert moment.start_offset_ms == 0
+    assert moment.end_offset_ms == 30000
+
+
 def test_quiz_to_manifest_normalizes_v4_context_arrays_to_description_cadence() -> None:
     quiz = manifest_generation.GeneratedQuizWithVideoContext(
         video_summary="A short algebra lesson.",
@@ -420,159 +401,6 @@ def test_quiz_to_manifest_normalizes_v4_context_arrays_to_description_cadence() 
     assert manifest.moment_contexts[2].at == "At ten seconds."
 
 
-@pytest.mark.parametrize(
-    ("video_descriptions", "video_duration_ms", "expected_log"),
-    [
-        (
-            [
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=1000,
-                    end_offset_ms=30000,
-                    description="The teacher writes on the board.",
-                )
-            ],
-            30000,
-            "starts at 1000ms; expected 0ms",
-        ),
-        (
-            [
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=0,
-                    end_offset_ms=30000,
-                    description="The teacher writes on the board.",
-                ),
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=31000,
-                    end_offset_ms=60000,
-                    description="The teacher points at the board.",
-                ),
-            ],
-            60000,
-            "starts at 31000ms; expected 30000ms",
-        ),
-        (
-            [
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=0,
-                    end_offset_ms=31000,
-                    description="The teacher writes on the board.",
-                ),
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=31000,
-                    end_offset_ms=60000,
-                    description="The teacher points at the board.",
-                ),
-            ],
-            60000,
-            "duration is 31000ms; expected 30000ms",
-        ),
-        (
-            [
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=0,
-                    end_offset_ms=30000,
-                    description="The teacher writes on the board.",
-                )
-            ],
-            45000,
-            "final video description ends at 30000ms; expected video duration 45000ms",
-        ),
-        (
-            [
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=0,
-                    end_offset_ms=45000,
-                    description="The teacher writes on the board.",
-                )
-            ],
-            45000,
-            "final video description duration is 45000ms; expected at most 30000ms",
-        ),
-    ],
-)
-def test_quiz_to_manifest_falls_back_for_invalid_video_description_structure(
-    caplog,
-    video_descriptions: list[manifest_generation.GeneratedVideoDescription],
-    video_duration_ms: int,
-    expected_log: str,
-) -> None:
-    quiz = _quiz_with_video_descriptions(video_descriptions)
-
-    with caplog.at_level("WARNING"):
-        manifest = manifest_generation._quiz_to_manifest(
-            quiz,
-            _transcript(),
-            video_duration_ms=video_duration_ms,
-        )
-
-    assert (
-        manifest.video_descriptions
-        == manifest_generation._fallback_video_descriptions(video_duration_ms)
-    )
-    assert expected_log in caplog.text
-
-
-def test_quiz_to_manifest_accepts_final_video_description_shorter_than_window() -> None:
-    quiz = _quiz_with_video_descriptions(
-        [
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes on the board.",
-            ),
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=30000,
-                end_offset_ms=45000,
-                description="The teacher points at the board.",
-            ),
-        ]
-    )
-
-    manifest = manifest_generation._quiz_to_manifest(
-        quiz,
-        _transcript(),
-        video_duration_ms=45000,
-    )
-
-    assert [
-        description.end_offset_ms for description in manifest.video_descriptions
-    ] == [
-        30000,
-        45000,
-    ]
-
-
-def test_quiz_to_manifest_uses_custom_video_description_window() -> None:
-    quiz = _quiz_with_video_descriptions(
-        [
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=10000,
-                description="The teacher writes on the board.",
-            ),
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=10000,
-                end_offset_ms=20000,
-                description="The teacher points at the board.",
-            ),
-        ]
-    )
-
-    manifest = manifest_generation._quiz_to_manifest(
-        quiz,
-        _transcript(),
-        video_duration_ms=20000,
-        video_description_window_ms=10000,
-    )
-
-    assert [
-        description.end_offset_ms for description in manifest.video_descriptions
-    ] == [
-        10000,
-        20000,
-    ]
-
-
 def test_build_generation_prompt_uses_custom_video_description_window() -> None:
     prompt = manifest_generation.build_generation_prompt(
         "Ask one question.",
@@ -618,6 +446,9 @@ def test_build_generation_prompt_warns_against_clip_relative_offsets_for_chunks(
         "when it equals generation_start_ms; boundary centers are required, "
         "not optional."
     ) in prompt
+    assert "fixed 10-second cadence" in prompt
+    assert "second-second" not in prompt
+    assert "seconds-second" not in prompt
 
 
 def test_build_generation_prompt_uses_half_window_moment_context_bounds() -> None:
@@ -841,13 +672,22 @@ async def test_merge_chunk_manifests_reconciles_questions_with_gemini(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    chunk_one = schemas.LectureVideoManifestV3(
+    chunk_one = schemas.LectureVideoManifestV4(
         word_level_transcription=_transcript(),
-        video_descriptions=[
-            schemas.LectureVideoManifestVideoDescriptionV3(
-                start_offset_ms=0,
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
                 end_offset_ms=30000,
-                description="The teacher writes an expression.",
+                summary="The teacher writes an expression.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=0,
+                start_offset_ms=0,
+                end_offset_ms=15000,
+                before="Before start.",
+                at="At start.",
+                after="After start.",
             )
         ],
         questions=[
@@ -873,13 +713,22 @@ async def test_merge_chunk_manifests_reconciles_questions_with_gemini(
             )
         ],
     )
-    chunk_two = schemas.LectureVideoManifestV3(
+    chunk_two = schemas.LectureVideoManifestV4(
         word_level_transcription=_transcript(),
-        video_descriptions=[
-            schemas.LectureVideoManifestVideoDescriptionV3(
-                start_offset_ms=30000,
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
                 end_offset_ms=60000,
-                description="The teacher points at the next step.",
+                summary="The teacher points at the next step.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=60000,
+                start_offset_ms=45000,
+                end_offset_ms=60000,
+                before="Before end.",
+                at="At end.",
+                after="After end.",
             )
         ],
         questions=[
@@ -955,8 +804,11 @@ async def test_merge_chunk_manifests_reconciles_questions_with_gemini(
         "Final reconciled question?"
     ]
     assert [
-        description.end_offset_ms for description in manifest.video_descriptions
-    ] == [30000, 60000]
+        checkpoint.end_offset_ms for checkpoint in manifest.summary_checkpoints
+    ] == [
+        30000,
+        60000,
+    ]
 
 
 async def test_merge_chunk_manifests_dedupes_and_sorts_v4_context_arrays(
@@ -1080,211 +932,9 @@ async def test_merge_chunk_manifests_dedupes_and_sorts_v4_context_arrays(
     assert manifest.moment_contexts[2].end_offset_ms == 60000
 
 
-async def test_merge_chunk_manifests_falls_back_only_for_invalid_chunk(
-    monkeypatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    candidate_question = schemas.LectureVideoManifestQuestionV1(
-        type=schemas.LectureVideoQuestionType.SINGLE_SELECT,
-        question_text="Candidate?",
-        intro_text="Try this.",
-        stop_offset_ms=1000,
-        options=[
-            schemas.LectureVideoManifestOptionV1(
-                option_text="Combine like terms",
-                post_answer_text="Right.",
-                continue_offset_ms=1500,
-                correct=True,
-            ),
-            schemas.LectureVideoManifestOptionV1(
-                option_text="Change every variable",
-                post_answer_text="Not quite.",
-                continue_offset_ms=1500,
-                correct=False,
-            ),
-        ],
-    )
-    chunk_one = schemas.LectureVideoManifestV3(
-        word_level_transcription=_transcript(),
-        video_descriptions=[
-            schemas.LectureVideoManifestVideoDescriptionV3(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression.",
-            )
-        ],
-        questions=[candidate_question],
-    )
-    chunk_two = schemas.LectureVideoManifestV3(
-        word_level_transcription=_transcript(),
-        video_descriptions=[
-            schemas.LectureVideoManifestVideoDescriptionV3(
-                start_offset_ms=31000,
-                end_offset_ms=60000,
-                description="The teacher points at the next step.",
-            )
-        ],
-        questions=[candidate_question],
-    )
-
-    async def fake_generate_manifest_quiz(
-        _client,
-        *,
-        model,
-        prompt,
-        contents,
-        response_model,
-    ):  # type: ignore[no-untyped-def]
-        return manifest_generation.ReconciledGeneratedQuiz(
-            questions=[_generated_question()]
-        )
-
-    monkeypatch.setattr(
-        manifest_generation.gemini_helpers,
-        "generate_manifest_quiz",
-        fake_generate_manifest_quiz,
-    )
-
-    with caplog.at_level("WARNING", logger=manifest_generation.logger.name):
-        manifest = await manifest_generation._merge_chunk_manifests(
-            gemini_client=object(),  # type: ignore[arg-type]
-            generation_prompt_content="Ask only 1 question.",
-            model="gemini-test",
-            chunk_manifests=[chunk_one, chunk_two],
-            full_transcript=_transcript(),
-            video_duration_ms=60000,
-        )
-
-    assert [
-        description.start_offset_ms for description in manifest.video_descriptions
-    ] == [
-        0,
-        30000,
-    ]
-    assert [
-        description.end_offset_ms for description in manifest.video_descriptions
-    ] == [
-        30000,
-        60000,
-    ]
-    assert manifest.video_descriptions[0].description == (
-        "The teacher writes an expression."
-    )
-    assert manifest.video_descriptions[1].description == (
-        "Visual descriptions were unavailable for this transcript-only generation pass."
-    )
-    assert "Falling back for this chunk only" in caplog.text
-
-
-async def test_merge_chunk_manifests_normalizes_split_child_descriptions(
-    monkeypatch,
-) -> None:
-    candidate_question = schemas.LectureVideoManifestQuestionV1(
-        type=schemas.LectureVideoQuestionType.SINGLE_SELECT,
-        question_text="Candidate?",
-        intro_text="Try this.",
-        stop_offset_ms=1000,
-        options=[
-            schemas.LectureVideoManifestOptionV1(
-                option_text="Combine like terms",
-                post_answer_text="Right.",
-                continue_offset_ms=1500,
-                correct=True,
-            ),
-            schemas.LectureVideoManifestOptionV1(
-                option_text="Change every variable",
-                post_answer_text="Not quite.",
-                continue_offset_ms=1500,
-                correct=False,
-            ),
-        ],
-    )
-    chunk_manifests = [
-        schemas.LectureVideoManifestV3(
-            word_level_transcription=_transcript(),
-            video_descriptions=[
-                schemas.LectureVideoManifestVideoDescriptionV3(
-                    start_offset_ms=0,
-                    end_offset_ms=15000,
-                    description="The teacher introduces the expression.",
-                )
-            ],
-            questions=[candidate_question],
-        ),
-        schemas.LectureVideoManifestV3(
-            word_level_transcription=_transcript(),
-            video_descriptions=[
-                schemas.LectureVideoManifestVideoDescriptionV3(
-                    start_offset_ms=15000,
-                    end_offset_ms=30000,
-                    description="The teacher finishes the first example.",
-                )
-            ],
-            questions=[candidate_question],
-        ),
-        schemas.LectureVideoManifestV3(
-            word_level_transcription=_transcript(),
-            video_descriptions=[
-                schemas.LectureVideoManifestVideoDescriptionV3(
-                    start_offset_ms=30000,
-                    end_offset_ms=60000,
-                    description="The teacher points at the next step.",
-                )
-            ],
-            questions=[candidate_question],
-        ),
-    ]
-
-    async def fake_generate_manifest_quiz(
-        _client,
-        *,
-        model,
-        prompt,
-        contents,
-        response_model,
-    ):  # type: ignore[no-untyped-def]
-        return manifest_generation.ReconciledGeneratedQuiz(
-            questions=[_generated_question()]
-        )
-
-    monkeypatch.setattr(
-        manifest_generation.gemini_helpers,
-        "generate_manifest_quiz",
-        fake_generate_manifest_quiz,
-    )
-
-    manifest = await manifest_generation._merge_chunk_manifests(
-        gemini_client=object(),  # type: ignore[arg-type]
-        generation_prompt_content="Ask only 1 question.",
-        model="gemini-test",
-        chunk_manifests=chunk_manifests,
-        full_transcript=_transcript(),
-        video_duration_ms=60000,
-    )
-
-    assert [
-        (description.start_offset_ms, description.end_offset_ms)
-        for description in manifest.video_descriptions
-    ] == [(0, 30000), (30000, 60000)]
-    assert manifest.video_descriptions[0].description == (
-        "The teacher introduces the expression. The teacher finishes the first example."
-    )
-    assert manifest.video_descriptions[1].description == (
-        "The teacher points at the next step."
-    )
-
-
 def test_quiz_to_manifest_reports_missing_choice_feedback() -> None:
-    quiz = manifest_generation.GeneratedQuizWithVideo(
-        video_summary="A short algebra lesson.",
-        video_descriptions=[
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ],
-        questions=[
+    quiz = _quiz_with_context(
+        [
             manifest_generation.GeneratedQuestion(
                 id=1,
                 question_source="generated",
@@ -1318,7 +968,7 @@ def test_quiz_to_manifest_reports_missing_choice_feedback() -> None:
                     ),
                 },
             )
-        ],
+        ]
     )
 
     with pytest.raises(ValueError, match="feedback is missing"):
@@ -1343,16 +993,8 @@ def test_quiz_to_manifest_reports_missing_choice_feedback() -> None:
 
 
 def test_quiz_to_manifest_uses_transcript_timestamps_for_question_offsets() -> None:
-    quiz = manifest_generation.GeneratedQuizWithVideo(
-        video_summary="A short algebra lesson.",
-        video_descriptions=[
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ],
-        questions=[
+    quiz = _quiz_with_context(
+        [
             manifest_generation.GeneratedQuestion(
                 id=1,
                 question_source="generated",
@@ -1386,7 +1028,7 @@ def test_quiz_to_manifest_uses_transcript_timestamps_for_question_offsets() -> N
                     ),
                 },
             )
-        ],
+        ]
     )
 
     manifest = manifest_generation._quiz_to_manifest(
@@ -1416,16 +1058,8 @@ def test_quiz_to_manifest_uses_transcript_timestamps_for_question_offsets() -> N
 def test_quiz_to_manifest_ignores_mismatched_model_timestamp(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    quiz = manifest_generation.GeneratedQuizWithVideo(
-        video_summary="A short algebra lesson.",
-        video_descriptions=[
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ],
-        questions=[
+    quiz = _quiz_with_context(
+        [
             manifest_generation.GeneratedQuestion(
                 id=1,
                 question_source="generated",
@@ -1459,7 +1093,7 @@ def test_quiz_to_manifest_ignores_mismatched_model_timestamp(
                     ),
                 },
             )
-        ],
+        ]
     )
 
     with caplog.at_level("WARNING", logger=manifest_generation.logger.name):
@@ -1492,16 +1126,7 @@ def test_quiz_to_manifest_accepts_word_and_timestamp_when_id_is_wrong(
     question = _generated_question()
     question.pause_after_word_id = "wrong-id"
     question.pause_at = 1.0
-    quiz = _quiz_with_video_descriptions(
-        [
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ]
-    )
-    quiz.questions = [question]
+    quiz = _quiz_with_context([question])
 
     with caplog.at_level("WARNING", logger=manifest_generation.logger.name):
         manifest = manifest_generation._quiz_to_manifest(
@@ -1519,16 +1144,7 @@ def test_quiz_to_manifest_rejects_word_reference_with_fewer_than_two_matches() -
     question.pause_after_word_id = "wrong-id"
     question.pause_after_word = "wrong-word"
     question.pause_at = 1.0
-    quiz = _quiz_with_video_descriptions(
-        [
-            manifest_generation.GeneratedVideoDescription(
-                start_offset_ms=0,
-                end_offset_ms=30000,
-                description="The teacher writes an expression on the board.",
-            )
-        ]
-    )
-    quiz.questions = [question]
+    quiz = _quiz_with_context([question])
 
     with pytest.raises(ValueError, match="did not match at least two"):
         manifest_generation._quiz_to_manifest(
@@ -1624,11 +1240,20 @@ async def test_generate_manifest_uses_uploaded_file_uri_without_refetch(
         captured_contents = contents
         return response_model(
             video_summary="A short algebra lesson.",
-            video_descriptions=[
-                manifest_generation.GeneratedVideoDescription(
-                    start_offset_ms=0,
+            summary_checkpoints=[
+                manifest_generation.GeneratedSummaryCheckpoint(
                     end_offset_ms=30000,
-                    description="The teacher writes an expression on the board.",
+                    summary="The teacher writes an expression on the board.",
+                )
+            ],
+            moment_contexts=[
+                manifest_generation.GeneratedMomentContext(
+                    center_offset_ms=0,
+                    start_offset_ms=0,
+                    end_offset_ms=15000,
+                    before="The lesson is starting.",
+                    at="The teacher writes an expression on the board.",
+                    after="The teacher prepares the next step.",
                 )
             ],
             questions=[

--- a/pingpong/test_lecture_video_manifest_generation.py
+++ b/pingpong/test_lecture_video_manifest_generation.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import cast
 
 from google.genai import types
+from pydantic import ValidationError
 import pytest
 
 import pingpong.lecture_video_manifest_generation as manifest_generation
@@ -61,6 +62,53 @@ def _transcript() -> list[schemas.LectureVideoManifestWordV3]:
             end_offset_ms=2000,
         ),
     ]
+
+
+def _manifest_with_summary_checkpoint(
+    end_offset_ms: int,
+    summary: str,
+) -> schemas.LectureVideoManifestV4:
+    return schemas.LectureVideoManifestV4(
+        word_level_transcription=_transcript(),
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=end_offset_ms,
+                summary=summary,
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                center_offset_ms=end_offset_ms,
+                start_offset_ms=0,
+                end_offset_ms=end_offset_ms,
+                before="Before this checkpoint.",
+                at="At this checkpoint.",
+                after="After this checkpoint.",
+            )
+        ],
+        questions=[
+            schemas.LectureVideoManifestQuestionV1(
+                type=schemas.LectureVideoQuestionType.SINGLE_SELECT,
+                question_text="Candidate?",
+                intro_text="Try this.",
+                stop_offset_ms=1000,
+                options=[
+                    schemas.LectureVideoManifestOptionV1(
+                        option_text="Combine like terms",
+                        post_answer_text="Right.",
+                        continue_offset_ms=1500,
+                        correct=True,
+                    ),
+                    schemas.LectureVideoManifestOptionV1(
+                        option_text="Change every variable",
+                        post_answer_text="Not quite.",
+                        continue_offset_ms=1500,
+                        correct=False,
+                    ),
+                ],
+            )
+        ],
+    )
 
 
 def test_prepare_lecture_video_audio_for_whisper_retries_until_under_target(
@@ -250,6 +298,23 @@ def _quiz_with_context(
         video_summary="A short algebra lesson.",
         questions=questions or [_generated_question()],
     )
+
+
+def test_generated_quiz_with_video_context_rejects_legacy_video_descriptions() -> None:
+    with pytest.raises(ValidationError, match="video_descriptions"):
+        manifest_generation.GeneratedQuizWithVideoContext.model_validate(
+            {
+                "video_summary": "A short algebra lesson.",
+                "questions": [_generated_question().model_dump()],
+                "video_descriptions": [
+                    {
+                        "start_offset_ms": 0,
+                        "end_offset_ms": 30000,
+                        "description": "Legacy V3 visual context.",
+                    }
+                ],
+            }
+        )
 
 
 def test_quiz_to_manifest_converts_generated_v4_context_arrays() -> None:
@@ -451,6 +516,27 @@ def test_build_generation_prompt_warns_against_clip_relative_offsets_for_chunks(
     assert "seconds-second" not in prompt
 
 
+def test_build_generation_prompt_extends_prior_chunk_summary() -> None:
+    prompt = manifest_generation.build_generation_prompt(
+        "Ask one question.",
+        _transcript(),
+        video_duration_ms=60000,
+        generation_start_ms=30000,
+        generation_end_ms=60000,
+        context_start_ms=0,
+        context_end_ms=60000,
+        previous_summary_checkpoint=schemas.LectureVideoManifestSummaryCheckpointV4(
+            end_offset_ms=30000,
+            summary="The teacher introduces the expression and combines like terms.",
+        ),
+    )
+
+    assert "PRIOR CUMULATIVE SUMMARY:" in prompt
+    assert "summarized the lecture through 30000ms" in prompt
+    assert "start from the supplied prior cumulative summary" in prompt
+    assert "Use this as the only source for lecture content before 30000ms" in prompt
+
+
 def test_build_generation_prompt_uses_half_window_moment_context_bounds() -> None:
     prompt = manifest_generation.build_generation_prompt(
         "Ask one question.",
@@ -591,6 +677,131 @@ def test_should_split_manifest_chunk_error_accepts_provider_deadline() -> None:
     )
 
     assert manifest_generation._should_split_manifest_chunk_error(exc)
+
+
+async def test_upload_and_generate_manifest_threads_summary_between_top_level_chunks(
+    monkeypatch,
+) -> None:
+    captured_previous_offsets: list[int | None] = []
+
+    async def fake_ffprobe_duration_ms(_video_path: str) -> int:
+        return 600_000
+
+    async def fake_upload_and_generate_manifest_chunks(
+        *,
+        chunk: manifest_generation.ManifestGenerationChunk,
+        previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+        | None,
+        **_kwargs: object,
+    ) -> list[schemas.LectureVideoManifestV4]:
+        captured_previous_offsets.append(
+            previous_summary_checkpoint.end_offset_ms
+            if previous_summary_checkpoint is not None
+            else None
+        )
+        return [
+            _manifest_with_summary_checkpoint(
+                chunk.generation_end_ms,
+                f"Summary through {chunk.generation_end_ms}ms.",
+            )
+        ]
+
+    async def fake_merge_chunk_manifests(
+        *,
+        chunk_manifests: list[schemas.LectureVideoManifestV4],
+        **_kwargs: object,
+    ) -> schemas.LectureVideoManifestV4:
+        return chunk_manifests[-1]
+
+    monkeypatch.setattr(
+        manifest_generation,
+        "_ffprobe_duration_ms",
+        fake_ffprobe_duration_ms,
+    )
+    monkeypatch.setattr(
+        manifest_generation,
+        "_upload_and_generate_manifest_chunks",
+        fake_upload_and_generate_manifest_chunks,
+    )
+    monkeypatch.setattr(
+        manifest_generation,
+        "_merge_chunk_manifests",
+        fake_merge_chunk_manifests,
+    )
+
+    await manifest_generation.upload_and_generate_manifest(
+        video_path="lecture.mp4",
+        gemini_client=object(),  # type: ignore[arg-type]
+        generation_prompt_content="Generate checks.",
+        transcript=_transcript(),
+        temp_dir="/tmp",
+        model="gemini-test",
+    )
+
+    assert captured_previous_offsets == [None, 300_000]
+
+
+async def test_upload_and_generate_manifest_chunks_threads_summary_through_split(
+    monkeypatch,
+) -> None:
+    captured: list[tuple[int, int, int | None]] = []
+
+    async def fake_upload_and_generate_manifest_chunk(
+        *,
+        chunk: manifest_generation.ManifestGenerationChunk,
+        previous_summary_checkpoint: schemas.LectureVideoManifestSummaryCheckpointV4
+        | None,
+        **_kwargs: object,
+    ) -> schemas.LectureVideoManifestV4:
+        captured.append(
+            (
+                chunk.generation_start_ms,
+                chunk.generation_end_ms,
+                previous_summary_checkpoint.end_offset_ms
+                if previous_summary_checkpoint is not None
+                else None,
+            )
+        )
+        if chunk.generation_start_ms == 0 and chunk.generation_end_ms == 600_000:
+            raise RuntimeError("503 UNAVAILABLE. Deadline expired.")
+        return _manifest_with_summary_checkpoint(
+            chunk.generation_end_ms,
+            f"Summary through {chunk.generation_end_ms}ms.",
+        )
+
+    monkeypatch.setattr(
+        manifest_generation,
+        "_upload_and_generate_manifest_chunk",
+        fake_upload_and_generate_manifest_chunk,
+    )
+
+    manifests = await manifest_generation._upload_and_generate_manifest_chunks(
+        video_path="lecture.mp4",
+        gemini_client=object(),  # type: ignore[arg-type]
+        generation_prompt_content="Generate checks.",
+        transcript=_transcript(),
+        video_duration_ms=600_000,
+        chunk=manifest_generation.ManifestGenerationChunk(
+            generation_start_ms=0,
+            generation_end_ms=600_000,
+            context_start_ms=0,
+            context_end_ms=600_000,
+        ),
+        temp_dir="/tmp",
+        model="gemini-test",
+    )
+
+    assert [
+        manifest.summary_checkpoints[-1].end_offset_ms for manifest in manifests
+    ] == [
+        300_000,
+        600_000,
+    ]
+    assert captured == [
+        (0, 600_000, None),
+        (0, 300_000, None),
+        (300_000, 600_000, 300_000),
+    ]
 
 
 async def test_generate_manifest_quiz_with_retries_handles_transient_provider_error(

--- a/pingpong/test_lecture_video_manifest_generation_server.py
+++ b/pingpong/test_lecture_video_manifest_generation_server.py
@@ -15,6 +15,7 @@ from .test_lecture_video_server import (
     DEFAULT_LECTURE_VIDEO_VOICE_ID,
     lecture_video_manifest,
     lecture_video_manifest_v3,
+    lecture_video_manifest_v4,
     make_lecture_video,
 )
 from .testutil import with_institution
@@ -655,7 +656,7 @@ async def test_complete_manifest_generation_run_cancels_when_assistant_detached(
     await lecture_video_processing._complete_manifest_generation_run(
         run_id,
         lease_token,
-        schemas.LectureVideoManifestV3.model_validate(lecture_video_manifest_v3()),
+        schemas.LectureVideoManifestV4.model_validate(lecture_video_manifest_v4()),
     )
 
     async with db.async_session() as session:
@@ -677,8 +678,8 @@ async def test_process_claimed_manifest_run_persists_generated_manifest(
     db, institution, monkeypatch
 ):
     lease_token = "lease-token"
-    manifest = schemas.LectureVideoManifestV3.model_validate(
-        lecture_video_manifest_v3()
+    manifest = schemas.LectureVideoManifestV4.model_validate(
+        lecture_video_manifest_v4()
     )
     transcript = manifest.word_level_transcription
     calls: list[tuple[str, object]] = []
@@ -706,7 +707,7 @@ async def test_process_claimed_manifest_run_persists_generated_manifest(
 
     async def fake_upload_and_generate_manifest(
         **kwargs: object,
-    ) -> schemas.LectureVideoManifestV3:
+    ) -> schemas.LectureVideoManifestV4:
         calls.append(("generate", kwargs))
         return manifest
 
@@ -799,7 +800,7 @@ async def test_process_claimed_manifest_run_persists_generated_manifest(
     assert refreshed_run.lease_token is None
     assert refreshed_video is not None
     assert refreshed_video.manual_manifest is False
-    assert refreshed_video.manifest_version == 3
+    assert refreshed_video.manifest_version == 4
     assert [call[0] for call in calls] == [
         "gemini-client",
         "transcribe",
@@ -873,8 +874,8 @@ async def test_upload_and_generate_manifest_propagates_generation_failure(
     monkeypatch,
 ):
     calls: list[tuple[str, object]] = []
-    transcript = schemas.LectureVideoManifestV3.model_validate(
-        lecture_video_manifest_v3()
+    transcript = schemas.LectureVideoManifestV4.model_validate(
+        lecture_video_manifest_v4()
     ).word_level_transcription
 
     class FakeGeminiAio:
@@ -891,7 +892,7 @@ async def test_upload_and_generate_manifest_propagates_generation_failure(
 
     async def fake_upload_and_generate_manifest(
         **kwargs: object,
-    ) -> schemas.LectureVideoManifestV3:
+    ) -> schemas.LectureVideoManifestV4:
         calls.append(("generate", kwargs))
         raise RuntimeError("generation failed")
 
@@ -1164,8 +1165,8 @@ async def test_process_claimed_manifest_run_reuses_transcript_data(
     db, institution, monkeypatch
 ):
     lease_token = "lease-token"
-    existing_manifest = schemas.LectureVideoManifestV3.model_validate(
-        lecture_video_manifest_v3()
+    existing_manifest = schemas.LectureVideoManifestV4.model_validate(
+        lecture_video_manifest_v4()
     )
     generated_manifest = existing_manifest.model_copy(
         update={
@@ -1200,7 +1201,7 @@ async def test_process_claimed_manifest_run_reuses_transcript_data(
 
     async def fake_upload_and_generate_manifest(
         **kwargs: object,
-    ) -> schemas.LectureVideoManifestV3:
+    ) -> schemas.LectureVideoManifestV4:
         calls.append(("generate", kwargs))
         assert kwargs["transcript"] == existing_manifest.word_level_transcription
         return generated_manifest

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1098,50 +1098,6 @@ async def test_send_message_requires_playback_position_for_v4_lecture_chat(
         ("user:123", "can_view", "assistant:1"),
     ]
 )
-async def test_send_message_rejects_invalid_v4_playback_position_with_400(
-    api, config, db, institution, valid_user_token
-):
-    async with db.async_session() as session:
-        class_, _lecture_video, _assistant = await create_ready_lecture_video_assistant(
-            session,
-            institution,
-            manifest=lecture_video_manifest_v4(),
-        )
-
-    create_response = api.post(
-        f"/api/v1/class/{class_.id}/thread/lecture",
-        json={"assistant_id": 1, "parties": [123]},
-        headers={"Authorization": f"Bearer {valid_user_token}"},
-    )
-    assert create_response.status_code == 200
-    thread_id = create_response.json()["thread"]["id"]
-    await grant_thread_permissions(config, thread_id, 123)
-
-    response = api.post(
-        f"/api/v1/class/{class_.id}/thread/{thread_id}",
-        json={
-            "message": "What is happening here?",
-            "lecture_video_playback_position_ms": "500",
-        },
-        headers={"Authorization": f"Bearer {valid_user_token}"},
-    )
-
-    assert response.status_code == 400
-    assert (
-        "lecture_video_playback_position_ms must be an integer"
-        in response.json()["detail"]
-    )
-
-
-@with_user(123)
-@with_institution(11, "Test Institution")
-@with_authz(
-    grants=[
-        ("user:123", "can_create_thread", "class:1"),
-        ("user:123", "student", "class:1"),
-        ("user:123", "can_view", "assistant:1"),
-    ]
-)
 async def test_list_thread_messages_hides_lecture_chat_context_messages(
     api, config, db, institution, monkeypatch, valid_user_token
 ):

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -3042,7 +3042,7 @@ async def test_get_plausible_playback_offset_ms_only_advances_while_playing(
         await session.flush()
 
         plausible_offset_ms = (
-            await lecture_video_runtime._get_plausible_playback_offset_ms(
+            await lecture_video_runtime.get_plausible_playback_offset_ms(
                 session,
                 state,
                 current_time=current_time,

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -267,6 +267,35 @@ def lecture_video_manifest_v3(**kwargs) -> dict:
     return manifest
 
 
+def lecture_video_manifest_v4(**kwargs) -> dict:
+    manifest = lecture_video_manifest_v3(**kwargs)
+    manifest["version"] = 4
+    manifest.pop("video_descriptions")
+    manifest["summary_checkpoints"] = [
+        {"end_offset_ms": 0, "summary": "The lesson has just started."},
+        {"end_offset_ms": 900, "summary": "The lesson introduces latency."},
+    ]
+    manifest["moment_contexts"] = [
+        {
+            "center_offset_ms": 0,
+            "start_offset_ms": 0,
+            "end_offset_ms": 400,
+            "before": "The lesson is starting.",
+            "at": "The first point is introduced.",
+            "after": "The teacher continues the explanation.",
+        },
+        {
+            "center_offset_ms": 500,
+            "start_offset_ms": 400,
+            "end_offset_ms": 900,
+            "before": "Latency has been introduced.",
+            "at": "The teacher explains why latency matters.",
+            "after": "The lesson continues from the example.",
+        },
+    ]
+    return manifest
+
+
 async def create_lecture_video_copy_credentials(
     session: AsyncSession,
     class_id: int,
@@ -1020,6 +1049,88 @@ async def test_send_message_allows_lecture_chat_while_awaiting_answer(
         "- Option B (incorrect). Feedback: Try again"
     ) in hidden_context_text
     assert "### Knowledge Checks Answered" not in hidden_context_text
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_thread", "class:1"),
+        ("user:123", "student", "class:1"),
+        ("user:123", "can_view", "assistant:1"),
+    ]
+)
+async def test_send_message_requires_playback_position_for_v4_lecture_chat(
+    api, config, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_, _lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            manifest=lecture_video_manifest_v4(),
+        )
+
+    create_response = api.post(
+        f"/api/v1/class/{class_.id}/thread/lecture",
+        json={"assistant_id": 1, "parties": [123]},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert create_response.status_code == 200
+    thread_id = create_response.json()["thread"]["id"]
+    await grant_thread_permissions(config, thread_id, 123)
+
+    response = api.post(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}",
+        json={"message": "What is happening here?"},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert response.status_code == 400
+    assert "lecture_video_playback_position_ms is required" in response.json()["detail"]
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_thread", "class:1"),
+        ("user:123", "student", "class:1"),
+        ("user:123", "can_view", "assistant:1"),
+    ]
+)
+async def test_send_message_rejects_invalid_v4_playback_position_with_400(
+    api, config, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_, _lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            manifest=lecture_video_manifest_v4(),
+        )
+
+    create_response = api.post(
+        f"/api/v1/class/{class_.id}/thread/lecture",
+        json={"assistant_id": 1, "parties": [123]},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert create_response.status_code == 200
+    thread_id = create_response.json()["thread"]["id"]
+    await grant_thread_permissions(config, thread_id, 123)
+
+    response = api.post(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}",
+        json={
+            "message": "What is happening here?",
+            "lecture_video_playback_position_ms": "500",
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert response.status_code == 400
+    assert (
+        "lecture_video_playback_position_ms must be an integer"
+        in response.json()["detail"]
+    )
 
 
 @with_user(123)
@@ -5346,8 +5457,9 @@ def test_get_forkserver_context_requests_forkserver(monkeypatch):
     monkeypatch.setattr(
         lecture_video_processing.multiprocessing,
         "get_context",
-        lambda start_method: seen.__setitem__("start_method", start_method)
-        or expected_context,
+        lambda start_method: (
+            seen.__setitem__("start_method", start_method) or expected_context
+        ),
     )
 
     context = lecture_video_processing.get_forkserver_context()
@@ -5434,10 +5546,9 @@ def test_worker_pool_manager_uses_generic_labels_and_recovery(caplog):
         worker_target=lambda *_args: None,
         process_context=fake_context,
         claim_run_fn=lambda _runner_id: next(claims),
-        recover_run_fn=lambda run_id, lease_token, error_message: recoveries.append(
-            (run_id, lease_token, error_message)
-        )
-        or True,
+        recover_run_fn=lambda run_id, lease_token, error_message: (
+            recoveries.append((run_id, lease_token, error_message)) or True
+        ),
         build_runner_id_fn=lambda worker_slot, pid: f"custom:{worker_slot}:{pid}",
         worker_label="custom worker",
         unexpected_exit_error_message="custom exit",
@@ -5508,10 +5619,9 @@ def test_narration_worker_pool_manager_recovers_job_exception_and_keeps_worker_i
         poll_interval_seconds=0.25,
         process_context=fake_context,
         claim_run_fn=lambda _runner_id: next(claims),
-        recover_run_fn=lambda run_id, lease_token, error_message: recoveries.append(
-            (run_id, lease_token, error_message)
-        )
-        or True,
+        recover_run_fn=lambda run_id, lease_token, error_message: (
+            recoveries.append((run_id, lease_token, error_message)) or True
+        ),
     )
 
     manager.start()
@@ -5575,10 +5685,9 @@ def test_narration_worker_pool_manager_recovers_dead_worker_and_respawns():
         poll_interval_seconds=0.25,
         process_context=fake_context,
         claim_run_fn=lambda _runner_id: next(claims),
-        recover_run_fn=lambda run_id, lease_token, error_message: recoveries.append(
-            (run_id, lease_token, error_message)
-        )
-        or True,
+        recover_run_fn=lambda run_id, lease_token, error_message: (
+            recoveries.append((run_id, lease_token, error_message)) or True
+        ),
     )
 
     manager.start()
@@ -5658,10 +5767,9 @@ def test_narration_worker_pool_manager_shutdown_recovers_busy_assignments_before
         poll_interval_seconds=0.25,
         process_context=fake_context,
         claim_run_fn=lambda _runner_id: next(claims),
-        recover_run_fn=lambda run_id, lease_token, error_message: recoveries.append(
-            (run_id, lease_token, error_message)
-        )
-        or True,
+        recover_run_fn=lambda run_id, lease_token, error_message: (
+            recoveries.append((run_id, lease_token, error_message)) or True
+        ),
         shutdown_grace_seconds=1.0,
     )
 
@@ -5698,10 +5806,9 @@ def test_narration_worker_pool_manager_shutdown_drains_queued_worker_job_excepti
         poll_interval_seconds=0.25,
         process_context=fake_context,
         claim_run_fn=lambda _runner_id: next(claims),
-        recover_run_fn=lambda run_id, lease_token, error_message: recoveries.append(
-            (run_id, lease_token, error_message)
-        )
-        or True,
+        recover_run_fn=lambda run_id, lease_token, error_message: (
+            recoveries.append((run_id, lease_token, error_message)) or True
+        ),
         shutdown_grace_seconds=1.0,
     )
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1572,10 +1572,33 @@ export type LectureVideoManifestV3 = {
 	video_descriptions: LectureVideoManifestVideoDescriptionV3[];
 };
 
+export type LectureVideoManifestSummaryCheckpointV4 = {
+	end_offset_ms: number;
+	summary: string;
+};
+
+export type LectureVideoManifestMomentContextV4 = {
+	center_offset_ms: number;
+	start_offset_ms: number;
+	end_offset_ms: number;
+	before: string;
+	at: string;
+	after: string;
+};
+
+export type LectureVideoManifestV4 = {
+	version: 4;
+	questions: LectureVideoManifestQuestion[];
+	word_level_transcription: LectureVideoManifestWordV3[];
+	summary_checkpoints: LectureVideoManifestSummaryCheckpointV4[];
+	moment_contexts: LectureVideoManifestMomentContextV4[];
+};
+
 export type LectureVideoManifest =
 	| LectureVideoManifestV1
 	| LectureVideoManifestV2
-	| LectureVideoManifestV3;
+	| LectureVideoManifestV3
+	| LectureVideoManifestV4;
 
 export type LectureVideoConfigResponse = {
 	lecture_video: LectureVideoSummary;
@@ -3613,6 +3636,7 @@ export type NewThreadMessageRequest = {
 	vision_image_descriptions?: ImageProxy[];
 	timezone?: string;
 	generate_speech?: boolean;
+	lecture_video_playback_position_ms?: number;
 };
 
 /**

--- a/web/pingpong/src/lib/components/ChatInput.svelte
+++ b/web/pingpong/src/lib/components/ChatInput.svelte
@@ -12,7 +12,6 @@
 		visionFileImageDescriptions: ImageProxy[];
 		optimisticVisionFiles: OptimisticVisionFile[];
 		message: string;
-		lecture_video_playback_position_ms?: number;
 		callback: ({ success, errorMessage, message_sent }: CallbackParams) => void;
 	};
 

--- a/web/pingpong/src/lib/components/ChatInput.svelte
+++ b/web/pingpong/src/lib/components/ChatInput.svelte
@@ -12,6 +12,7 @@
 		visionFileImageDescriptions: ImageProxy[];
 		optimisticVisionFiles: OptimisticVisionFile[];
 		message: string;
+		lecture_video_playback_position_ms?: number;
 		callback: ({ success, errorMessage, message_sent }: CallbackParams) => void;
 	};
 

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -684,6 +684,7 @@
 		vision_file_ids,
 		visionFileImageDescriptions,
 		optimisticVisionFiles,
+		lecture_video_playback_position_ms,
 		callback
 	}: ChatInputMessage) => {
 		try {
@@ -696,7 +697,8 @@
 				vision_file_ids,
 				visionFileImageDescriptions,
 				optimisticVisionFiles,
-				currentMessageAttachments
+				currentMessageAttachments,
+				lecture_video_playback_position_ms
 			);
 		} catch (e) {
 			callback({
@@ -713,8 +715,14 @@
 	};
 
 	const handleLectureChatSubmit = async (message: ChatInputMessage) => {
+		const lectureVideoPlaybackPositionMs = lectureVideoViewRef?.getPlaybackPositionMs();
 		void lectureVideoViewRef?.pauseForChatSubmit();
-		await postMessage(message);
+		await postMessage({
+			...message,
+			...(lectureVideoPlaybackPositionMs !== undefined
+				? { lecture_video_playback_position_ms: lectureVideoPlaybackPositionMs }
+				: {})
+		});
 	};
 
 	const handleLectureSessionChange = (e: CustomEvent<api.LectureVideoSession>) => {

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -56,6 +56,7 @@
 		LinkOutline,
 		TerminalOutline
 	} from 'flowbite-svelte-icons';
+
 	import { parseTextContent } from '$lib/content';
 	import { ThreadManager, type Message } from '$lib/stores/thread';
 	import AttachmentDeletedPlaceholder from '$lib/components/AttachmentDeletedPlaceholder.svelte';
@@ -86,6 +87,10 @@
 	} from '$lib/components/lecture-video/LectureVideoView.svelte';
 	import { LECTURE_CHAT_TTS_VOLUME_SCALE } from '$lib/components/lecture-video/audio-levels';
 	import LectureVideoChatPanel from '$lib/components/lecture-video/LectureVideoChatPanel.svelte';
+
+	type ThreadPostMessage = ChatInputMessage & {
+		lecture_video_playback_position_ms?: number;
+	};
 
 	function formatLectureVideoTitle(filename: string | null | undefined): string | null {
 		if (!filename) return null;
@@ -686,7 +691,7 @@
 		optimisticVisionFiles,
 		lecture_video_playback_position_ms,
 		callback
-	}: ChatInputMessage) => {
+	}: ThreadPostMessage) => {
 		try {
 			await threadMgr.postMessage(
 				data.me.user!.id,

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -2,6 +2,7 @@
 	export type LectureVideoViewHandle = {
 		pauseForChatSubmit: () => Promise<void>;
 		continueWatchingAfterChat: () => Promise<boolean>;
+		getPlaybackPositionMs: () => number;
 	};
 </script>
 
@@ -1247,6 +1248,10 @@
 		if (!(await ensureControllerSession())) {
 			return;
 		}
+	}
+
+	export function getPlaybackPositionMs(): number {
+		return Math.round(currentTimeMs);
 	}
 
 	export async function continueWatchingAfterChat(): Promise<boolean> {

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -717,7 +717,8 @@ export class ThreadManager {
 		vision_file_ids?: string[],
 		vision_image_descriptions?: api.ImageProxy[],
 		optimisticVisionFiles?: api.OptimisticVisionFile[],
-		attachments?: api.ServerFile[]
+		attachments?: api.ServerFile[],
+		lecture_video_playback_position_ms?: number
 	) {
 		if (!message) {
 			callback({
@@ -863,7 +864,10 @@ export class ThreadManager {
 			vision_file_ids,
 			vision_image_descriptions,
 			timezone: this.timezone,
-			...(isLectureVideoThread ? { generate_speech: !get(this.#ttsMuted) } : {})
+			...(isLectureVideoThread ? { generate_speech: !get(this.#ttsMuted) } : {}),
+			...(lecture_video_playback_position_ms !== undefined
+				? { lecture_video_playback_position_ms }
+				: {})
 		});
 
 		this.attachments = derived(this.#data, ($data) => {

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -143,6 +143,18 @@
 			end_offset_ms: number;
 			description: string;
 		}[];
+		summary_checkpoints?: {
+			end_offset_ms: number;
+			summary: string;
+		}[];
+		moment_contexts?: {
+			center_offset_ms: number;
+			start_offset_ms: number;
+			end_offset_ms: number;
+			before: string;
+			at: string;
+			after: string;
+		}[];
 	};
 
 	type LectureVideoSaveAffordances = {
@@ -368,7 +380,7 @@
 		if (candidate.version === 1) {
 			return true;
 		}
-		if (candidate.version === 2 || candidate.version === 3) {
+		if (candidate.version === 2 || candidate.version === 3 || candidate.version === 4) {
 			return !hasWordLevelTranscription;
 		}
 		if (candidate.word_level_transcription !== undefined) {
@@ -407,11 +419,12 @@
 			candidate.version !== undefined &&
 			candidate.version !== 1 &&
 			candidate.version !== 2 &&
-			candidate.version !== 3
+			candidate.version !== 3 &&
+			candidate.version !== 4
 		) {
 			return {
 				manifest: null,
-				error: 'Lecture video manifest version must be 1, 2, or 3.'
+				error: 'Lecture video manifest version must be 1, 2, 3, or 4.'
 			};
 		}
 		if (!Array.isArray(candidate.questions) || candidate.questions.length < 1) {
@@ -519,7 +532,127 @@
 			candidate.version === 3 ||
 			(candidate.version === undefined &&
 				(candidate.video_descriptions !== undefined || hasV3TranscriptShape));
+		const shouldUseV4Manifest =
+			candidate.version === 4 ||
+			(candidate.version === undefined &&
+				(candidate.summary_checkpoints !== undefined || candidate.moment_contexts !== undefined));
 		const shouldUseV2Manifest = candidate.version === 2 || hasWordLevelTranscription;
+
+		if (shouldUseV4Manifest) {
+			if (
+				!Array.isArray(candidate.word_level_transcription) ||
+				candidate.word_level_transcription.length < 1
+			) {
+				return {
+					manifest: null,
+					error: 'Lecture video manifest version 4 must include non-empty word_level_transcription.'
+				};
+			}
+			if (
+				!Array.isArray(candidate.summary_checkpoints) ||
+				candidate.summary_checkpoints.length < 1
+			) {
+				return {
+					manifest: null,
+					error: 'Lecture video manifest version 4 must include non-empty summary_checkpoints.'
+				};
+			}
+			if (!Array.isArray(candidate.moment_contexts) || candidate.moment_contexts.length < 1) {
+				return {
+					manifest: null,
+					error: 'Lecture video manifest version 4 must include non-empty moment_contexts.'
+				};
+			}
+
+			for (let index = 0; index < candidate.word_level_transcription.length; index += 1) {
+				const word = candidate.word_level_transcription[index];
+				if (
+					!word ||
+					typeof word !== 'object' ||
+					typeof word.id !== 'string' ||
+					word.id.length < 1 ||
+					typeof word.word !== 'string' ||
+					word.word.length < 1 ||
+					!isValidLectureVideoInterval(word.start_offset_ms, word.end_offset_ms)
+				) {
+					return {
+						manifest: null,
+						error: `word_level_transcription entry ${index + 1} is invalid.`
+					};
+				}
+			}
+
+			for (let index = 0; index < candidate.summary_checkpoints.length; index += 1) {
+				const checkpoint = candidate.summary_checkpoints[index];
+				if (
+					!checkpoint ||
+					typeof checkpoint !== 'object' ||
+					typeof checkpoint.summary !== 'string' ||
+					checkpoint.summary.trim().length < 1 ||
+					typeof checkpoint.end_offset_ms !== 'number' ||
+					!Number.isFinite(checkpoint.end_offset_ms) ||
+					checkpoint.end_offset_ms < 0
+				) {
+					return {
+						manifest: null,
+						error: `summary_checkpoints entry ${index + 1} is invalid.`
+					};
+				}
+			}
+
+			for (let index = 0; index < candidate.moment_contexts.length; index += 1) {
+				const moment = candidate.moment_contexts[index];
+				if (
+					!moment ||
+					typeof moment !== 'object' ||
+					typeof moment.before !== 'string' ||
+					moment.before.trim().length < 1 ||
+					typeof moment.at !== 'string' ||
+					moment.at.trim().length < 1 ||
+					typeof moment.after !== 'string' ||
+					moment.after.trim().length < 1 ||
+					!isValidLectureVideoInterval(moment.start_offset_ms, moment.end_offset_ms) ||
+					typeof moment.center_offset_ms !== 'number' ||
+					!Number.isFinite(moment.center_offset_ms) ||
+					moment.center_offset_ms < moment.start_offset_ms ||
+					moment.center_offset_ms > moment.end_offset_ms
+				) {
+					return {
+						manifest: null,
+						error: `moment_contexts entry ${index + 1} is invalid.`
+					};
+				}
+			}
+
+			const wordLevelTranscription = candidate.word_level_transcription.map((word) => ({
+				id: word.id,
+				word: word.word,
+				start_offset_ms: word.start_offset_ms as number,
+				end_offset_ms: word.end_offset_ms as number
+			})) satisfies api.LectureVideoManifestWordV3[];
+			const manifest = {
+				version: 4,
+				questions,
+				word_level_transcription: wordLevelTranscription,
+				summary_checkpoints: candidate.summary_checkpoints.map((checkpoint) => ({
+					end_offset_ms: checkpoint.end_offset_ms,
+					summary: checkpoint.summary.trim()
+				})),
+				moment_contexts: candidate.moment_contexts.map((moment) => ({
+					center_offset_ms: moment.center_offset_ms,
+					start_offset_ms: moment.start_offset_ms,
+					end_offset_ms: moment.end_offset_ms,
+					before: moment.before.trim(),
+					at: moment.at.trim(),
+					after: moment.after.trim()
+				}))
+			} satisfies api.LectureVideoManifestV4;
+
+			return {
+				manifest,
+				error: null
+			};
+		}
 
 		if (shouldUseV3Manifest) {
 			if (


### PR DESCRIPTION
## Lecture Video (Preview)
### New Features
* Introducing the fourth generation of Lecture Video manifests. Manifests now include cumulative lecture summaries and local moment context throughout the video.
* Version 4 manifests provide richer text-only lecture context without relying on extracted frame images during chat.
* Lecture Video Chat now picks context based on the student's position: the latest summary up to their furthest watched offset, plus the latest moment context at or before the current playback position.

### Updates & Improvements
* The Gemini-backed manifest generator will now generate fourth generation manifests for all Lecture Videos.  Use the "Regenerate" button under Advanced Options to request a regeneration without making other changes to your assistant configuration. 
* Chat requests now send the current playback offset, validated server-side against the student's unlocked progress.