### PR TITLE
feat(lv): landing page updates

### DIFF
--- a/alembic/versions/a557c213b631_add_lecture_video_poster_stored_objects.py
+++ b/alembic/versions/a557c213b631_add_lecture_video_poster_stored_objects.py
@@ -1,0 +1,59 @@
+"""add lecture video poster stored objects
+
+Revision ID: a557c213b631
+Revises: 0b7a1d2e9c45
+Create Date: 2026-04-30 22:38:51.275860
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a557c213b631'
+down_revision: Union[str, None] = '0b7a1d2e9c45'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Resolves CodeQL's py/unused-global-variable
+    _ = revision, down_revision, branch_labels, depends_on
+    op.create_table(
+        'lecture_video_poster_stored_objects',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('key', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=False),
+        sa.Column(
+            'created',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=True,
+        ),
+        sa.Column('updated', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('key'),
+    )
+    op.add_column(
+        'lecture_videos',
+        sa.Column('poster_stored_object_id', sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        'fk_lecture_videos_poster_stored_object_id',
+        'lecture_videos',
+        'lecture_video_poster_stored_objects',
+        ['poster_stored_object_id'],
+        ['id'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'fk_lecture_videos_poster_stored_object_id',
+        'lecture_videos',
+        type_='foreignkey',
+    )
+    op.drop_column('lecture_videos', 'poster_stored_object_id')
+    op.drop_table('lecture_video_poster_stored_objects')

--- a/alembic/versions/a557c213b631_add_lecture_video_poster_stored_objects.py
+++ b/alembic/versions/a557c213b631_add_lecture_video_poster_stored_objects.py
@@ -5,6 +5,7 @@ Revises: 0b7a1d2e9c45
 Create Date: 2026-04-30 22:38:51.275860
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'a557c213b631'
-down_revision: Union[str, None] = '0b7a1d2e9c45'
+revision: str = "a557c213b631"
+down_revision: Union[str, None] = "0b7a1d2e9c45"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -22,38 +23,38 @@ def upgrade() -> None:
     # Resolves CodeQL's py/unused-global-variable
     _ = revision, down_revision, branch_labels, depends_on
     op.create_table(
-        'lecture_video_poster_stored_objects',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('key', sa.String(), nullable=False),
-        sa.Column('content_type', sa.String(), nullable=False),
+        "lecture_video_poster_stored_objects",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("content_type", sa.String(), nullable=False),
         sa.Column(
-            'created',
+            "created",
             sa.DateTime(timezone=True),
-            server_default=sa.text('now()'),
+            server_default=sa.text("now()"),
             nullable=True,
         ),
-        sa.Column('updated', sa.DateTime(timezone=True), nullable=True),
-        sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('key'),
+        sa.Column("updated", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key"),
     )
     op.add_column(
-        'lecture_videos',
-        sa.Column('poster_stored_object_id', sa.Integer(), nullable=True),
+        "lecture_videos",
+        sa.Column("poster_stored_object_id", sa.Integer(), nullable=True),
     )
     op.create_foreign_key(
-        'fk_lecture_videos_poster_stored_object_id',
-        'lecture_videos',
-        'lecture_video_poster_stored_objects',
-        ['poster_stored_object_id'],
-        ['id'],
+        "fk_lecture_videos_poster_stored_object_id",
+        "lecture_videos",
+        "lecture_video_poster_stored_objects",
+        ["poster_stored_object_id"],
+        ["id"],
     )
 
 
 def downgrade() -> None:
     op.drop_constraint(
-        'fk_lecture_videos_poster_stored_object_id',
-        'lecture_videos',
-        type_='foreignkey',
+        "fk_lecture_videos_poster_stored_object_id",
+        "lecture_videos",
+        type_="foreignkey",
     )
-    op.drop_column('lecture_videos', 'poster_stored_object_id')
-    op.drop_table('lecture_video_poster_stored_objects')
+    op.drop_column("lecture_videos", "poster_stored_object_id")
+    op.drop_table("lecture_video_poster_stored_objects")

--- a/pingpong/__main__.py
+++ b/pingpong/__main__.py
@@ -62,6 +62,9 @@ from pingpong.migrations.m07_backfill_lecture_video_content_lengths import (
 from pingpong.migrations.m08_cleanup_invalid_lecture_video_schema_rows import (
     cleanup_invalid_lecture_video_schema_rows,
 )
+from pingpong.migrations.m09_backfill_lecture_video_posters import (
+    backfill_lecture_video_posters,
+)
 from pingpong.now import _get_next_run_time, croner, utcnow
 from pingpong.schemas import LMSType, RunStatus
 from pingpong.lti.course_bridge import course_bridge_sync_all
@@ -1008,6 +1011,20 @@ def m08_cleanup_invalid_lecture_video_schema_rows() -> None:
                 )
 
     asyncio.run(_m08_cleanup_invalid_lecture_video_schema_rows())
+
+
+@db.command("m09_backfill_lecture_video_posters")
+def m09_backfill_lecture_video_posters() -> None:
+    async def _m09_backfill_lecture_video_posters() -> None:
+        async with config.db.driver.async_session() as session:
+            logger.info("Backfilling lecture video posters...")
+            extracted = await backfill_lecture_video_posters(session)
+            logger.info(
+                "Done! Backfilled posters for %s lecture videos.",
+                extracted,
+            )
+
+    asyncio.run(_m09_backfill_lecture_video_posters())
 
 
 @db.command("m02_remove_responses_threads")

--- a/pingpong/lecture_video_poster.py
+++ b/pingpong/lecture_video_poster.py
@@ -7,7 +7,9 @@ import tempfile
 from pathlib import Path
 
 import uuid_utils as uuid
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 import pingpong.models as models
 from pingpong.config import config
@@ -52,6 +54,7 @@ async def _probe_duration_ms(video_source: VideoInputSource) -> int | None:
                     ffprobe_path,
                     "-v",
                     "quiet",
+                    *video_source.ffmpeg_input_args,
                     "-show_entries",
                     "format=duration",
                     "-of",
@@ -71,6 +74,34 @@ async def _probe_duration_ms(video_source: VideoInputSource) -> int | None:
     return await asyncio.to_thread(run_ffprobe)
 
 
+def _build_ffmpeg_extract_args(
+    *,
+    video_source: VideoInputSource,
+    output_path: Path,
+    offset_ms: int,
+) -> list[str]:
+    return [
+        "ffmpeg",
+        "-loglevel",
+        "error",
+        "-y",
+        "-ss",
+        f"{offset_ms / 1000:.3f}",
+        *video_source.ffmpeg_input_args,
+        "-i",
+        video_source.url,
+        "-frames:v",
+        "1",
+        "-vf",
+        f"scale='min({_POSTER_MAX_WIDTH},iw)':-2",
+        "-c:v",
+        "libwebp",
+        "-quality",
+        str(_POSTER_QUALITY),
+        str(output_path),
+    ]
+
+
 async def _extract_poster_to_path(
     video_source: VideoInputSource,
     output_path: Path,
@@ -78,24 +109,11 @@ async def _extract_poster_to_path(
 ) -> bool:
     try:
         process = await asyncio.create_subprocess_exec(
-            "ffmpeg",
-            "-loglevel",
-            "error",
-            "-y",
-            "-ss",
-            f"{offset_ms / 1000:.3f}",
-            *video_source.ffmpeg_input_args,
-            "-i",
-            video_source.url,
-            "-frames:v",
-            "1",
-            "-vf",
-            f"scale='min({_POSTER_MAX_WIDTH},iw)':-2",
-            "-c:v",
-            "libwebp",
-            "-quality",
-            str(_POSTER_QUALITY),
-            str(output_path),
+            *_build_ffmpeg_extract_args(
+                video_source=video_source,
+                output_path=output_path,
+                offset_ms=offset_ms,
+            ),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -158,6 +176,9 @@ async def extract_poster_bytes(
     manifest pipeline) for a fast probe + extract. Otherwise pass a
     `video_source` from the configured video store.
     """
+    if local_video_path is not None and video_source is not None:
+        raise ValueError("Pass either local_video_path or video_source, not both.")
+
     if local_video_path is not None:
         source = VideoInputSource(
             url=Path(local_video_path).as_uri(),
@@ -214,15 +235,15 @@ async def _persist_poster_bytes(
         return None
 
     try:
-        stored_object = await models.LectureVideoPosterStoredObject.create(
-            session,
-            key=store_key,
-            content_type=_POSTER_CONTENT_TYPE,
-        )
-        lecture_video.poster_stored_object_id = stored_object.id
-        lecture_video.poster_stored_object = stored_object
-        await session.flush()
-        return stored_object
+        async with session.begin_nested():
+            stored_object = await models.LectureVideoPosterStoredObject.create(
+                session,
+                key=store_key,
+                content_type=_POSTER_CONTENT_TYPE,
+            )
+            lecture_video.poster_stored_object_id = stored_object.id
+            lecture_video.poster_stored_object = stored_object
+            await session.flush()
     except Exception:
         logger.exception(
             "Failed to persist lecture video poster row. lecture_video_id=%s key=%s",
@@ -238,6 +259,20 @@ async def _persist_poster_bytes(
             )
         return None
 
+    return stored_object
+
+
+async def _lock_lecture_video_for_poster(
+    session: AsyncSession,
+    lecture_video_id: int,
+) -> models.LectureVideo | None:
+    return await session.scalar(
+        select(models.LectureVideo)
+        .where(models.LectureVideo.id == lecture_video_id)
+        .options(selectinload(models.LectureVideo.stored_object))
+        .with_for_update()
+    )
+
 
 async def extract_and_store_poster(
     session: AsyncSession,
@@ -245,13 +280,18 @@ async def extract_and_store_poster(
     *,
     local_video_path: str | None = None,
 ) -> models.LectureVideoPosterStoredObject | None:
-    if lecture_video.poster_stored_object_id is not None:
+    locked_lecture_video = await _lock_lecture_video_for_poster(
+        session, lecture_video.id
+    )
+    if locked_lecture_video is None:
+        return None
+    if locked_lecture_video.poster_stored_object_id is not None:
         return None
 
     if local_video_path is not None:
         poster_bytes = await extract_poster_bytes(local_video_path=local_video_path)
     else:
-        video_source = await _video_source_for_lecture_video(lecture_video)
+        video_source = await _video_source_for_lecture_video(locked_lecture_video)
         if video_source is None:
             return None
         poster_bytes = await extract_poster_bytes(video_source=video_source)
@@ -259,4 +299,4 @@ async def extract_and_store_poster(
     if poster_bytes is None:
         return None
 
-    return await _persist_poster_bytes(session, lecture_video, poster_bytes)
+    return await _persist_poster_bytes(session, locked_lecture_video, poster_bytes)

--- a/pingpong/lecture_video_poster.py
+++ b/pingpong/lecture_video_poster.py
@@ -1,0 +1,260 @@
+import asyncio
+import io
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import uuid_utils as uuid
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import pingpong.models as models
+from pingpong.config import config
+from pingpong.video_store import VideoInputSource, VideoStoreError
+
+logger = logging.getLogger(__name__)
+
+_POSTER_TARGET_OFFSET_FRACTION = 0.05
+_POSTER_MIN_OFFSET_MS = 1_000
+_POSTER_MAX_OFFSET_MS = 30_000
+_POSTER_FALLBACK_OFFSET_MS = 2_000
+_POSTER_MAX_WIDTH = 1_280
+_POSTER_QUALITY = 80
+_POSTER_CONTENT_TYPE = "image/webp"
+_POSTER_FFMPEG_TIMEOUT_SECONDS = 60
+_POSTER_FFPROBE_TIMEOUT_SECONDS = 30
+
+
+def _generate_poster_store_key() -> str:
+    return f"lv_poster_{uuid.uuid7()}.webp"
+
+
+def _compute_poster_offset_ms(duration_ms: int | None) -> int:
+    if duration_ms is None or duration_ms <= 0:
+        return _POSTER_FALLBACK_OFFSET_MS
+    raw_offset = int(duration_ms * _POSTER_TARGET_OFFSET_FRACTION)
+    clamped = max(_POSTER_MIN_OFFSET_MS, min(_POSTER_MAX_OFFSET_MS, raw_offset))
+    # Never seek past the end of a very short video.
+    if clamped >= duration_ms:
+        return max(0, duration_ms // 2)
+    return clamped
+
+
+async def _probe_duration_ms(video_source: VideoInputSource) -> int | None:
+    def run_ffprobe() -> int | None:
+        ffprobe_path = shutil.which("ffprobe")
+        if ffprobe_path is None:
+            return None
+        try:
+            result = subprocess.run(
+                [
+                    ffprobe_path,
+                    "-v",
+                    "quiet",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "csv=p=0",
+                    video_source.url,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=_POSTER_FFPROBE_TIMEOUT_SECONDS,
+            )
+            seconds = float(result.stdout.strip())
+            return int(seconds * 1000)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError):
+            return None
+
+    return await asyncio.to_thread(run_ffprobe)
+
+
+async def _extract_poster_to_path(
+    video_source: VideoInputSource,
+    output_path: Path,
+    offset_ms: int,
+) -> bool:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-loglevel",
+            "error",
+            "-y",
+            "-ss",
+            f"{offset_ms / 1000:.3f}",
+            *video_source.ffmpeg_input_args,
+            "-i",
+            video_source.url,
+            "-frames:v",
+            "1",
+            "-vf",
+            f"scale='min({_POSTER_MAX_WIDTH},iw)':-2",
+            "-c:v",
+            "libwebp",
+            "-quality",
+            str(_POSTER_QUALITY),
+            str(output_path),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        logger.warning("ffmpeg is unavailable; skipping lecture video poster extraction")
+        return False
+
+    try:
+        _, stderr = await asyncio.wait_for(
+            process.communicate(), timeout=_POSTER_FFMPEG_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        process.kill()
+        _, stderr = await process.communicate()
+        logger.warning(
+            "Timed out extracting lecture video poster. offset_ms=%s stderr=%s",
+            offset_ms,
+            stderr.decode("utf-8", errors="ignore").strip(),
+        )
+        return False
+
+    if process.returncode != 0 or not output_path.exists():
+        logger.warning(
+            "Failed to extract lecture video poster. offset_ms=%s stderr=%s",
+            offset_ms,
+            stderr.decode("utf-8", errors="ignore").strip(),
+        )
+        return False
+    return True
+
+
+async def _video_source_for_lecture_video(
+    lecture_video: models.LectureVideo,
+) -> VideoInputSource | None:
+    if not config.video_store or lecture_video.stored_object is None:
+        return None
+    try:
+        return await config.video_store.store.get_ffmpeg_input_source(
+            lecture_video.stored_object.key
+        )
+    except VideoStoreError as e:
+        logger.warning(
+            "Unable to open lecture video for poster extraction. lecture_video_id=%s error=%s",
+            lecture_video.id,
+            e.detail or str(e),
+        )
+        return None
+
+
+async def extract_poster_bytes(
+    *,
+    video_source: VideoInputSource | None = None,
+    local_video_path: str | None = None,
+) -> bytes | None:
+    """Extract a single WEBP poster frame.
+
+    Pass `local_video_path` when the video is already on disk (e.g. inside the
+    manifest pipeline) for a fast probe + extract. Otherwise pass a
+    `video_source` from the configured video store.
+    """
+    if local_video_path is not None:
+        source = VideoInputSource(
+            url=Path(local_video_path).as_uri(),
+            ffmpeg_input_args=[],
+        )
+    elif video_source is not None:
+        source = video_source
+    else:
+        return None
+
+    duration_ms = await _probe_duration_ms(source)
+    offset_ms = _compute_poster_offset_ms(duration_ms)
+
+    with tempfile.TemporaryDirectory(prefix="pingpong_lv_poster_") as tmp_dir:
+        output_path = Path(tmp_dir) / "poster.webp"
+        ok = await _extract_poster_to_path(source, output_path, offset_ms)
+        if not ok:
+            return None
+        try:
+            return output_path.read_bytes()
+        except OSError:
+            logger.exception(
+                "Failed to read extracted poster file. offset_ms=%s", offset_ms
+            )
+            return None
+
+
+async def _persist_poster_bytes(
+    session: AsyncSession,
+    lecture_video: models.LectureVideo,
+    poster_bytes: bytes,
+) -> models.LectureVideoPosterStoredObject | None:
+    if not config.video_store:
+        return None
+
+    store_key = _generate_poster_store_key()
+
+    try:
+        await config.video_store.store.put(
+            store_key, io.BytesIO(poster_bytes), _POSTER_CONTENT_TYPE
+        )
+    except VideoStoreError as e:
+        logger.warning(
+            "Failed to upload lecture video poster. lecture_video_id=%s error=%s",
+            lecture_video.id,
+            e.detail or str(e),
+        )
+        return None
+    except Exception:
+        logger.exception(
+            "Unexpected error uploading lecture video poster. lecture_video_id=%s",
+            lecture_video.id,
+        )
+        return None
+
+    try:
+        stored_object = await models.LectureVideoPosterStoredObject.create(
+            session,
+            key=store_key,
+            content_type=_POSTER_CONTENT_TYPE,
+        )
+        lecture_video.poster_stored_object_id = stored_object.id
+        lecture_video.poster_stored_object = stored_object
+        await session.flush()
+        return stored_object
+    except Exception:
+        logger.exception(
+            "Failed to persist lecture video poster row. lecture_video_id=%s key=%s",
+            lecture_video.id,
+            store_key,
+        )
+        try:
+            await config.video_store.store.delete(store_key)
+        except Exception:
+            logger.exception(
+                "Failed to clean up uploaded poster after DB error. key=%s",
+                store_key,
+            )
+        return None
+
+
+async def extract_and_store_poster(
+    session: AsyncSession,
+    lecture_video: models.LectureVideo,
+    *,
+    local_video_path: str | None = None,
+) -> models.LectureVideoPosterStoredObject | None:
+    if lecture_video.poster_stored_object_id is not None:
+        return None
+
+    if local_video_path is not None:
+        poster_bytes = await extract_poster_bytes(local_video_path=local_video_path)
+    else:
+        video_source = await _video_source_for_lecture_video(lecture_video)
+        if video_source is None:
+            return None
+        poster_bytes = await extract_poster_bytes(video_source=video_source)
+
+    if poster_bytes is None:
+        return None
+
+    return await _persist_poster_bytes(session, lecture_video, poster_bytes)

--- a/pingpong/lecture_video_poster.py
+++ b/pingpong/lecture_video_poster.py
@@ -100,7 +100,9 @@ async def _extract_poster_to_path(
             stderr=asyncio.subprocess.PIPE,
         )
     except FileNotFoundError:
-        logger.warning("ffmpeg is unavailable; skipping lecture video poster extraction")
+        logger.warning(
+            "ffmpeg is unavailable; skipping lecture video poster extraction"
+        )
         return False
 
     try:

--- a/pingpong/lecture_video_processing.py
+++ b/pingpong/lecture_video_processing.py
@@ -19,7 +19,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import pingpong.models as models
 import pingpong.schemas as schemas
-from pingpong import gemini, lecture_video_manifest_generation, lecture_video_service
+from pingpong import (
+    gemini,
+    lecture_video_manifest_generation,
+    lecture_video_poster,
+    lecture_video_service,
+)
 from pingpong.ai import get_openai_client_by_class_id
 from pingpong.audio_store import AudioStoreError
 from pingpong.class_credential_validation import (
@@ -864,6 +869,49 @@ async def _ensure_manifest_generation_transcript(
     return generated_transcript
 
 
+async def _extract_manifest_generation_poster(
+    run_id: int,
+    lease_token: str,
+    lecture_video_id: int,
+    video_path: str,
+) -> None:
+    logger.info(
+        "Lecture video manifest extracting poster. run_id=%s lecture_video_id=%s",
+        run_id,
+        lecture_video_id,
+    )
+    async with config.db.driver.async_session() as session:
+        lecture_video = await models.LectureVideo.get_by_id(session, lecture_video_id)
+        if lecture_video is None or lecture_video.poster_stored_object_id is not None:
+            return
+
+        stored_object = await _await_with_run_lease_heartbeat(
+            run_id,
+            lease_token,
+            lecture_video_poster.extract_and_store_poster(
+                session,
+                lecture_video,
+                local_video_path=video_path,
+            ),
+        )
+        if stored_object is None:
+            logger.info(
+                "Lecture video manifest poster not extracted. run_id=%s lecture_video_id=%s",
+                run_id,
+                lecture_video_id,
+            )
+            return
+
+        stored_object_key = stored_object.key
+        await session.commit()
+        logger.info(
+            "Lecture video manifest extracted poster. run_id=%s lecture_video_id=%s key=%s",
+            run_id,
+            lecture_video_id,
+            stored_object_key,
+        )
+
+
 async def _upload_and_generate_manifest(
     run_id: int,
     lease_token: str,
@@ -953,6 +1001,12 @@ async def _process_claimed_manifest_run(run_id: int, lease_token: str) -> None:
             )
             if video_path is None:
                 return
+            await _extract_manifest_generation_poster(
+                run_id,
+                lease_token,
+                context.lecture_video_id,
+                video_path,
+            )
             transcript = await _ensure_manifest_generation_transcript(
                 run_id,
                 lease_token,

--- a/pingpong/lecture_video_service.py
+++ b/pingpong/lecture_video_service.py
@@ -13,7 +13,6 @@ import uuid_utils as uuid
 
 import pingpong.models as models
 import pingpong.schemas as schemas
-from . import lecture_video_poster
 from .authz import AuthzClient, Relation
 from .config import config
 from .video_store import VideoStoreError
@@ -181,13 +180,6 @@ async def create_lecture_video(
             user_id=uploader_id,
         )
         lecture_video.stored_object = stored_object
-        try:
-            await lecture_video_poster.extract_and_store_poster(session, lecture_video)
-        except Exception:
-            logger.exception(
-                "Failed to extract lecture video poster on upload. lecture_video_id=%s",
-                lecture_video.id,
-            )
         return lecture_video
     except Exception as e:
         try:
@@ -866,10 +858,25 @@ async def delete_lecture_video(
     revoke_grants = lecture_video_grants(lecture_video)
     stored_object_id = lecture_video.stored_object_id
     store_key = lecture_video.stored_object.key if lecture_video.stored_object else None
+    poster_stored_object_id = lecture_video.poster_stored_object_id
+    poster_store_key = None
+    if poster_stored_object_id is not None:
+        poster_stored_object = await session.get(
+            models.LectureVideoPosterStoredObject, poster_stored_object_id
+        )
+        poster_store_key = poster_stored_object.key if poster_stored_object else None
     is_orphaned_after_delete = not bool(
         await session.scalar(
             select(models.LectureVideo.id).where(
                 models.LectureVideo.stored_object_id == stored_object_id,
+                models.LectureVideo.id != lecture_video_id,
+            )
+        )
+    )
+    is_poster_orphaned_after_delete = poster_stored_object_id is not None and not bool(
+        await session.scalar(
+            select(models.LectureVideo.id).where(
+                models.LectureVideo.poster_stored_object_id == poster_stored_object_id,
                 models.LectureVideo.id != lecture_video_id,
             )
         )
@@ -897,12 +904,22 @@ async def delete_lecture_video(
             )
         )
 
+    if is_poster_orphaned_after_delete and poster_stored_object_id is not None:
+        await session.execute(
+            delete(models.LectureVideoPosterStoredObject).where(
+                models.LectureVideoPosterStoredObject.id == poster_stored_object_id
+            )
+        )
+
     if audio_keys_to_delete and config.lecture_video_audio_store:
         for key in audio_keys_to_delete:
             await config.lecture_video_audio_store.store.delete_file(key)
 
     if is_orphaned_after_delete and store_key and config.video_store:
         await config.video_store.store.delete(store_key)
+
+    if is_poster_orphaned_after_delete and poster_store_key and config.video_store:
+        await config.video_store.store.delete(poster_store_key)
 
     if authz is not None:
         await authz.write_safe(revoke=revoke_grants)

--- a/pingpong/lecture_video_service.py
+++ b/pingpong/lecture_video_service.py
@@ -13,6 +13,7 @@ import uuid_utils as uuid
 
 import pingpong.models as models
 import pingpong.schemas as schemas
+from . import lecture_video_poster
 from .authz import AuthzClient, Relation
 from .config import config
 from .video_store import VideoStoreError
@@ -180,6 +181,13 @@ async def create_lecture_video(
             user_id=uploader_id,
         )
         lecture_video.stored_object = stored_object
+        try:
+            await lecture_video_poster.extract_and_store_poster(session, lecture_video)
+        except Exception:
+            logger.exception(
+                "Failed to extract lecture video poster on upload. lecture_video_id=%s",
+                lecture_video.id,
+            )
         return lecture_video
     except Exception as e:
         try:
@@ -664,6 +672,7 @@ async def clone_lecture_video_snapshot(
         source_lecture_video_id_snapshot=lecture_video.id,
         status=lecture_video.status,
         error_message=lecture_video.error_message,
+        poster_stored_object_id=lecture_video.poster_stored_object_id,
     )
     cloned_lecture_video.stored_object = lecture_video.stored_object
     return cloned_lecture_video

--- a/pingpong/migrations/m09_backfill_lecture_video_posters.py
+++ b/pingpong/migrations/m09_backfill_lecture_video_posters.py
@@ -1,0 +1,74 @@
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+import pingpong.models as models
+from pingpong.config import config
+from pingpong.lecture_video_poster import extract_and_store_poster
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 25
+
+
+async def backfill_lecture_video_posters(session: AsyncSession) -> int:
+    if not config.video_store:
+        logger.warning(
+            "No video store configured; skipping lecture video poster backfill."
+        )
+        return 0
+
+    extracted = 0
+    skipped = 0
+    last_processed_id = 0
+
+    while True:
+        result = await session.execute(
+            select(models.LectureVideo)
+            .where(models.LectureVideo.poster_stored_object_id.is_(None))
+            .where(models.LectureVideo.id > last_processed_id)
+            .order_by(models.LectureVideo.id.asc())
+            .options(selectinload(models.LectureVideo.stored_object))
+            .limit(_BATCH_SIZE)
+        )
+        lecture_videos = result.scalars().all()
+        if not lecture_videos:
+            break
+
+        for lecture_video in lecture_videos:
+            last_processed_id = lecture_video.id
+            try:
+                stored_object = await extract_and_store_poster(session, lecture_video)
+            except Exception:
+                skipped += 1
+                logger.exception(
+                    "Unexpected error backfilling lecture video poster. lecture_video_id=%s",
+                    lecture_video.id,
+                )
+                continue
+
+            if stored_object is None:
+                skipped += 1
+                logger.warning(
+                    "Could not generate poster for lecture video. lecture_video_id=%s",
+                    lecture_video.id,
+                )
+                continue
+
+            extracted += 1
+            logger.info(
+                "Backfilled lecture video poster. lecture_video_id=%s key=%s",
+                lecture_video.id,
+                stored_object.key,
+            )
+        await session.commit()
+        session.expunge_all()
+
+    logger.info(
+        "Finished backfilling lecture video posters: extracted=%s skipped=%s",
+        extracted,
+        skipped,
+    )
+    return extracted

--- a/pingpong/migrations/m09_backfill_lecture_video_posters.py
+++ b/pingpong/migrations/m09_backfill_lecture_video_posters.py
@@ -37,15 +37,30 @@ async def backfill_lecture_video_posters(session: AsyncSession) -> int:
         if not lecture_videos:
             break
 
-        for lecture_video in lecture_videos:
-            last_processed_id = lecture_video.id
+        lecture_video_ids = [lecture_video.id for lecture_video in lecture_videos]
+        for lecture_video_id in lecture_video_ids:
+            last_processed_id = lecture_video_id
+            lecture_video = await session.get(
+                models.LectureVideo,
+                lecture_video_id,
+                options=[selectinload(models.LectureVideo.stored_object)],
+            )
+            if lecture_video is None:
+                skipped += 1
+                logger.warning(
+                    "Could not find lecture video for poster backfill. lecture_video_id=%s",
+                    lecture_video_id,
+                )
+                continue
+
             try:
                 stored_object = await extract_and_store_poster(session, lecture_video)
             except Exception:
+                await session.rollback()
                 skipped += 1
                 logger.exception(
                     "Unexpected error backfilling lecture video poster. lecture_video_id=%s",
-                    lecture_video.id,
+                    lecture_video_id,
                 )
                 continue
 
@@ -53,17 +68,19 @@ async def backfill_lecture_video_posters(session: AsyncSession) -> int:
                 skipped += 1
                 logger.warning(
                     "Could not generate poster for lecture video. lecture_video_id=%s",
-                    lecture_video.id,
+                    lecture_video_id,
                 )
                 continue
 
+            stored_object_key = stored_object.key
+            await session.commit()
             extracted += 1
             logger.info(
                 "Backfilled lecture video poster. lecture_video_id=%s key=%s",
-                lecture_video.id,
-                stored_object.key,
+                lecture_video_id,
+                stored_object_key,
             )
-        await session.commit()
+        # Keep long-running backfills from retaining every processed ORM object.
         session.expunge_all()
 
     logger.info(

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -2013,6 +2013,36 @@ class LectureVideoNarrationStoredObject(Base):
     updated = Column(DateTime(timezone=True), index=True, onupdate=func.now())
 
 
+class LectureVideoPosterStoredObject(Base):
+    __tablename__ = "lecture_video_poster_stored_objects"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    key = Column(String, nullable=False, unique=True)
+    content_type = Column(String, nullable=False)
+    lecture_videos = relationship(
+        "LectureVideo", back_populates="poster_stored_object"
+    )
+    created = Column(DateTime(timezone=True), server_default=func.now())
+    updated = Column(DateTime(timezone=True), onupdate=func.now())
+
+    @classmethod
+    async def create(
+        cls,
+        session: AsyncSession,
+        *,
+        key: str,
+        content_type: str,
+    ) -> "LectureVideoPosterStoredObject":
+        stored_object = LectureVideoPosterStoredObject(
+            key=key,
+            content_type=content_type,
+        )
+        session.add(stored_object)
+        await session.flush()
+        await session.refresh(stored_object)
+        return stored_object
+
+
 # Single-select correctness gets its own storage so multi-select can use a
 # separate schema later without overloading the same table.
 lecture_video_question_single_select_correct_option_association = Table(
@@ -2054,6 +2084,19 @@ class LectureVideo(Base):
     )
     stored_object = relationship(
         "LectureVideoStoredObject", back_populates="lecture_videos", uselist=False
+    )
+    poster_stored_object_id = Column(
+        Integer,
+        ForeignKey(
+            "lecture_video_poster_stored_objects.id",
+            name="fk_lecture_videos_poster_stored_object_id",
+        ),
+        nullable=True,
+    )
+    poster_stored_object = relationship(
+        "LectureVideoPosterStoredObject",
+        back_populates="lecture_videos",
+        uselist=False,
     )
     # Immutable provenance pointer to the immediate source snapshot when this
     # lecture video was cloned. This is intentionally not a live FK because
@@ -2120,6 +2163,7 @@ class LectureVideo(Base):
         source_lecture_video_id_snapshot: int | None = None,
         status: schemas.LectureVideoStatus = schemas.LectureVideoStatus.UPLOADED,
         error_message: str | None = None,
+        poster_stored_object_id: int | None = None,
     ) -> "LectureVideo":
         lecture_video = LectureVideo(
             class_id=class_id,
@@ -2137,6 +2181,7 @@ class LectureVideo(Base):
             status=status,
             error_message=error_message,
             uploader_id=user_id,
+            poster_stored_object_id=poster_stored_object_id,
         )
         session.add(lecture_video)
         await session.flush()

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -2375,6 +2375,7 @@ class LectureVideo(Base):
             source_lecture_video_id_snapshot=lecture_video.id,
             status=lecture_video.status,
             error_message=lecture_video.error_message,
+            poster_stored_object_id=lecture_video.poster_stored_object_id,
         )
 
         option_map: dict[int, LectureVideoQuestionOption] = {}

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -2019,9 +2019,7 @@ class LectureVideoPosterStoredObject(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     key = Column(String, nullable=False, unique=True)
     content_type = Column(String, nullable=False)
-    lecture_videos = relationship(
-        "LectureVideo", back_populates="poster_stored_object"
-    )
+    lecture_videos = relationship("LectureVideo", back_populates="poster_stored_object")
     created = Column(DateTime(timezone=True), server_default=func.now())
     updated = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -107,10 +107,9 @@ from pingpong.summary import send_class_summary_to_user_task
 from pingpong.video_store import VideoStoreError
 
 from . import (
-    lecture_video_chat,
     assistant_service,
+    lecture_video_chat,
     lecture_video_manifest_generation,
-    lecture_video_poster,
     lecture_video_processing,
     lecture_video_runtime,
     lecture_video_service,
@@ -8590,17 +8589,7 @@ async def get_assistant_lecture_video_poster(
         raise HTTPException(status_code=404, detail="Lecture video not found.")
 
     if lecture_video.poster_stored_object_id is None:
-        try:
-            await lecture_video_poster.extract_and_store_poster(
-                request.state["db"], lecture_video
-            )
-        except Exception:
-            logger.exception(
-                "Failed to lazily extract lecture video poster. lecture_video_id=%s",
-                lecture_video.id,
-            )
-        if lecture_video.poster_stored_object_id is None:
-            raise HTTPException(status_code=404, detail="Poster not available.")
+        raise HTTPException(status_code=404, detail="Poster not available.")
 
     poster = await request.state["db"].get(
         models.LectureVideoPosterStoredObject, lecture_video.poster_stored_object_id

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -110,6 +110,7 @@ from . import (
     lecture_video_chat,
     assistant_service,
     lecture_video_manifest_generation,
+    lecture_video_poster,
     lecture_video_processing,
     lecture_video_runtime,
     lecture_video_service,
@@ -8560,6 +8561,71 @@ async def upload_lecture_video_for_assistant(
     )
     return await lecture_video_service.lecture_video_summary_from_model(
         request.state["db"], lecture_video
+    )
+
+
+@v1.get(
+    "/class/{class_id}/assistant/{assistant_id}/lecture-video/poster",
+    dependencies=[Depends(Authz("can_view", "assistant:{assistant_id}"))],
+    response_class=StreamingResponse,
+)
+async def get_assistant_lecture_video_poster(
+    class_id: str,
+    assistant_id: str,
+    request: StateRequest,
+):
+    if not config.video_store:
+        raise HTTPException(status_code=404, detail="No Video Store exists.")
+
+    assistant = await lecture_video_service.get_lecture_video_assistant_for_class(
+        request.state["db"], int(assistant_id), int(class_id)
+    )
+    if assistant.lecture_video_id is None:
+        raise HTTPException(status_code=404, detail="Lecture video not found.")
+
+    lecture_video = await models.LectureVideo.get_by_id(
+        request.state["db"], assistant.lecture_video_id
+    )
+    if lecture_video is None:
+        raise HTTPException(status_code=404, detail="Lecture video not found.")
+
+    if lecture_video.poster_stored_object_id is None:
+        try:
+            await lecture_video_poster.extract_and_store_poster(
+                request.state["db"], lecture_video
+            )
+        except Exception:
+            logger.exception(
+                "Failed to lazily extract lecture video poster. lecture_video_id=%s",
+                lecture_video.id,
+            )
+        if lecture_video.poster_stored_object_id is None:
+            raise HTTPException(status_code=404, detail="Poster not available.")
+
+    poster = await request.state["db"].get(
+        models.LectureVideoPosterStoredObject, lecture_video.poster_stored_object_id
+    )
+    if poster is None:
+        raise HTTPException(status_code=404, detail="Poster not available.")
+
+    try:
+        stream = await prefetch_stream(
+            config.video_store.store.stream_video_range(key=poster.key),
+            store_error=VideoStoreError,
+            logger=logger,
+            store_error_log="VideoStoreError while streaming lecture video poster; aborting stream.",
+            unexpected_error_log="Unexpected error while streaming lecture video poster",
+        )
+    except VideoStoreError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unable to stream lecture video poster: {e.detail or str(e)}",
+        ) from e
+
+    return StreamingResponse(
+        stream,
+        media_type=poster.content_type or "image/webp",
+        headers={"Cache-Control": "private, max-age=86400"},
     )
 
 

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -9855,6 +9855,10 @@ async def test_copy_lecture_video_assistant_to_other_class_clones_lecture_video_
             status=schemas.LectureVideoStatus.READY.value,
             uploader_id=123,
         )
+        lecture_video.poster_stored_object = models.LectureVideoPosterStoredObject(
+            key="copy-source-poster.webp",
+            content_type="image/webp",
+        )
         session.add(source_class)
         session.add(target_class)
         session.add(lecture_video)
@@ -9942,6 +9946,7 @@ async def test_copy_lecture_video_assistant_to_other_class_clones_lecture_video_
     assert copied_assistant.lecture_video_id != lecture_video.id
     assert copied_video.class_id == 2
     assert copied_video.stored_object_id == lecture_video.stored_object_id
+    assert copied_video.poster_stored_object_id == source_video.poster_stored_object_id
     assert copied_video.source_lecture_video_id_snapshot == lecture_video.id
     assert copied_question == "Copied question?"
 
@@ -10891,6 +10896,73 @@ async def test_lecture_video_delete_deletes_unused_video_stored_object(
     assert stored_object_after_first_delete is not None
     assert stored_object_after_second_delete is None
     assert not (video_dir / "shared-video.mp4").exists()
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_video_delete_deletes_unused_poster_stored_object(
+    db, institution, config, monkeypatch, tmp_path
+):
+    video_dir = tmp_path / "videos"
+    monkeypatch.setattr(
+        config,
+        "video_store",
+        LocalVideoStoreSettings(type="local", save_target=str(video_dir)),
+    )
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Lecture Class",
+            institution_id=institution.id,
+            api_key="sk-test",
+        )
+        stored_object = models.LectureVideoStoredObject(
+            key="shared-video.mp4",
+            original_filename="shared-video.mp4",
+            content_type="video/mp4",
+            content_length=1000,
+        )
+        poster_stored_object = models.LectureVideoPosterStoredObject(
+            key="shared-poster.webp",
+            content_type="image/webp",
+        )
+        session.add_all([class_, stored_object, poster_stored_object])
+        await session.flush()
+        video_dir.mkdir(parents=True, exist_ok=True)
+        (video_dir / stored_object.key).write_bytes(b"shared-video")
+        (video_dir / poster_stored_object.key).write_bytes(b"shared-poster")
+
+        first_video = await models.LectureVideo.create(
+            session,
+            class_id=class_.id,
+            stored_object_id=stored_object.id,
+            user_id=None,
+            poster_stored_object_id=poster_stored_object.id,
+        )
+        second_video = await models.LectureVideo.create(
+            session,
+            class_id=class_.id,
+            stored_object_id=stored_object.id,
+            user_id=None,
+            poster_stored_object_id=poster_stored_object.id,
+        )
+        await session.commit()
+
+        await lecture_video_service.delete_lecture_video(session, first_video.id)
+        await session.commit()
+        poster_after_first_delete = await session.get(
+            models.LectureVideoPosterStoredObject, poster_stored_object.id
+        )
+
+        await lecture_video_service.delete_lecture_video(session, second_video.id)
+        await session.commit()
+        poster_after_second_delete = await session.get(
+            models.LectureVideoPosterStoredObject, poster_stored_object.id
+        )
+
+    assert poster_after_first_delete is not None
+    assert poster_after_second_delete is None
+    assert not (video_dir / "shared-poster.webp").exists()
 
 
 @with_institution(11, "Test Institution")

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -142,14 +142,16 @@
 	let assistant = {} as Assistant;
 	$: assistantMeta = getAssistantMetadata(assistant);
 	let lectureVideoPosterFailed = false;
+	let lectureVideoPosterLoaded = false;
 	$: lectureVideoPosterUrl =
 		assistant.interaction_mode === 'lecture_video' && data?.class?.id && assistant.id
 			? `/api/v1/class/${data.class.id}/assistant/${assistant.id}/lecture-video/poster`
 			: '';
 	$: {
 		// Reset failure state when the selected assistant changes so we re-attempt the new poster.
-		void assistant.id;
+		assistant.id;
 		lectureVideoPosterFailed = false;
+		lectureVideoPosterLoaded = false;
 	}
 	// Whether billing is set up for the class (which controls everything).
 	$: hasVisibleAssistants = assistants.length > 0;
@@ -833,12 +835,21 @@
 				{:else if assistant.interaction_mode === 'lecture_video'}
 					<div class="h-[5%] max-h-8"></div>
 					{#if lectureVideoPosterUrl && !lectureVideoPosterFailed}
-						<img
-							src={lectureVideoPosterUrl}
-							alt=""
-							class="aspect-video w-full max-w-md rounded-lg object-cover shadow-lg"
-							onerror={() => (lectureVideoPosterFailed = true)}
-						/>
+						<div class="relative aspect-video w-full max-w-md overflow-hidden rounded-lg shadow-lg">
+							{#if !lectureVideoPosterLoaded}
+								<div class="flex h-full w-full items-center justify-center bg-blue-light-50">
+									<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />
+								</div>
+							{/if}
+							<img
+								src={lectureVideoPosterUrl}
+								alt=""
+								class="absolute inset-0 h-full w-full object-cover transition-opacity"
+								class:opacity-0={!lectureVideoPosterLoaded}
+								onload={() => (lectureVideoPosterLoaded = true)}
+								onerror={() => (lectureVideoPosterFailed = true)}
+							/>
+						</div>
 					{:else}
 						<div class="rounded-lg bg-blue-light-50 p-3">
 							<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -143,15 +143,18 @@
 	$: assistantMeta = getAssistantMetadata(assistant);
 	let lectureVideoPosterFailed = false;
 	let lectureVideoPosterLoaded = false;
+	let lectureVideoPosterAssistantId: number | undefined;
 	$: lectureVideoPosterUrl =
 		assistant.interaction_mode === 'lecture_video' && data?.class?.id && assistant.id
 			? `/api/v1/class/${data.class.id}/assistant/${assistant.id}/lecture-video/poster`
 			: '';
 	$: {
 		// Reset failure state when the selected assistant changes so we re-attempt the new poster.
-		assistant.id;
-		lectureVideoPosterFailed = false;
-		lectureVideoPosterLoaded = false;
+		if (lectureVideoPosterAssistantId !== assistant.id) {
+			lectureVideoPosterAssistantId = assistant.id;
+			lectureVideoPosterFailed = false;
+			lectureVideoPosterLoaded = false;
+		}
 	}
 	// Whether billing is set up for the class (which controls everything).
 	$: hasVisibleAssistants = assistants.length > 0;

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -123,8 +123,34 @@
 		(asst: Assistant) => asst.creator_id !== data.me.user?.id
 	);
 	$: otherAssistants = otherAssistantsAll.filter((asst: Assistant) => !asst.endorsed);
+	$: lessonAssistants = assistants.filter(
+		(asst: Assistant) => asst.interaction_mode === 'lecture_video'
+	);
+	// In LV mode, lessons are surfaced in their own section at the top of the
+	// dropdown, so exclude them from the source-attribution sections to avoid
+	// listing the same assistant twice.
+	$: inLectureVideoMode = assistant.interaction_mode === 'lecture_video';
+	$: courseAssistantsForDropdown = inLectureVideoMode
+		? courseAssistants.filter((asst: Assistant) => asst.interaction_mode !== 'lecture_video')
+		: courseAssistants;
+	$: myAssistantsForDropdown = inLectureVideoMode
+		? myAssistants.filter((asst: Assistant) => asst.interaction_mode !== 'lecture_video')
+		: myAssistants;
+	$: otherAssistantsForDropdown = inLectureVideoMode
+		? otherAssistants.filter((asst: Assistant) => asst.interaction_mode !== 'lecture_video')
+		: otherAssistants;
 	let assistant = {} as Assistant;
 	$: assistantMeta = getAssistantMetadata(assistant);
+	let lectureVideoPosterFailed = false;
+	$: lectureVideoPosterUrl =
+		assistant.interaction_mode === 'lecture_video' && data?.class?.id && assistant.id
+			? `/api/v1/class/${data.class.id}/assistant/${assistant.id}/lecture-video/poster`
+			: '';
+	$: {
+		// Reset failure state when the selected assistant changes so we re-attempt the new poster.
+		void assistant.id;
+		lectureVideoPosterFailed = false;
+	}
 	// Whether billing is set up for the class (which controls everything).
 	$: hasVisibleAssistants = assistants.length > 0;
 	$: isConfigured = hasVisibleAssistants && data?.hasAPIKey;
@@ -534,7 +560,7 @@
 					<div class="flex flex-col items-center justify-center gap-1">
 						<div class="text-xl leading-tight font-medium md:text-4xl">{assistant.name}</div>
 					</div>
-					{#if !(data.isSharedAssistantPage || data.isSharedThreadPage)}
+					{#if !(data.isSharedAssistantPage || data.isSharedThreadPage) && assistant.interaction_mode !== 'lecture_video'}
 						<div
 							class="flex flex-row items-center gap-1 text-xs font-normal text-gray-400 sm:text-sm"
 						>
@@ -560,7 +586,11 @@
 								(assistantDropdownOpen ? ' bg-gray-50' : '')}
 							type="button"
 						>
-							<span class="text-center text-xs font-normal"> Change assistant </span>
+							<span class="text-center text-xs font-normal">
+								{assistant.interaction_mode === 'lecture_video'
+									? 'Change lesson'
+									: 'Change assistant'}
+							</span>
 							<ChevronSortOutline class="text-gray-500" size="xs" />
 						</Button>
 						<Dropdown
@@ -568,8 +598,49 @@
 							classContainer="rounded-3xl lg:w-1/3 md:w-1/2 w-2/3 border border-gray-100 max-h-[40%] overflow-y-auto"
 							bind:open={assistantDropdownOpen}
 						>
+							<!-- Lessons (LV mode only) -->
+							{#if inLectureVideoMode && lessonAssistants.length > 0}
+								<DropdownItem
+									class="pointer-events-none pb-1 font-normal tracking-tight text-gray-400 normal-case select-none hover:bg-none"
+								>
+									Lessons
+								</DropdownItem>
+								{#each lessonAssistants as asst (asst.id)}
+									<DropdownItem
+										onclick={() => selectAi(asst)}
+										ontouchstart={() => selectAi(asst)}
+										class="group max-w-full rounded-lg font-normal tracking-tight normal-case select-none hover:bg-gray-100"
+									>
+										<div class="flex max-w-full flex-row items-center justify-between gap-5">
+											<div class="flex w-10/12 flex-col gap-1">
+												<div class="text-sm leading-snug">
+													<ClapperboardPlayOutline
+														size="sm"
+														class="inline align-text-bottom text-gray-400"
+													/>
+													<Tooltip>Lecture Video mode assistant</Tooltip>
+													{asst.name}
+												</div>
+												{#if asst.description}
+													<div class="truncate text-xs text-gray-500">
+														{asst.description}
+													</div>
+												{/if}
+											</div>
+
+											{#if assistant.id === asst.id}
+												<CheckCircleSolid size="md" class="text-blue-dark-40 group-hover:hidden" />
+											{/if}
+										</div>
+									</DropdownItem>
+								{/each}
+								{#if courseAssistantsForDropdown.length > 0 || myAssistantsForDropdown.length > 0 || otherAssistantsForDropdown.length > 0}
+									<DropdownDivider />
+								{/if}
+							{/if}
+
 							<!-- Show course assistants first -->
-							{#if courseAssistants.length > 0}
+							{#if courseAssistantsForDropdown.length > 0}
 								<DropdownItem
 									class="pointer-events-none pb-1 font-normal tracking-tight text-gray-400 normal-case select-none hover:bg-none"
 								>
@@ -577,7 +648,7 @@
 								</DropdownItem>
 							{/if}
 
-							{#each courseAssistants as asst (asst.id)}
+							{#each courseAssistantsForDropdown as asst (asst.id)}
 								<DropdownItem
 									onclick={() => selectAi(asst)}
 									ontouchstart={() => selectAi(asst)}
@@ -616,19 +687,19 @@
 							{/each}
 
 							<!-- Show a divider if necessary -->
-							{#if myAssistants.length > 0 && courseAssistants.length > 0}
+							{#if myAssistantsForDropdown.length > 0 && courseAssistantsForDropdown.length > 0}
 								<DropdownDivider />
 							{/if}
 
 							<!-- Show the user's assistants -->
-							{#if myAssistants.length > 0}
+							{#if myAssistantsForDropdown.length > 0}
 								<DropdownItem
 									class="pointer-events-none pb-1 font-normal tracking-tight text-gray-400 normal-case select-none hover:bg-none"
 								>
 									Your assistants
 								</DropdownItem>
 
-								{#each myAssistants as asst (asst.id)}
+								{#each myAssistantsForDropdown as asst (asst.id)}
 									<DropdownItem
 										onclick={() => selectAi(asst)}
 										ontouchstart={() => selectAi(asst)}
@@ -667,19 +738,19 @@
 								{/each}
 							{/if}
 							<!-- Show a divider if necessary -->
-							{#if otherAssistants.length > 0 && (myAssistants.length > 0 || courseAssistants.length > 0)}
+							{#if otherAssistantsForDropdown.length > 0 && (myAssistantsForDropdown.length > 0 || courseAssistantsForDropdown.length > 0)}
 								<DropdownDivider />
 							{/if}
 
 							<!-- Show the user's assistants -->
-							{#if otherAssistants.length > 0}
+							{#if otherAssistantsForDropdown.length > 0}
 								<DropdownItem
 									class="pointer-events-none pb-1 font-normal tracking-tight text-gray-400 normal-case select-none hover:bg-none"
 								>
 									Other assistants
 								</DropdownItem>
 
-								{#each otherAssistants as asst (asst.id)}
+								{#each otherAssistantsForDropdown as asst (asst.id)}
 									<DropdownItem
 										onclick={() => selectAi(asst)}
 										ontouchstart={() => selectAi(asst)}
@@ -761,9 +832,18 @@
 					{/if}
 				{:else if assistant.interaction_mode === 'lecture_video'}
 					<div class="h-[5%] max-h-8"></div>
-					<div class="rounded-lg bg-blue-light-50 p-3">
-						<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />
-					</div>
+					{#if lectureVideoPosterUrl && !lectureVideoPosterFailed}
+						<img
+							src={lectureVideoPosterUrl}
+							alt=""
+							class="aspect-video w-full max-w-md rounded-lg object-cover shadow-sm"
+							onerror={() => (lectureVideoPosterFailed = true)}
+						/>
+					{:else}
+						<div class="rounded-lg bg-blue-light-50 p-3">
+							<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />
+						</div>
+					{/if}
 					<div class="flex min-w-2/5 flex-col items-center">
 						<p class="text-center text-sm font-semibold text-blue-dark-40 sm:text-xl">
 							Learn with Interactive Videos

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -836,7 +836,7 @@
 						<img
 							src={lectureVideoPosterUrl}
 							alt=""
-							class="aspect-video w-full max-w-md rounded-lg object-cover shadow-sm"
+							class="aspect-video w-full max-w-md rounded-lg object-cover shadow-lg"
 							onerror={() => (lectureVideoPosterFailed = true)}
 						/>
 					{:else}


### PR DESCRIPTION
## Lecture Video (Preview)
### New Features
* Lecture Video landing pages now show a still frame from the lecture video, making it easier to identify a lesson at a glance.

### Updates & Improvements
* The assistant dropdown now groups every video lesson together under a new "Lessons" section at the top when viewing a Lecture Video assistant.
* Renamed the "Change assistant" button to "Change lesson" on Lecture Video landing pages.
* Removed the "Group assistant" / "Created by you" attribution row from Lecture Video landing pages to keep the page focused on the lesson.