### PR TITLE
feat(lv): hide video playback during answer

### DIFF
--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -89,6 +89,7 @@
 		allowFullSeek = false,
 		maxSeekOffsetMs = null,
 		activeQuestionIds = null,
+		questionPresentationVersion = 0,
 		furthestOffsetMs = null,
 		videoElement = $bindable(null),
 		previewVideoElement = $bindable(null),
@@ -116,6 +117,7 @@
 		allowFullSeek?: boolean;
 		maxSeekOffsetMs?: number | null;
 		activeQuestionIds?: number[] | null;
+		questionPresentationVersion?: number;
 		furthestOffsetMs?: number | null;
 		videoElement?: HTMLVideoElement | null;
 		previewVideoElement?: HTMLVideoElement | null;
@@ -178,6 +180,7 @@
 	let activeClusterKey: string | null = $state(null);
 	let clusterCollapseTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 	let playbackCompleted = $state(false);
+	// Non-reactive: tracks the last shown question without retriggering the effect.
 	let lastQuestionPresentationKey: string | null = null;
 
 	let effectiveOffsetMs = $derived(
@@ -200,10 +203,12 @@
 		endedPlayback = computedEndedPlayback;
 	});
 	let questionPendingControls = $derived(Boolean(activeQuestionIds?.length));
-	let questionPresentationKey = $derived(activeQuestionIds?.join(':') ?? null);
+	let questionPresentationKey = $derived(
+		activeQuestionIds?.[0] == null ? null : `${activeQuestionIds[0]}:${questionPresentationVersion}`
+	);
 	let visibleControls = $derived(
 		!manualPlaybackPrompt &&
-			!disabled &&
+			(!disabled || questionPendingControls) &&
 			(endedPlayback || (!startedPlaybackOnce && !questionPendingControls) || showControls)
 	);
 	let visibleMarkers = $derived(
@@ -409,6 +414,10 @@
 			if (questionPresentationKey !== lastQuestionPresentationKey) {
 				lastQuestionPresentationKey = questionPresentationKey;
 				showControls = true;
+			}
+			if (disabled) {
+				clearQuestionPresentationHideTimeout();
+			} else if (showControls && !questionPresentationHideTimeout) {
 				scheduleQuestionPresentationHide();
 			}
 			showVolumeSlider = false;
@@ -438,6 +447,12 @@
 	});
 
 	$effect(() => () => clearClusterCollapseTimeout());
+	$effect(() => () => {
+		if (hideTimeout) {
+			clearTimeout(hideTimeout);
+		}
+		clearQuestionPresentationHideTimeout();
+	});
 
 	$effect(() => {
 		if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) {
@@ -547,8 +562,10 @@
 		if (videoElement) {
 			paused = videoElement.paused;
 		}
-		showControls = true;
-		scheduleHide();
+		if (!questionPendingControls || questionPresentationKey !== lastQuestionPresentationKey) {
+			showControls = true;
+			scheduleHide();
+		}
 		syncMediaSessionState();
 		onpause?.();
 	}
@@ -979,6 +996,7 @@
 
 	function scheduleHide(delayMs: number = 3000) {
 		if (questionPendingControls) {
+			// Question presentations use a fixed short window instead of caller-specific delays.
 			scheduleQuestionPresentationHide();
 			return;
 		}
@@ -1015,7 +1033,7 @@
 		questionPresentationHideTimeout = setTimeout(() => {
 			questionPresentationHideTimeout = null;
 			if (!questionPendingControls) return;
-			if (draggingSeek || draggingVolume || seekPreviewVisible) {
+			if (disabled || pointerInsidePlayer || draggingSeek || draggingVolume || seekPreviewVisible) {
 				scheduleQuestionPresentationHide();
 				return;
 			}
@@ -1198,7 +1216,7 @@
 		</div>
 	{/if}
 
-	{#if visibleControls && subtitleText == null}
+	{#if !disabled && visibleControls && subtitleText == null}
 		<div
 			class="pointer-events-none absolute inset-x-0 top-4 z-[11] hidden justify-center px-4 sm:flex"
 		>

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -1061,6 +1061,12 @@
 		}
 		hoveringLockedSeek = false;
 		hideSeekPreview();
+		if (questionPendingControls) {
+			if (!disabled && showControls && !questionPresentationHideTimeout) {
+				scheduleQuestionPresentationHide();
+			}
+			return;
+		}
 		showControls = false;
 	}
 

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -27,6 +27,7 @@
 
 	const PREVIEW_WIDTH = 224;
 	const PREVIEW_VIDEO_IDLE_DEACTIVATE_MS = 3000;
+	const QUESTION_PRESENTATION_CONTROLS_HIDE_MS = 2000;
 	const PREVIEW_VIDEO_SEEK_TOLERANCE_S = 0.15;
 	const PREVIEW_FRAME_REDRAW_EPSILON_S = 0.001;
 	const VOLUME_SLIDER_PADDING_PX = 5;
@@ -171,11 +172,13 @@
 	let keyboardActionOverlayUnmountTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 	let mediaSessionRefreshTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 	let previewVideoDeactivateTimeout: ReturnType<typeof setTimeout> | null = $state(null);
+	let questionPresentationHideTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 	let snapshotCanvasElement: HTMLCanvasElement | null = $state(null);
 	let playerContainerElement: HTMLDivElement | null = $state(null);
 	let activeClusterKey: string | null = $state(null);
 	let clusterCollapseTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 	let playbackCompleted = $state(false);
+	let lastQuestionPresentationKey: string | null = null;
 
 	let effectiveOffsetMs = $derived(
 		draggingSeek ? (dragPreviewOffsetMs ?? currentTimeMs) : currentTimeMs
@@ -197,10 +200,11 @@
 		endedPlayback = computedEndedPlayback;
 	});
 	let questionPendingControls = $derived(Boolean(activeQuestionIds?.length));
+	let questionPresentationKey = $derived(activeQuestionIds?.join(':') ?? null);
 	let visibleControls = $derived(
 		!manualPlaybackPrompt &&
-			(questionPendingControls ||
-				(!disabled && (endedPlayback || !startedPlaybackOnce || showControls)))
+			!disabled &&
+			(endedPlayback || (!startedPlaybackOnce && !questionPendingControls) || showControls)
 	);
 	let visibleMarkers = $derived(
 		condensedMarkerMode && condensedMarkerIds.length > 0
@@ -402,11 +406,18 @@
 
 	$effect(() => {
 		if (questionPendingControls) {
+			if (questionPresentationKey !== lastQuestionPresentationKey) {
+				lastQuestionPresentationKey = questionPresentationKey;
+				showControls = true;
+				scheduleQuestionPresentationHide();
+			}
 			showVolumeSlider = false;
 			condensedMarkerMode = true;
 			condensedMarkerIds = [...activeQuestionIds!];
 			return;
 		}
+		lastQuestionPresentationKey = null;
+		clearQuestionPresentationHideTimeout();
 		if (!visibleControls) {
 			condensedMarkerMode = false;
 			condensedMarkerIds = [];
@@ -967,6 +978,10 @@
 	}
 
 	function scheduleHide(delayMs: number = 3000) {
+		if (questionPendingControls) {
+			scheduleQuestionPresentationHide();
+			return;
+		}
 		if (hideTimeout) {
 			clearTimeout(hideTimeout);
 		}
@@ -983,6 +998,29 @@
 			}
 			showControls = false;
 		}, delayMs);
+	}
+
+	function clearQuestionPresentationHideTimeout() {
+		if (!questionPresentationHideTimeout) return;
+		clearTimeout(questionPresentationHideTimeout);
+		questionPresentationHideTimeout = null;
+	}
+
+	function scheduleQuestionPresentationHide() {
+		if (hideTimeout) {
+			clearTimeout(hideTimeout);
+			hideTimeout = null;
+		}
+		clearQuestionPresentationHideTimeout();
+		questionPresentationHideTimeout = setTimeout(() => {
+			questionPresentationHideTimeout = null;
+			if (!questionPendingControls) return;
+			if (draggingSeek || draggingVolume || seekPreviewVisible) {
+				scheduleQuestionPresentationHide();
+				return;
+			}
+			showControls = false;
+		}, QUESTION_PRESENTATION_CONTROLS_HIDE_MS);
 	}
 
 	function handleMouseMove() {

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -107,6 +107,7 @@
 	let subtitleText: string | null = $state(null);
 	let playerDisabled: boolean = $state(false);
 	let questionPlaybackLocked: boolean = $state(false);
+	let questionPresentationVersion: number = $state(0);
 	let furthestOffsetMs: number = $state(0);
 	let initialStartOffsetMs: number = $state(0);
 	let videoReadyForPlayback: boolean = $state(false);
@@ -594,8 +595,8 @@
 		if (!videoElement || videoElement.paused) return;
 
 		suppressPauseInteraction = true;
-		videoElement.pause();
 		paused = true;
+		videoElement.pause();
 	}
 
 	function queueVideoRetry() {
@@ -1365,6 +1366,9 @@
 	function handleTimeUpdate() {
 		if (questionReviewPlaybackAllowed && currentQuestion) {
 			if (currentTimeMs >= currentQuestion.stop_offset_ms) {
+				if (!videoElement?.paused) {
+					questionPresentationVersion += 1;
+				}
 				suppressPauseInteraction = true;
 				setVideoPosition(currentQuestion.stop_offset_ms);
 				videoElement?.pause();
@@ -1389,6 +1393,7 @@
 
 			// Auto-pause at question timestamp (suppress the pause interaction)
 			questionPlaybackLocked = true;
+			questionPresentationVersion += 1;
 			suppressPauseInteraction = true;
 			setVideoPosition(currentQuestion.stop_offset_ms);
 			videoElement?.pause();
@@ -1422,6 +1427,7 @@
 		if (!videoElement) return;
 		if (questionReviewPlaybackAllowed) {
 			if (currentQuestion && currentTimeMs >= currentQuestion.stop_offset_ms) {
+				questionPresentationVersion += 1;
 				suppressPauseInteraction = true;
 				videoElement.pause();
 			}
@@ -1967,6 +1973,7 @@
 							{subtitleText}
 							disabled={playerInteractionDisabled}
 							{activeQuestionIds}
+							{questionPresentationVersion}
 							{furthestOffsetMs}
 							allowFullSeek={isCompleted && canParticipate}
 							maxSeekOffsetMs={questionReviewSeekLimitMs}

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -589,6 +589,15 @@
 		);
 	}
 
+	function pauseVideoForAnswerSubmission() {
+		clearPendingVideoRetry();
+		if (!videoElement || videoElement.paused) return;
+
+		suppressPauseInteraction = true;
+		videoElement.pause();
+		paused = true;
+	}
+
 	function queueVideoRetry() {
 		manualPlaybackTarget = 'video';
 	}
@@ -1687,6 +1696,7 @@
 		const questionAtAnswer = currentQuestion;
 		autoContinueFailed = false;
 		answerSubmissionInFlight = true;
+		pauseVideoForAnswerSubmission();
 
 		try {
 			const response = await api.postLectureVideoInteraction(fetch, classId, threadId, {


### PR DESCRIPTION
## Lecture Videos (Preview)
### Updates & Improvements
* When the video stops at a knowledge check, the "Answer the comprehension check to continue" overlay appears for a short time before showing the full lecture video frame.

### Resolved Issues
* Fixed: When seeking backward during an active knowledge check, submitting an answer may cause the voice feedback and video audio to play at the same time.