### PR TITLE
feat(voice): better persistence behavior when recording

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -5812,6 +5812,32 @@ class VoiceModeRecording(Base):
         return recording
 
     @classmethod
+    async def create_or_replace_for_thread(
+        cls, session: AsyncSession, data: dict
+    ) -> tuple["VoiceModeRecording", str | None]:
+        stmt = (
+            select(VoiceModeRecording)
+            .where(VoiceModeRecording.thread_id == data["thread_id"])
+            .order_by(
+                VoiceModeRecording.created_at.desc(),
+                VoiceModeRecording.id.desc(),
+            )
+            .with_for_update()
+            .limit(1)
+        )
+        existing_recording = await session.scalar(stmt)
+        if existing_recording:
+            previous_recording_id = existing_recording.recording_id
+            existing_recording.recording_id = data["recording_id"]
+            existing_recording.duration = data["duration"]
+            session.add(existing_recording)
+            await session.flush()
+            return existing_recording, previous_recording_id
+
+        recording = await cls.create(session, data)
+        return recording, None
+
+    @classmethod
     async def delete(cls, session: AsyncSession, id_: int) -> None:
         stmt = delete(VoiceModeRecording).where(VoiceModeRecording.id == id_)
         await session.execute(stmt)

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -5815,6 +5815,10 @@ class VoiceModeRecording(Base):
     async def create_or_replace_for_thread(
         cls, session: AsyncSession, data: dict
     ) -> tuple["VoiceModeRecording", str | None]:
+        await session.scalar(
+            select(Thread.id).where(Thread.id == data["thread_id"]).with_for_update()
+        )
+
         stmt = (
             select(VoiceModeRecording)
             .where(VoiceModeRecording.thread_id == data["thread_id"])

--- a/pingpong/realtime_recorder.py
+++ b/pingpong/realtime_recorder.py
@@ -5,6 +5,7 @@ import inspect
 from io import BytesIO
 import logging
 import sys
+import uuid_utils as uuid
 from typing import Union
 
 from pingpong.audio_store import LocalAudioUploadObject, S3AudioUploadObject
@@ -26,6 +27,10 @@ AUDIO_APPLICATION = "voip"
 MIN_AUDIO_CHUNK_SIZE = 5 * 1024 * 1024  # S3 multipart minimum (except last)
 AUDIO_SIZE_TO_READ = 4_096
 STDIN_CHUNK_SIZE = 32_768
+
+
+def make_audio_recording_id(thread_obj_id: str) -> str:
+    return f"realtime_recorder_{thread_obj_id}_{uuid.uuid4().hex}.webm"
 
 
 class UserAudioChunk(BaseModel):
@@ -166,7 +171,12 @@ class RealtimeRecorder:
         """
         Creates a new RealtimeRecorder instance.
         """
-        audio_recording_id = f"realtime_recorder_{thread_obj_id}.webm"
+        audio_recording_id = make_audio_recording_id(thread_obj_id)
+        realtime_recorder_logger.info(
+            "Creating realtime recorder upload: thread_id=%s, recording_id=%s",
+            thread_id,
+            sanitize_for_log(audio_recording_id, max_len=256),
+        )
         audio_store_obj = await config.audio_store.store.create_upload(
             name=audio_recording_id,
             content_type="audio/webm",
@@ -774,19 +784,53 @@ class RealtimeRecorder:
         # Complete the upload
         await self.audio_store_obj.complete_upload()
 
-        # Save the recording metadata to the database
+        # Save the recording metadata to the database. Keep this in a savepoint so
+        # a metadata conflict cannot poison the websocket transaction that contains
+        # the persisted realtime transcript messages.
         try:
-            await VoiceModeRecording.create(
-                session=self.session,
-                data={
-                    "recording_id": self.audio_recording_id,
-                    "thread_id": self.thread_id,
-                    "duration": self.audio_duration,
-                },
-            )
+            async with self.session.begin_nested():
+                (
+                    recording,
+                    previous_recording_id,
+                ) = await VoiceModeRecording.create_or_replace_for_thread(
+                    session=self.session,
+                    data={
+                        "recording_id": self.audio_recording_id,
+                        "thread_id": self.thread_id,
+                        "duration": self.audio_duration,
+                    },
+                )
         except Exception as e:
-            realtime_recorder_logger.exception("Error saving VoiceModeRecording: %s", e)
-            await self.audio_store_obj.delete_file()
+            realtime_recorder_logger.exception(
+                "Error saving VoiceModeRecording; keeping completed audio object. "
+                "thread_id=%s, recording_id=%s, duration_ms=%s, error=%s",
+                self.thread_id,
+                sanitize_for_log(self.audio_recording_id, max_len=256),
+                self.audio_duration,
+                e,
+            )
+        else:
+            if previous_recording_id:
+                realtime_recorder_logger.warning(
+                    "Replaced existing VoiceModeRecording metadata. "
+                    "thread_id=%s, recording_row_id=%s, previous_recording_id=%s, "
+                    "new_recording_id=%s, duration_ms=%s. "
+                    "Previous audio object left intact.",
+                    self.thread_id,
+                    recording.id,
+                    sanitize_for_log(previous_recording_id, max_len=256),
+                    sanitize_for_log(self.audio_recording_id, max_len=256),
+                    self.audio_duration,
+                )
+            else:
+                realtime_recorder_logger.info(
+                    "Saved VoiceModeRecording metadata. "
+                    "thread_id=%s, recording_row_id=%s, recording_id=%s, duration_ms=%s",
+                    self.thread_id,
+                    recording.id,
+                    sanitize_for_log(self.audio_recording_id, max_len=256),
+                    self.audio_duration,
+                )
 
         self.closed = True
 

--- a/pingpong/test_realtime_recorder.py
+++ b/pingpong/test_realtime_recorder.py
@@ -1,8 +1,11 @@
 from typing import Any
 
 import pytest
+from sqlalchemy import select
 
-from pingpong.realtime_recorder import RealtimeRecorder
+from pingpong import models, schemas
+from pingpong.models import VoiceModeRecording
+from pingpong.realtime_recorder import RealtimeRecorder, make_audio_recording_id
 
 
 ONE_SECOND_PCM16 = b"\0" * 48_000
@@ -11,6 +14,7 @@ ONE_SECOND_PCM16 = b"\0" * 48_000
 class FakeFfmpegStdin:
     def __init__(self):
         self.writes: list[bytes] = []
+        self.closed = False
 
     def write(self, data: bytes) -> None:
         self.writes.append(data)
@@ -18,15 +22,47 @@ class FakeFfmpegStdin:
     async def drain(self) -> None:
         pass
 
+    def close(self) -> None:
+        self.closed = True
+
 
 class FakeFfmpeg:
     def __init__(self):
         self.stdin = FakeFfmpegStdin()
 
+    async def wait(self) -> None:
+        pass
+
+
+class FakeAudioStoreObject:
+    def __init__(self):
+        self.completed = False
+        self.deleted = False
+
+    async def complete_upload(self) -> None:
+        self.completed = True
+
+    async def delete_file(self) -> None:
+        self.deleted = True
+
+
+class FakeNestedTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeSession:
+    def begin_nested(self) -> FakeNestedTransaction:
+        return FakeNestedTransaction()
+
 
 def make_recorder() -> RealtimeRecorder:
+    audio_store_obj = FakeAudioStoreObject()
     recorder = RealtimeRecorder(
-        audio_store_obj=object(),  # type: ignore[arg-type]
+        audio_store_obj=audio_store_obj,  # type: ignore[arg-type]
         audio_recording_id="test.webm",
         thread_id=1,
         session=None,  # type: ignore[arg-type]
@@ -34,6 +70,149 @@ def make_recorder() -> RealtimeRecorder:
     recorder.ffmpeg = FakeFfmpeg()  # type: ignore[assignment]
     recorder.end_timestamp = 1_000
     return recorder
+
+
+def test_make_audio_recording_id_keeps_thread_id_and_adds_unique_suffix():
+    first = make_audio_recording_id("79169")
+    second = make_audio_recording_id("79169")
+
+    assert first.startswith("realtime_recorder_79169_")
+    assert first.endswith(".webm")
+    assert second.startswith("realtime_recorder_79169_")
+    assert second.endswith(".webm")
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_create_or_replace_for_thread_updates_existing_recording(db):
+    async with db.async_session() as session:
+        existing = await VoiceModeRecording.create(
+            session,
+            {
+                "thread_id": 123,
+                "recording_id": "old.webm",
+                "duration": 1000,
+            },
+        )
+        existing_id = existing.id
+        await session.commit()
+
+        (
+            recording,
+            previous_recording_id,
+        ) = await VoiceModeRecording.create_or_replace_for_thread(
+            session,
+            {
+                "thread_id": 123,
+                "recording_id": "new.webm",
+                "duration": 2000,
+            },
+        )
+        await session.commit()
+
+        assert recording.id == existing_id
+        assert previous_recording_id == "old.webm"
+
+    async with db.async_session() as session:
+        recording = await session.get(VoiceModeRecording, existing_id)
+        assert recording is not None
+        assert recording.recording_id == "new.webm"
+        assert recording.duration == 2000
+
+
+@pytest.mark.asyncio
+async def test_complete_audio_upload_keeps_completed_object_on_metadata_error(
+    monkeypatch,
+):
+    recorder = make_recorder()
+    audio_store_obj = recorder.audio_store_obj
+    assert isinstance(audio_store_obj, FakeAudioStoreObject)
+    recorder.session = FakeSession()  # type: ignore[assignment]
+    recorder.should_save_audio = True
+    recorder.audio_duration = 1000
+
+    async def fail_create_or_replace_for_thread(cls, session, data):
+        raise RuntimeError("metadata failed")
+
+    monkeypatch.setattr(
+        VoiceModeRecording,
+        "create_or_replace_for_thread",
+        classmethod(fail_create_or_replace_for_thread),
+    )
+
+    await recorder.complete_audio_upload()
+
+    assert audio_store_obj.completed
+    assert not audio_store_obj.deleted
+    assert recorder.closed
+
+
+@pytest.mark.asyncio
+async def test_recording_metadata_error_does_not_roll_back_transcript_messages(db):
+    async with db.async_session() as session:
+        await VoiceModeRecording.create(
+            session,
+            {
+                "thread_id": 999,
+                "recording_id": "test.webm",
+                "duration": 500,
+            },
+        )
+        await session.commit()
+
+    async with db.async_session() as session:
+        thread = models.Thread(thread_id="thread-recording-savepoint", version=3)
+        session.add(thread)
+        await session.flush()
+
+        run = models.Run(status=schemas.RunStatus.COMPLETED, thread_id=thread.id)
+        session.add(run)
+        await session.flush()
+
+        message = await models.Message.create(
+            session,
+            {
+                "message_id": "item-1",
+                "message_status": schemas.MessageStatus.COMPLETED,
+                "run_id": run.id,
+                "thread_id": thread.id,
+                "output_index": 1,
+                "role": schemas.MessageRole.USER,
+            },
+        )
+        await models.MessagePart.create(
+            session,
+            {
+                "message_id": message.id,
+                "part_index": 0,
+                "type": schemas.MessagePartType.INPUT_TEXT,
+                "text": "hello",
+            },
+        )
+
+        recorder = make_recorder()
+        audio_store_obj = recorder.audio_store_obj
+        assert isinstance(audio_store_obj, FakeAudioStoreObject)
+        recorder.session = session
+        recorder.thread_id = thread.id
+        recorder.should_save_audio = True
+        recorder.audio_duration = 1000
+
+        await recorder.complete_audio_upload()
+        await session.commit()
+        message_id = message.id
+
+    async with db.async_session() as session:
+        saved_message = await session.get(models.Message, message_id)
+        assert saved_message is not None
+        assert saved_message.message_id == "item-1"
+        saved_message_part = await session.scalar(
+            select(models.MessagePart).where(
+                models.MessagePart.message_id == message_id
+            )
+        )
+        assert saved_message_part is not None
+        assert saved_message_part.text == "hello"
 
 
 @pytest.mark.asyncio

--- a/pingpong/test_realtime_recorder.py
+++ b/pingpong/test_realtime_recorder.py
@@ -86,15 +86,20 @@ def test_make_audio_recording_id_keeps_thread_id_and_adds_unique_suffix():
 @pytest.mark.asyncio
 async def test_create_or_replace_for_thread_updates_existing_recording(db):
     async with db.async_session() as session:
+        thread = models.Thread(thread_id="thread-create-or-replace", version=3)
+        session.add(thread)
+        await session.flush()
+
         existing = await VoiceModeRecording.create(
             session,
             {
-                "thread_id": 123,
+                "thread_id": thread.id,
                 "recording_id": "old.webm",
                 "duration": 1000,
             },
         )
         existing_id = existing.id
+        thread_id = thread.id
         await session.commit()
 
         (
@@ -103,7 +108,7 @@ async def test_create_or_replace_for_thread_updates_existing_recording(db):
         ) = await VoiceModeRecording.create_or_replace_for_thread(
             session,
             {
-                "thread_id": 123,
+                "thread_id": thread_id,
                 "recording_id": "new.webm",
                 "duration": 2000,
             },
@@ -148,17 +153,18 @@ async def test_complete_audio_upload_keeps_completed_object_on_metadata_error(
 
 
 @pytest.mark.asyncio
-async def test_recording_metadata_error_does_not_roll_back_transcript_messages(db):
-    async with db.async_session() as session:
-        await VoiceModeRecording.create(
-            session,
-            {
-                "thread_id": 999,
-                "recording_id": "test.webm",
-                "duration": 500,
-            },
-        )
-        await session.commit()
+async def test_recording_metadata_error_does_not_roll_back_transcript_messages(
+    db,
+    monkeypatch,
+):
+    async def fail_create_or_replace_for_thread(cls, session, data):
+        raise RuntimeError("metadata failed")
+
+    monkeypatch.setattr(
+        VoiceModeRecording,
+        "create_or_replace_for_thread",
+        classmethod(fail_create_or_replace_for_thread),
+    )
 
     async with db.async_session() as session:
         thread = models.Thread(thread_id="thread-recording-savepoint", version=3)
@@ -201,8 +207,16 @@ async def test_recording_metadata_error_does_not_roll_back_transcript_messages(d
         await recorder.complete_audio_upload()
         await session.commit()
         message_id = message.id
+        thread_id = thread.id
 
     async with db.async_session() as session:
+        recording = await session.scalar(
+            select(VoiceModeRecording).where(
+                VoiceModeRecording.thread_id == thread_id,
+            )
+        )
+        assert recording is None
+
         saved_message = await session.get(models.Message, message_id)
         assert saved_message is not None
         assert saved_message.message_id == "item-1"

--- a/pingpong/test_server_audio_websocket.py
+++ b/pingpong/test_server_audio_websocket.py
@@ -131,7 +131,11 @@ async def test_single_realtime_session_rejects_finished_thread(
             assistant=realtime_assistant(),
             instructions="Speak clearly.",
             timezone=None,
-            voice_mode_recording=object() if has_recording else None,
+            voice_mode_recording=(
+                SimpleNamespace(recording_id="recording.webm")
+                if has_recording
+                else None
+            ),
         )
 
     async def fake_thread_has_messages(_db, _thread_id):
@@ -205,14 +209,15 @@ async def test_create_non_lecture_assistant_clears_elevenlabs_settings(db):
 
     async with db.async_session() as session:
         class_ = models.Class(id=1, name="Test Class", api_key="test-key")
-        session.add(class_)
+        user = models.User(email="assistant-creator@example.com")
+        session.add_all([class_, user])
         await session.flush()
 
         assistant = await models.Assistant.create(
             session,
             req,
             class_id=class_.id,
-            user_id=123,
+            user_id=user.id,
         )
 
         assert assistant.elevenlabs_stability is None

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -13,6 +13,7 @@ from pingpong.ai import (
 )
 from pingpong.session import populate_request
 from pingpong.state_types import StateWebSocket
+from pingpong.log_utils import sanitize_for_log
 from .config import config
 
 browser_connection_logger = logging.getLogger("realtime_browser")
@@ -368,14 +369,16 @@ def ws_with_single_realtime_session(func):
             browser_connection.state["db"], thread.id
         )
         if thread.voice_mode_recording or has_messages:
-            existing_recording_id = getattr(
-                thread.voice_mode_recording, "recording_id", None
+            existing_recording_id = (
+                thread.voice_mode_recording.recording_id
+                if thread.voice_mode_recording
+                else None
             )
             browser_connection_logger.warning(
                 "Rejecting realtime session for finalized thread. "
                 "thread_id=%s, existing_recording_id=%s, has_messages=%s",
                 thread.id,
-                existing_recording_id,
+                sanitize_for_log(existing_recording_id, max_len=256),
                 has_messages,
             )
             await _reject_realtime_session(

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -364,9 +364,20 @@ def ws_with_single_realtime_session(func):
             )
             return None
 
-        if thread.voice_mode_recording or await _thread_has_messages(
+        has_messages = await _thread_has_messages(
             browser_connection.state["db"], thread.id
-        ):
+        )
+        if thread.voice_mode_recording or has_messages:
+            existing_recording_id = getattr(
+                thread.voice_mode_recording, "recording_id", None
+            )
+            browser_connection_logger.warning(
+                "Rejecting realtime session for finalized thread. "
+                "thread_id=%s, existing_recording_id=%s, has_messages=%s",
+                thread.id,
+                existing_recording_id,
+                has_messages,
+            )
             await _reject_realtime_session(
                 browser_connection, VOICE_SESSION_FINAL_MESSAGE
             )


### PR DESCRIPTION
## Voice Mode
### Updates & Improvements
* Voice Mode recordings now use unique storage keys so a later recording attempt on the same thread cannot overwrite or delete a previous recording file.
* Voice Mode now saves realtime transcript messages separately from recording metadata, so a recording metadata error cannot prevent transcript messages from being saved.
* If a recording already exists for a thread, PingPong now updates the recording metadata to the latest completed upload while leaving the previous recording file intact. A clean-up plan for overwritten recordings will be added at a later time.
* Added additional recording diagnostics to help monitor thread IDs, recording IDs, replaced recordings, and finalized-session rejections.

### Resolved Issues
* Fixed: Starting the same Voice Mode session twice may, in rare cases, cause a recording metadata error that deletes a previously saved recording file.
* Fixed: Starting the same Voice Mode session twice in Next-Gen Assistants mode may, in rare cases, cause a recording metadata error that prevents transcript messages from being saved to the database.