### PR TITLE
fix(exports): include all applicable threads

### DIFF
--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -7788,11 +7788,15 @@ class Thread(Base):
         last_activity_before: datetime | None = None,
     ) -> AsyncGenerator["Thread", None]:
         condition = Thread.class_id == int(class_id)
-        if include_only_user_ids:
+        if include_only_user_ids is not None:
+            if not include_only_user_ids:
+                return
             condition = and_(
                 condition, Thread.users.any(User.id.in_(include_only_user_ids))
             )
-        if include_only_assistant_ids:
+        if include_only_assistant_ids is not None:
+            if not include_only_assistant_ids:
+                return
             condition = and_(
                 condition, Thread.assistant_id.in_(include_only_assistant_ids)
             )

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -33,7 +33,6 @@ from sqlalchemy import (
     literal,
     not_,
     or_,
-    true,
     union_all,
 )
 from sqlalchemy import Enum as SQLEnum
@@ -7788,18 +7787,12 @@ class Thread(Base):
         last_activity_after: datetime | None = None,
         last_activity_before: datetime | None = None,
     ) -> AsyncGenerator["Thread", None]:
-        condition = and_(
-            Thread.class_id == int(class_id), Thread.private.is_not(true())
-        )
-        if include_only_user_ids is not None:
-            if not include_only_user_ids:
-                return
+        condition = Thread.class_id == int(class_id)
+        if include_only_user_ids:
             condition = and_(
                 condition, Thread.users.any(User.id.in_(include_only_user_ids))
             )
-        if include_only_assistant_ids is not None:
-            if not include_only_assistant_ids:
-                return
+        if include_only_assistant_ids:
             condition = and_(
                 condition, Thread.assistant_id.in_(include_only_assistant_ids)
             )
@@ -7809,7 +7802,6 @@ class Thread(Base):
             condition = and_(condition, Thread.last_activity <= last_activity_before)
         stmt = (
             select(Thread)
-            .outerjoin(Thread.users)
             .options(
                 selectinload(Thread.users).options(
                     load_only(

--- a/pingpong/test_models_threads.py
+++ b/pingpong/test_models_threads.py
@@ -443,6 +443,56 @@ async def test_get_thread_by_class_id_filters_by_assistant_ids(db):
 
 
 @pytest.mark.asyncio
+async def test_get_thread_by_class_id_empty_user_filter_returns_no_threads(db):
+    async with db.async_session() as session:
+        class_ = models.Class(name="Export Thread Empty User Filter Class")
+        thread = models.Thread(
+            thread_id="thread_export_empty_user_filter",
+            class_=class_,
+        )
+        session.add(thread)
+        await session.commit()
+        class_id = class_.id
+
+    async with db.async_session() as session:
+        threads = [
+            t
+            async for t in models.Thread.get_thread_by_class_id(
+                session,
+                class_id=class_id,
+                include_only_user_ids=[],
+            )
+        ]
+
+    assert threads == []
+
+
+@pytest.mark.asyncio
+async def test_get_thread_by_class_id_empty_assistant_filter_returns_no_threads(db):
+    async with db.async_session() as session:
+        class_ = models.Class(name="Export Thread Empty Assistant Filter Class")
+        thread = models.Thread(
+            thread_id="thread_export_empty_assistant_filter",
+            class_=class_,
+        )
+        session.add(thread)
+        await session.commit()
+        class_id = class_.id
+
+    async with db.async_session() as session:
+        threads = [
+            t
+            async for t in models.Thread.get_thread_by_class_id(
+                session,
+                class_id=class_id,
+                include_only_assistant_ids=[],
+            )
+        ]
+
+    assert threads == []
+
+
+@pytest.mark.asyncio
 async def test_list_messages_tool_calls_excludes_hidden_messages_by_default(db):
     async with db.async_session() as session:
         thread = models.Thread(thread_id="thread_hidden_messages_default", version=3)

--- a/pingpong/test_models_threads.py
+++ b/pingpong/test_models_threads.py
@@ -312,10 +312,16 @@ async def test_get_thread_by_class_id_preloads_export_user_fields(db):
             last_name="User",
             anonymous_link=share_link,
         )
+        second_user = models.User(
+            email="export-user-2@example.com",
+            display_name="Second Export User",
+            first_name="Second",
+            last_name="User",
+        )
         thread = models.Thread(
             thread_id="thread_export_user_fields",
             class_=class_,
-            users=[user],
+            users=[user, second_user],
             display_user_info=True,
         )
         session.add(thread)
@@ -331,7 +337,10 @@ async def test_get_thread_by_class_id_preloads_export_user_fields(db):
         ]
 
     assert len(threads) == 1
-    loaded_user = threads[0].users[0]
+    assert len(threads[0].users) == 2
+    loaded_user = next(
+        user for user in threads[0].users if user.email == "export-user@example.com"
+    )
     unloaded = inspect(loaded_user).unloaded
 
     assert "id" not in unloaded


### PR DESCRIPTION
## Data & Sharing
### Resolved Issues
* Fixed: Non-published threads may not be included in thread exports.
* Fixed: A thread created in anonymous session by an authenticated user may appear more than once in thread exports. 