### PR TITLE
feat(next): selective annotation inclusion in input

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -171,6 +171,14 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
 
+CONTAINER_TTL_SECONDS = 19 * 60
+ANNOTATION_PRIORITY_TYPES = (
+    AnnotationType.CONTAINER_FILE_CITATION,
+    AnnotationType.FILE_CITATION,
+    AnnotationType.URL_CITATION,
+    AnnotationType.FILE_PATH,
+)
+
 
 def get_response_message_phase_value(phase: object) -> str | None:
     return phase if isinstance(phase, str) else None
@@ -639,9 +647,15 @@ async def build_response_input_item_list(
             return True
         return (
             utcnow() - container_by_last_active_time[container_id]
-        ).total_seconds() > 19 * 60
+        ).total_seconds() > CONTAINER_TTL_SECONDS
 
-    async for tool_call in models.Thread.list_all_tool_calls_gen(session, thread_id):
+    tool_calls = [
+        tool_call
+        async for tool_call in models.Thread.list_all_tool_calls_gen(session, thread_id)
+    ]
+    for tool_call in tool_calls:
+        if tool_call.status == ToolCallStatus.INCOMPLETE:
+            continue
         if tool_call.type != ToolCallType.CODE_INTERPRETER:
             continue
         update_container_last_active_time(
@@ -681,30 +695,28 @@ async def build_response_input_item_list(
                 case MessagePartType.OUTPUT_TEXT:
                     annotations: list[Annotation] = []
                     stored_annotations = list(content.annotations)
-                    selected_citation_type = next(
+                    present_annotation_types = {
+                        annotation.type
+                        for annotation in stored_annotations
+                        if annotation.type in ANNOTATION_PRIORITY_TYPES
+                        and (
+                            annotation.type != AnnotationType.CONTAINER_FILE_CITATION
+                            or not is_container_expired(annotation.container_id)
+                        )
+                    }
+                    selected_annotation_type = next(
                         (
                             annotation_type
-                            for annotation_type in (
-                                AnnotationType.CONTAINER_FILE_CITATION,
-                                AnnotationType.FILE_CITATION,
-                                AnnotationType.URL_CITATION,
-                            )
-                            if any(
-                                annotation.type == annotation_type
-                                and (
-                                    annotation_type
-                                    != AnnotationType.CONTAINER_FILE_CITATION
-                                    or not is_container_expired(annotation.container_id)
-                                )
-                                for annotation in stored_annotations
-                            )
+                            for annotation_type in ANNOTATION_PRIORITY_TYPES
+                            if annotation_type in present_annotation_types
                         ),
                         None,
                     )
                     for annotation in stored_annotations:
                         if (
-                            selected_citation_type is not None
-                            and annotation.type != selected_citation_type
+                            selected_annotation_type is not None
+                            and annotation.type in ANNOTATION_PRIORITY_TYPES
+                            and annotation.type != selected_annotation_type
                         ):
                             continue
                         match annotation.type:
@@ -720,7 +732,7 @@ async def build_response_input_item_list(
                             case AnnotationType.FILE_PATH:
                                 annotations.append(
                                     AnnotationFilePath(
-                                        file_path=annotation.file_path,
+                                        file_id=annotation.file_id,
                                         index=annotation.index or 0,
                                         type="file_path",
                                     )
@@ -798,9 +810,7 @@ async def build_response_input_item_list(
         )
 
     if not user_assistant_messages_only:
-        async for tool_call in models.Thread.list_all_tool_calls_gen(
-            session, thread_id
-        ):
+        for tool_call in tool_calls:
             if tool_call.status == ToolCallStatus.INCOMPLETE:
                 continue
             match tool_call.type:

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -649,6 +649,11 @@ async def build_response_input_item_list(
             utcnow() - container_by_last_active_time[container_id]
         ).total_seconds() > CONTAINER_TTL_SECONDS
 
+    def is_container_file_citation_replayable(annotation: models.Annotation) -> bool:
+        return bool(
+            annotation.file_id and annotation.file_id.startswith("cfile_")
+        ) and (not is_container_expired(annotation.container_id))
+
     tool_calls = [
         tool_call
         async for tool_call in models.Thread.list_all_tool_calls_gen(session, thread_id)
@@ -701,7 +706,7 @@ async def build_response_input_item_list(
                         if annotation.type in ANNOTATION_PRIORITY_TYPES
                         and (
                             annotation.type != AnnotationType.CONTAINER_FILE_CITATION
-                            or not is_container_expired(annotation.container_id)
+                            or is_container_file_citation_replayable(annotation)
                         )
                     }
                     selected_annotation_type = next(
@@ -748,7 +753,9 @@ async def build_response_input_item_list(
                                     )
                                 )
                             case AnnotationType.CONTAINER_FILE_CITATION:
-                                if is_container_expired(annotation.container_id):
+                                if not is_container_file_citation_replayable(
+                                    annotation
+                                ):
                                     continue
                                 annotations.append(
                                     AnnotationContainerFileCitation(
@@ -1535,7 +1542,7 @@ class BufferedResponseStreamHandler:
 
         annotation_data = {
             "type": AnnotationType.CONTAINER_FILE_CITATION,
-            "file_id": file.file_id,
+            "file_id": data["file_id"],
             "file_object_id": file.id if not file.vision_file_id else None,
             "vision_file_id": file.vision_file_id,
             "vision_file_object_id": file.id if file.vision_file_id else None,

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -616,10 +616,39 @@ async def build_response_input_item_list(
     response_input_items_with_time: list[
         tuple[datetime, int, str, ResponseInputItemParam]
     ] = []
-    container_by_last_active_time: dict[int, datetime] = {}
+    container_by_last_active_time: dict[str, datetime] = {}
 
     def coerce_utc(value: datetime) -> datetime:
         return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+    def update_container_last_active_time(
+        container_id: str | None,
+        *timestamps: datetime | None,
+    ) -> None:
+        if not container_id:
+            return
+        existing_time = container_by_last_active_time.get(container_id)
+        candidates = [coerce_utc(value) for value in timestamps if value is not None]
+        if existing_time is not None:
+            candidates.append(coerce_utc(existing_time))
+        if candidates:
+            container_by_last_active_time[container_id] = max(candidates)
+
+    def is_container_expired(container_id: str | None) -> bool:
+        if not container_id or container_id not in container_by_last_active_time:
+            return True
+        return (
+            utcnow() - container_by_last_active_time[container_id]
+        ).total_seconds() > 19 * 60
+
+    async for tool_call in models.Thread.list_all_tool_calls_gen(session, thread_id):
+        if tool_call.type != ToolCallType.CODE_INTERPRETER:
+            continue
+        update_container_last_active_time(
+            tool_call.container_id,
+            tool_call.created,
+            getattr(tool_call, "completed", None),
+        )
 
     message_roles = (
         [MessageRole.USER, MessageRole.ASSISTANT]
@@ -651,7 +680,33 @@ async def build_response_input_item_list(
                     )
                 case MessagePartType.OUTPUT_TEXT:
                     annotations: list[Annotation] = []
-                    for annotation in content.annotations:
+                    stored_annotations = list(content.annotations)
+                    selected_citation_type = next(
+                        (
+                            annotation_type
+                            for annotation_type in (
+                                AnnotationType.CONTAINER_FILE_CITATION,
+                                AnnotationType.FILE_CITATION,
+                                AnnotationType.URL_CITATION,
+                            )
+                            if any(
+                                annotation.type == annotation_type
+                                and (
+                                    annotation_type
+                                    != AnnotationType.CONTAINER_FILE_CITATION
+                                    or not is_container_expired(annotation.container_id)
+                                )
+                                for annotation in stored_annotations
+                            )
+                        ),
+                        None,
+                    )
+                    for annotation in stored_annotations:
+                        if (
+                            selected_citation_type is not None
+                            and annotation.type != selected_citation_type
+                        ):
+                            continue
                         match annotation.type:
                             case AnnotationType.FILE_CITATION:
                                 annotations.append(
@@ -681,21 +736,18 @@ async def build_response_input_item_list(
                                     )
                                 )
                             case AnnotationType.CONTAINER_FILE_CITATION:
-                                continue
-                                # The API currently rejects
-                                # container_file_citation as input
-                                #
-                                # annotations.append(
-                                #     AnnotationContainerFileCitation(
-                                #         file_id=annotation.file_id,
-                                #         container_id=annotation.container_id,
-                                #         filename=annotation.filename,
-                                #         start_index=annotation.start_index or 0,
-                                #         end_index=annotation.end_index or 0,
-                                #         type="container_file_citation",
-                                #         index=0,
-                                #     )
-                                # )
+                                if is_container_expired(annotation.container_id):
+                                    continue
+                                annotations.append(
+                                    AnnotationContainerFileCitation(
+                                        file_id=annotation.file_id,
+                                        container_id=annotation.container_id,
+                                        filename=annotation.filename,
+                                        start_index=annotation.start_index or 0,
+                                        end_index=annotation.end_index or 0,
+                                        type="container_file_citation",
+                                    )
+                                )
                             case _:
                                 continue  # Skip unsupported annotation types
 
@@ -779,21 +831,11 @@ async def build_response_input_item_list(
                             ),
                         )
                     )
-
-                    existing_time = container_by_last_active_time.get(
-                        tool_call.container_id
+                    update_container_last_active_time(
+                        tool_call.container_id,
+                        tool_call.created,
+                        getattr(tool_call, "completed", None),
                     )
-                    candidates: list[datetime] = []
-                    if existing_time is not None:
-                        candidates.append(coerce_utc(existing_time))
-                    if tool_call.created is not None:
-                        candidates.append(coerce_utc(tool_call.created))
-                    if getattr(tool_call, "completed", None) is not None:
-                        candidates.append(coerce_utc(tool_call.completed))
-                    if candidates:
-                        container_by_last_active_time[tool_call.container_id] = max(
-                            candidates
-                        )
 
                 case ToolCallType.FILE_SEARCH:
                     file_search_results: list[Result] = []
@@ -1033,11 +1075,7 @@ async def build_response_input_item_list(
         if not container_id:
             expired_ci_output_indices.add(output_index)
             continue
-        if (
-            container_id not in container_by_last_active_time
-            or (utcnow() - container_by_last_active_time[container_id]).total_seconds()
-            > 19 * 60
-        ):
+        if is_container_expired(container_id):
             expired_ci_output_indices.add(output_index)
 
     reasoning_output_indices_to_remove: set[int] = set()

--- a/pingpong/test_ai_build_response_input_item_list.py
+++ b/pingpong/test_ai_build_response_input_item_list.py
@@ -419,6 +419,304 @@ async def test_build_response_input_item_list_replays_developer_and_system_messa
 
 
 @pytest.mark.asyncio
+async def test_build_response_input_item_list_keeps_only_file_citations_when_present(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_mixed_output_text_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the cited source.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=4,
+                            end_index=9,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_123",
+                            filename="source.pdf",
+                            index=14,
+                        ),
+                    ],
+                )
+            ],
+            created=utcnow(),
+        )
+        session.add(message)
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "file_id": "file_123",
+            "filename": "source.pdf",
+            "index": 14,
+            "type": "file_citation",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_keeps_non_file_citations_when_no_file_citation(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_non_file_output_text_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the cited page.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=4,
+                            end_index=9,
+                        ),
+                    ],
+                )
+            ],
+            created=utcnow(),
+        )
+        session.add(message)
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert [annotation["type"] for annotation in annotations] == ["url_citation"]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_prefers_active_container_file_citations(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_container_output_text_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        base_time = utcnow() - timedelta(minutes=5)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=4,
+                            end_index=9,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_search_123",
+                            filename="source.pdf",
+                            index=14,
+                        ),
+                        models.Annotation(
+                            annotation_index=2,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_123",
+                            container_id="container-active-citation",
+                            filename="output.csv",
+                            start_index=14,
+                            end_index=18,
+                        ),
+                    ],
+                )
+            ],
+            created=base_time,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_active_citation",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('ok')",
+            container_id="container-active-citation",
+            created=base_time + timedelta(minutes=1),
+            completed=base_time + timedelta(minutes=2),
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "container_id": "container-active-citation",
+            "end_index": 18,
+            "file_id": "container_file_123",
+            "filename": "output.csv",
+            "start_index": 14,
+            "type": "container_file_citation",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_skips_expired_container_file_citations(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_expired_container_output_text_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        base_time = utcnow() - timedelta(hours=1)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=4,
+                            end_index=9,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_search_456",
+                            filename="source.pdf",
+                            index=14,
+                        ),
+                        models.Annotation(
+                            annotation_index=2,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_456",
+                            container_id="container-expired-citation",
+                            filename="output.csv",
+                            start_index=14,
+                            end_index=18,
+                        ),
+                    ],
+                )
+            ],
+            created=base_time,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_expired_citation",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('expired')",
+            container_id="container-expired-citation",
+            created=base_time + timedelta(minutes=1),
+            completed=base_time + timedelta(minutes=2),
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "file_id": "file_search_456",
+            "filename": "source.pdf",
+            "index": 14,
+            "type": "file_citation",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_build_response_input_item_list_can_build_user_assistant_messages_only(
     db,
 ):

--- a/pingpong/test_ai_build_response_input_item_list.py
+++ b/pingpong/test_ai_build_response_input_item_list.py
@@ -582,7 +582,7 @@ async def test_build_response_input_item_list_prefers_active_container_file_cita
                         models.Annotation(
                             annotation_index=2,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_123",
+                            file_id="cfile_123",
                             container_id="container-active-citation",
                             filename="output.csv",
                             start_index=14,
@@ -619,7 +619,7 @@ async def test_build_response_input_item_list_prefers_active_container_file_cita
         {
             "container_id": "container-active-citation",
             "end_index": 18,
-            "file_id": "container_file_123",
+            "file_id": "cfile_123",
             "filename": "output.csv",
             "start_index": 14,
             "type": "container_file_citation",
@@ -673,7 +673,7 @@ async def test_build_response_input_item_list_skips_expired_container_file_citat
                         models.Annotation(
                             annotation_index=2,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_456",
+                            file_id="cfile_456",
                             container_id="container-expired-citation",
                             filename="output.csv",
                             start_index=14,
@@ -709,6 +709,95 @@ async def test_build_response_input_item_list_skips_expired_container_file_citat
     assert annotations == [
         {
             "file_id": "file_search_456",
+            "filename": "source.pdf",
+            "index": 14,
+            "type": "file_citation",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_skips_legacy_container_file_citations(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_legacy_container_output_text_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        base_time = utcnow() - timedelta(minutes=5)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=4,
+                            end_index=9,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_search_legacy",
+                            filename="source.pdf",
+                            index=14,
+                        ),
+                        models.Annotation(
+                            annotation_index=2,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="file-uploaded-copy",
+                            container_id="container-legacy-citation",
+                            filename="output.csv",
+                            start_index=14,
+                            end_index=18,
+                        ),
+                    ],
+                )
+            ],
+            created=base_time,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_legacy_citation",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('legacy')",
+            container_id="container-legacy-citation",
+            created=base_time + timedelta(minutes=1),
+            completed=base_time + timedelta(minutes=2),
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "file_id": "file_search_legacy",
             "filename": "source.pdf",
             "index": 14,
             "type": "file_citation",
@@ -872,7 +961,7 @@ async def test_build_response_input_item_list_drops_expired_container_only_citat
                         models.Annotation(
                             annotation_index=0,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_expired_only",
+                            file_id="cfile_expired_only",
                             container_id="container-expired-only",
                             filename="output.csv",
                             start_index=8,
@@ -968,7 +1057,7 @@ async def test_build_response_input_item_list_selects_citation_type_per_message_
                         models.Annotation(
                             annotation_index=1,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_part_two",
+                            file_id="cfile_part_two",
                             container_id="container-per-part",
                             filename="output.csv",
                             start_index=8,
@@ -1058,7 +1147,7 @@ async def test_build_response_input_item_list_treats_exact_19_minute_container_a
                         models.Annotation(
                             annotation_index=2,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_boundary",
+                            file_id="cfile_boundary",
                             container_id="container-boundary",
                             filename="output.csv",
                             start_index=8,
@@ -1095,7 +1184,7 @@ async def test_build_response_input_item_list_treats_exact_19_minute_container_a
         {
             "container_id": "container-boundary",
             "end_index": 22,
-            "file_id": "container_file_boundary",
+            "file_id": "cfile_boundary",
             "filename": "output.csv",
             "start_index": 8,
             "type": "container_file_citation",
@@ -1134,7 +1223,7 @@ async def test_build_response_input_item_list_ignores_incomplete_tool_calls_for_
                         models.Annotation(
                             annotation_index=0,
                             type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
-                            file_id="container_file_incomplete",
+                            file_id="cfile_incomplete",
                             container_id="container-incomplete",
                             filename="output.csv",
                             start_index=8,

--- a/pingpong/test_ai_build_response_input_item_list.py
+++ b/pingpong/test_ai_build_response_input_item_list.py
@@ -717,6 +717,458 @@ async def test_build_response_input_item_list_skips_expired_container_file_citat
 
 
 @pytest.mark.asyncio
+async def test_build_response_input_item_list_keeps_file_citation_before_file_path(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_file_path_with_citation_annotations", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file and cited source.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.FILE_PATH,
+                            file_id="file_path_123",
+                            index=8,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=31,
+                            end_index=37,
+                        ),
+                        models.Annotation(
+                            annotation_index=2,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_789",
+                            filename="source.pdf",
+                            index=31,
+                        ),
+                    ],
+                )
+            ],
+            created=utcnow(),
+        )
+        session.add(message)
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "file_id": "file_789",
+            "filename": "source.pdf",
+            "index": 31,
+            "type": "file_citation",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_preserves_file_path_when_no_citation(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(thread_id="thread_file_path_only_annotation", version=3)
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.FILE_PATH,
+                            file_id="file_path_456",
+                            index=8,
+                        ),
+                    ],
+                )
+            ],
+            created=utcnow(),
+        )
+        session.add(message)
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    assert items[0]["content"][0]["annotations"] == [
+        {
+            "file_id": "file_path_456",
+            "index": 8,
+            "type": "file_path",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_drops_expired_container_only_citation(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_expired_container_only_annotation", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        base_time = utcnow() - timedelta(hours=1)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_expired_only",
+                            container_id="container-expired-only",
+                            filename="output.csv",
+                            start_index=8,
+                            end_index=22,
+                        ),
+                    ],
+                )
+            ],
+            created=base_time,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_expired_only",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('expired')",
+            container_id="container-expired-only",
+            created=base_time + timedelta(minutes=1),
+            completed=base_time + timedelta(minutes=2),
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    assert items[0]["content"][0]["annotations"] == []
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_selects_citation_type_per_message_part(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_per_part_annotation_selection", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        base_time = utcnow() - timedelta(minutes=5)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the cited source.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com/one",
+                            title="Example One",
+                            start_index=8,
+                            end_index=14,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_part_one",
+                            filename="source.pdf",
+                            index=8,
+                        ),
+                    ],
+                ),
+                models.MessagePart(
+                    part_index=1,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com/two",
+                            title="Example Two",
+                            start_index=8,
+                            end_index=17,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_part_two",
+                            container_id="container-per-part",
+                            filename="output.csv",
+                            start_index=8,
+                            end_index=22,
+                        ),
+                    ],
+                ),
+            ],
+            created=base_time,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_per_part",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('ok')",
+            container_id="container-per-part",
+            created=base_time + timedelta(minutes=1),
+            completed=base_time + timedelta(minutes=2),
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    assert [
+        annotation["type"] for annotation in items[0]["content"][0]["annotations"]
+    ] == ["file_citation"]
+    assert [
+        annotation["type"] for annotation in items[0]["content"][1]["annotations"]
+    ] == ["container_file_citation"]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_treats_exact_19_minute_container_as_active(
+    db,
+    monkeypatch,
+):
+    fixed_now = utcnow()
+    monkeypatch.setattr(ai, "utcnow", lambda: fixed_now)
+
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_exact_container_expiration_boundary", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        completed_time = fixed_now - timedelta(minutes=19)
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.URL_CITATION,
+                            url="https://example.com",
+                            title="Example",
+                            start_index=8,
+                            end_index=17,
+                        ),
+                        models.Annotation(
+                            annotation_index=1,
+                            type=schemas.AnnotationType.FILE_CITATION,
+                            file_id="file_boundary",
+                            filename="source.pdf",
+                            index=8,
+                        ),
+                        models.Annotation(
+                            annotation_index=2,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_boundary",
+                            container_id="container-boundary",
+                            filename="output.csv",
+                            start_index=8,
+                            end_index=22,
+                        ),
+                    ],
+                )
+            ],
+            created=completed_time - timedelta(minutes=1),
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_boundary",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('boundary')",
+            container_id="container-boundary",
+            created=completed_time - timedelta(minutes=1),
+            completed=completed_time,
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    annotations = items[0]["content"][0]["annotations"]
+    assert annotations == [
+        {
+            "container_id": "container-boundary",
+            "end_index": 22,
+            "file_id": "container_file_boundary",
+            "filename": "output.csv",
+            "start_index": 8,
+            "type": "container_file_citation",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_response_input_item_list_ignores_incomplete_tool_calls_for_container_freshness(
+    db,
+):
+    async with db.async_session() as session:
+        thread = models.Thread(
+            thread_id="thread_incomplete_container_freshness", version=3
+        )
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        now = utcnow()
+        message = models.Message(
+            message_status=schemas.MessageStatus.COMPLETED,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=1,
+            role=schemas.MessageRole.ASSISTANT,
+            content=[
+                models.MessagePart(
+                    part_index=0,
+                    type=schemas.MessagePartType.OUTPUT_TEXT,
+                    text="See the generated file.",
+                    annotations=[
+                        models.Annotation(
+                            annotation_index=0,
+                            type=schemas.AnnotationType.CONTAINER_FILE_CITATION,
+                            file_id="container_file_incomplete",
+                            container_id="container-incomplete",
+                            filename="output.csv",
+                            start_index=8,
+                            end_index=22,
+                        ),
+                    ],
+                )
+            ],
+            created=now,
+        )
+        tool_call = models.ToolCall(
+            tool_call_id="tc_incomplete_freshness",
+            type=schemas.ToolCallType.CODE_INTERPRETER,
+            status=schemas.ToolCallStatus.INCOMPLETE,
+            run_id=run.id,
+            thread_id=thread.id,
+            output_index=2,
+            code="print('still running')",
+            container_id="container-incomplete",
+            created=now,
+        )
+
+        session.add_all([message, tool_call])
+        await session.commit()
+
+        thread_id = thread.id
+
+    async with db.async_session() as session:
+        items = await build_response_input_item_list(session, thread_id=thread_id)
+
+    assert items[0]["content"][0]["annotations"] == []
+
+
+@pytest.mark.asyncio
 async def test_build_response_input_item_list_can_build_user_assistant_messages_only(
     db,
 ):

--- a/pingpong/test_multi_message.py
+++ b/pingpong/test_multi_message.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy import select
 
+from pingpong import ai as ai_module
 from pingpong import models, schemas
 from pingpong.ai import BufferedResponseStreamHandler
 from pingpong.testutil import with_authz, with_user
@@ -109,6 +110,71 @@ async def _setup_handler_with_initial_message(db):
     await handler.on_output_message_created(first_event)
     assert handler.message_id is not None
     return handler, 5001, handler.message_id
+
+
+async def test_container_file_citation_preserves_container_file_id(db, monkeypatch):
+    handler, _, _ = await _setup_handler_with_initial_message(db)
+    await handler.on_output_text_part_created(
+        SimpleNamespace(type="output_text", text="Generated a CSV.")
+    )
+    assert handler.message_part_id is not None
+
+    handler.openai_cli = SimpleNamespace(
+        containers=SimpleNamespace(
+            files=SimpleNamespace(
+                content=SimpleNamespace(
+                    retrieve=AsyncMock(
+                        return_value=SimpleNamespace(content=b"name,email\n")
+                    )
+                )
+            )
+        )
+    )
+
+    async def fake_handle_create_file(session, **_kwargs):
+        file = models.File(
+            file_id="file-uploaded-copy",
+            name="random_names_emails.csv",
+            content_type="text/csv",
+            class_id=handler.class_id,
+        )
+        session.add(file)
+        await session.flush()
+        return schemas.File(
+            id=file.id,
+            file_id=file.file_id,
+            name=file.name,
+            content_type=file.content_type,
+            private=True,
+            uploader_id=handler.user_id,
+            created=file.created,
+            updated=file.updated,
+        )
+
+    monkeypatch.setattr(ai_module, "handle_create_file", fake_handle_create_file)
+
+    await handler.on_output_text_container_file_citation_added(
+        {
+            "type": "container_file_citation",
+            "file_id": "cfile-original-container",
+            "container_id": "cntr-original",
+            "filename": "random_names_emails.csv",
+            "start_index": 10,
+            "end_index": 30,
+        },
+        annotation_index=0,
+    )
+
+    async with db.async_session() as session:
+        annotation = await session.scalar(
+            select(models.Annotation).where(
+                models.Annotation.message_part_id == handler.message_part_id
+            )
+        )
+
+    assert annotation is not None
+    assert annotation.file_id == "cfile-original-container"
+    assert annotation.file_object_id is not None
 
 
 async def _setup_handler_with_phase(db, phase: str):


### PR DESCRIPTION
## Next-Gen Assistants
### Updates & Improvements
* PingPong will now selectively filter assistant message annotations to ensure messages are accepted by the Responses API. When annotations of multiple types are included in the output message, PingPong will selectively send a single type of annotations as input in the following priority order: Code Interpreter files from unexpired containers, File Search results, URL citations, File Paths. Code Interpreter files from expired containers will never be included in the input object, similar to Code Interpreter tool calls from expired containers.
### Resolved Issues
* Fixed: User follow-up messages to assistant responses that contain both File Search and Web Search annotations may fail to send.
* Fixed: Code Interpreter file annotations may save the incorrect OpenAI file ID in the annotation object, which may be later rejected by the API.