### PR TITLE
fix(lv): stop feedback on narration

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -738,6 +738,10 @@
 		threadMgr.interruptTts().catch(() => {});
 	};
 
+	const handleLectureNarrationPlaybackStarted = () => {
+		threadMgr.interruptTts().catch(() => {});
+	};
+
 	const handleLectureChatContinueWatching = async () => {
 		return (await lectureVideoViewRef?.continueWatchingAfterChat()) ?? false;
 	};
@@ -1561,6 +1565,7 @@
 					chatAvailable={threadLectureChatAvailable}
 					on:sessionchange={handleLectureSessionChange}
 					on:playbackresumed={handleLecturePlaybackResumed}
+					on:narrationplaybackstarted={handleLectureNarrationPlaybackStarted}
 					on:lessonupdated={handleLectureVideoLessonUpdated}
 				>
 					{#snippet chat(lectureVideoAtEnd = false)}

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -74,6 +74,7 @@
 	const dispatch = createEventDispatcher<{
 		sessionchange: LectureVideoSession;
 		playbackresumed: void;
+		narrationplaybackstarted: void;
 		lessonupdated: void;
 	}>();
 
@@ -1519,6 +1520,7 @@
 		onChatAbort: () => void = onComplete
 	) {
 		stopNarrationPlayback();
+		dispatch('narrationplaybackstarted');
 		const playbackGeneration = narrationPlaybackGeneration;
 		pendingNarrationCompletion = onComplete;
 		pendingNarrationChatAbort = onChatAbort;


### PR DESCRIPTION
## Lecture Video
### Resolved Issues
* Fixed: After answering a knowledge check, voice feedback for the knowledge check may overlap with voice feedback for a chat response that is still playing.