### PR TITLE
feat(lv): include instructions during run

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -4781,6 +4781,24 @@ def format_instructions(
                 '\ue200say\ue202{"speech":"a","display":"$a$"}\ue201'
                 ", the other has "
                 '\ue200say\ue202{"speech":"c","display":"$c$"}\ue201.\n'
+                "When you output a Mermaid or SVG fenced code block in a "
+                "lecture-video response, you MUST wrap the entire fenced code "
+                "block in a `say` snippet. The `speech` value should be a short, "
+                "natural description of what the diagram shows, not the code. "
+                "The `display` value should be the exact fenced code block the "
+                "student should see. Use escaped newlines in the JSON string.\n"
+                "Correct Mermaid diagram:\n"
+                '\ue200say\ue202{"speech":"Here is a simple flow from input to '
+                'output.","display":"```mermaid\\ngraph TD\\n    A[Input] --> '
+                'B[Output]\\n```"}\ue201\n'
+                "Correct SVG diagram:\n"
+                '\ue200say\ue202{"speech":"Here is a simple yellow circle.",'
+                '"display":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
+                "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
+                "fill='gold'/>\\n</svg>\\n```\"}\ue201\n"
+                "If Mermaid or SVG contains labels, formulas, symbols, or "
+                "notation, the spoken description must include the natural "
+                "spoken form of those labels or symbols.\n"
                 "If you are deciding between raw LaTeX and a `say` snippet "
                 "in a lecture-video response, choose the `say` snippet.\n"
                 "Do not mention the snippet syntax to the user.\n\n"

--- a/pingpong/migrations/m11_enable_latex_for_lecture_video_assistants.py
+++ b/pingpong/migrations/m11_enable_latex_for_lecture_video_assistants.py
@@ -1,54 +1,15 @@
 import logging
 
-from sqlalchemy import select, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from pingpong.ai import format_instructions
 import pingpong.models as models
 from pingpong.schemas import InteractionMode
 
 logger = logging.getLogger(__name__)
-LECTURE_VIDEO_LATEX_HEADER = "---Formatting: Lecture Video LaTeX---"
-
-
-def _lecture_video_latex_instructions() -> str:
-    return format_instructions(
-        "",
-        use_latex=True,
-        lecture_video_mode=True,
-    ).strip()
-
-
-def _with_lecture_video_latex_instructions(instructions: str | None) -> str:
-    existing = instructions or ""
-    if LECTURE_VIDEO_LATEX_HEADER in existing:
-        return existing
-
-    formatting_instructions = _lecture_video_latex_instructions()
-    return (
-        f"{existing}\n\n{formatting_instructions}"
-        if existing
-        else formatting_instructions
-    )
 
 
 async def enable_latex_for_lecture_video_assistants(session: AsyncSession) -> int:
-    thread_rows = (
-        (
-            await session.execute(
-                select(models.Thread).where(
-                    models.Thread.interaction_mode == InteractionMode.LECTURE_VIDEO
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    for thread in thread_rows:
-        thread.instructions = _with_lecture_video_latex_instructions(
-            thread.instructions
-        )
-
     result = await session.execute(
         update(models.Assistant)
         .where(models.Assistant.interaction_mode == InteractionMode.LECTURE_VIDEO)
@@ -58,8 +19,7 @@ async def enable_latex_for_lecture_video_assistants(session: AsyncSession) -> in
     updated = result.rowcount or 0
     await session.flush()
     logger.info(
-        "Enabled LaTeX for lecture video assistants. updated=%s threads_updated=%s",
+        "Enabled LaTeX for lecture video assistants. updated=%s",
         updated,
-        len(thread_rows),
     )
     return updated

--- a/pingpong/migrations/m11_enable_latex_for_lecture_video_assistants.py
+++ b/pingpong/migrations/m11_enable_latex_for_lecture_video_assistants.py
@@ -10,16 +10,24 @@ logger = logging.getLogger(__name__)
 
 
 async def enable_latex_for_lecture_video_assistants(session: AsyncSession) -> int:
-    result = await session.execute(
+    assistant_result = await session.execute(
         update(models.Assistant)
         .where(models.Assistant.interaction_mode == InteractionMode.LECTURE_VIDEO)
         .where(models.Assistant.use_latex.is_not(True))
         .values(use_latex=True)
     )
-    updated = result.rowcount or 0
+    assistants_updated = assistant_result.rowcount or 0
+    thread_result = await session.execute(
+        update(models.Thread)
+        .where(models.Thread.interaction_mode == InteractionMode.LECTURE_VIDEO)
+        .where(models.Thread.instructions.is_not(None))
+        .values(instructions=None)
+    )
+    threads_updated = thread_result.rowcount or 0
     await session.flush()
     logger.info(
-        "Enabled LaTeX for lecture video assistants. updated=%s",
-        updated,
+        "Enabled LaTeX for lecture video assistants. updated=%s threads_cleared=%s",
+        assistants_updated,
+        threads_updated,
     )
-    return updated
+    return assistants_updated

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -7669,8 +7669,7 @@ async def create_run(
             ):
                 if (
                     not thread.instructions
-                    and thread.interaction_mode
-                    != schemas.InteractionMode.LECTURE_VIDEO
+                    and thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO
                 ):
                     thread.instructions = format_instructions(
                         asst.instructions,

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -361,7 +361,7 @@ def _build_run_instructions(
     asst: models.Assistant,
     user_id: int | None,
 ) -> str | None:
-    """Return the instructions to send to OpenAI for a V3 run.
+    """Return the effective instructions for a run or prompt inspection.
 
     Lecture-video threads compute formatting fresh per run so that prompt
     segment updates (say snippets, follow-ups, LaTeX/diagrams) take effect on
@@ -369,6 +369,8 @@ def _build_run_instructions(
     instructions verbatim.
     """
     if thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO:
+        # Random blocks remain stable because format_instructions seeds them
+        # from the thread and user ids instead of sampling per call.
         return format_instructions(
             asst.instructions or "",
             use_latex=asst.use_latex,
@@ -379,6 +381,57 @@ def _build_run_instructions(
             lecture_video_mode=True,
         )
     return thread.instructions
+
+
+def _effective_thread_instructions(
+    thread: models.Thread,
+    assistant: models.Assistant | None,
+    user_id: int | None,
+) -> str | None:
+    if not assistant:
+        return thread.instructions
+    return _build_run_instructions(thread, assistant, user_id)
+
+
+def _ensure_lecture_video_thread_version(thread: models.Thread) -> None:
+    if (
+        thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
+        and thread.version != 3
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Lecture video threads must use next generation conversations.",
+        )
+
+
+async def _ensure_thread_instructions_migrated(
+    session: AsyncSession,
+    thread: models.Thread,
+    asst: models.Assistant,
+    user_id: int,
+) -> None:
+    if (
+        thread.instructions
+        or thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
+    ):
+        session.add(thread)
+        return
+
+    logger.info(
+        "Thread %s does not have instructions set, migrating from assistant instructions",
+        thread.id,
+    )
+    thread.instructions = format_instructions(
+        asst.instructions,
+        asst.use_latex,
+        asst.use_image_descriptions,
+        disable_prompt_randomization=asst.disable_prompt_randomization,
+        thread_id=thread.thread_id or str(thread.id),
+        user_id=user_id,
+    )
+    session.add(thread)
+    await session.flush()
+    await session.refresh(thread)
 
 
 def _display_text_for_thread(thread: models.Thread, text: str) -> str:
@@ -3909,8 +3962,11 @@ async def get_thread(
             thread, request.state["session"].user.id, is_supervisor
         )
 
+        effective_instructions = _effective_thread_instructions(
+            thread, assistant, request.state["session"].user.id
+        )
         can_view_prompt = False
-        if thread.instructions and assistant:
+        if effective_instructions and assistant:
             if not assistant.hide_prompt:
                 can_view_prompt = True
             else:
@@ -3960,7 +4016,7 @@ async def get_thread(
             "mcp_messages": [],
             "reasoning_messages": [],
             "attachments": all_files,
-            "instructions": thread.instructions if can_view_prompt else None,
+            "instructions": effective_instructions if can_view_prompt else None,
             "lecture_video_matches_assistant": lecture_video_matches_assistant,
             "lecture_video_session": lecture_video_session,
             "lecture_video_tts_available": lecture_video_tts_available,
@@ -4530,8 +4586,11 @@ async def get_thread(
             thread, request.state["session"].user.id, is_supervisor
         )
 
+        effective_instructions = _effective_thread_instructions(
+            thread, assistant, request.state["session"].user.id
+        )
         can_view_prompt = False
-        if thread.instructions and assistant:
+        if effective_instructions and assistant:
             if not assistant.hide_prompt:
                 can_view_prompt = True
             else:
@@ -4583,7 +4642,7 @@ async def get_thread(
                 failed_at=None,
                 status=latest_run.status.value,
                 thread_id=str(thread_id),
-                instructions=thread.instructions or "",
+                instructions=latest_run.instructions or effective_instructions or "",
                 last_error=schemas.OpenAIRunError(
                     message=latest_run.error_message,
                     code=latest_run.error_code,
@@ -4608,7 +4667,7 @@ async def get_thread(
             "mcp_messages": mcp_messages,
             "reasoning_messages": reasoning_messages,
             "attachments": all_files,
-            "instructions": thread.instructions if can_view_prompt else None,
+            "instructions": effective_instructions if can_view_prompt else None,
             "lecture_video_id": thread.lecture_video_id,
             "lecture_video_matches_assistant": lecture_video_matches_assistant,
             "lecture_video_session": lecture_video_session,
@@ -7635,6 +7694,8 @@ async def create_run(
             detail="We could not find the thread or assistant you specified. Please try again.",
         )
 
+    _ensure_lecture_video_thread_version(thread)
+
     if thread.version == 3:
         try:
             thread = await models.Thread.get_by_id(
@@ -7667,21 +7728,12 @@ async def create_run(
                     schemas.RunStatus.INCOMPLETE,
                 }
             ):
-                if (
-                    not thread.instructions
-                    and thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO
-                ):
-                    thread.instructions = format_instructions(
-                        asst.instructions,
-                        asst.use_latex,
-                        asst.use_image_descriptions,
-                        disable_prompt_randomization=asst.disable_prompt_randomization,
-                        thread_id=str(thread.id),
-                        user_id=request.state["session"].user.id,
-                    )
-                    request.state["db"].add(thread)
-                    await request.state["db"].flush()
-                    await request.state["db"].refresh(thread)
+                await _ensure_thread_instructions_migrated(
+                    request.state["db"],
+                    thread,
+                    asst,
+                    request.state["session"].user.id,
+                )
 
                 run_to_complete = models.Run(
                     status=schemas.RunStatus.PENDING,
@@ -7873,6 +7925,7 @@ async def send_message(
     mcp_tool_ids: list[int] = []
     try:
         thread = await models.Thread.get_by_id(request.state["db"], int(thread_id))
+        _ensure_lecture_video_thread_version(thread)
         if thread.tools_available and "mcp_server" in thread.tools_available:
             mcp_tool_ids = await models.Thread.get_mcp_tool_ids_by_thread_id(
                 request.state["db"], thread.id
@@ -8101,30 +8154,12 @@ async def send_message(
         thread.last_activity = func.now()
         thread.user_message_ct += 1
 
-        # One-time migration for threads that don't have instructions set.
-        # Lecture-video threads format fresh at run time (see _build_run_instructions)
-        # so prompt segment updates apply to existing threads.
-        if (
-            not thread.instructions
-            and thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO
-        ):
-            logger.info(
-                "Thread %s does not have instructions set, migrating from assistant instructions",
-                thread.id,
-            )
-            thread.instructions = format_instructions(
-                asst.instructions,
-                asst.use_latex,
-                asst.use_image_descriptions,
-                disable_prompt_randomization=asst.disable_prompt_randomization,
-                thread_id=thread.thread_id or str(thread.id),
-                user_id=request.state["session"].user.id,
-            )
-            request.state["db"].add(thread)
-            await request.state["db"].flush()
-            await request.state["db"].refresh(thread)
-        else:
-            request.state["db"].add(thread)
+        await _ensure_thread_instructions_migrated(
+            request.state["db"],
+            thread,
+            asst,
+            request.state["session"].user.id,
+        )
 
         metrics.inbound_messages.inc(
             app=config.public_url,

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -356,6 +356,31 @@ def _lecture_video_followups_enabled(thread: models.Thread) -> bool:
     return thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
 
 
+def _build_run_instructions(
+    thread: models.Thread,
+    asst: models.Assistant,
+    user_id: int | None,
+) -> str | None:
+    """Return the instructions to send to OpenAI for a V3 run.
+
+    Lecture-video threads compute formatting fresh per run so that prompt
+    segment updates (say snippets, follow-ups, LaTeX/diagrams) take effect on
+    existing threads. Other modes continue to use the thread's stored
+    instructions verbatim.
+    """
+    if thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO:
+        return format_instructions(
+            asst.instructions or "",
+            use_latex=asst.use_latex,
+            use_image_descriptions=asst.use_image_descriptions,
+            disable_prompt_randomization=asst.disable_prompt_randomization,
+            thread_id=str(thread.id),
+            user_id=user_id,
+            lecture_video_mode=True,
+        )
+    return thread.instructions
+
+
 def _display_text_for_thread(thread: models.Thread, text: str) -> str:
     if _lecture_video_followups_enabled(thread):
         text = strip_followup_snippets(text)
@@ -7042,15 +7067,9 @@ async def create_lecture_thread(
     result: None | models.Thread = None
     try:
         result = await models.Thread.create(request.state["db"], new_thread)
-        result.instructions = format_instructions(
-            assistant.instructions,
-            assistant.use_latex,
-            assistant.use_image_descriptions,
-            disable_prompt_randomization=assistant.disable_prompt_randomization,
-            thread_id=result.id,
-            user_id=request.state["session"].user.id,
-            lecture_video_mode=True,
-        )
+        # Lecture-video formatting (say snippets, follow-ups, LaTeX/diagrams)
+        # is injected at OpenAI request time so prompt-segment updates apply to
+        # existing threads. Leave thread.instructions unset here.
         request.state["db"].add(result)
         await request.state["db"].flush()
         try:
@@ -7648,7 +7667,11 @@ async def create_run(
                     schemas.RunStatus.INCOMPLETE,
                 }
             ):
-                if not thread.instructions:
+                if (
+                    not thread.instructions
+                    and thread.interaction_mode
+                    != schemas.InteractionMode.LECTURE_VIDEO
+                ):
                     thread.instructions = format_instructions(
                         asst.instructions,
                         asst.use_latex,
@@ -7656,10 +7679,6 @@ async def create_run(
                         disable_prompt_randomization=asst.disable_prompt_randomization,
                         thread_id=str(thread.id),
                         user_id=request.state["session"].user.id,
-                        lecture_video_mode=(
-                            thread.interaction_mode
-                            == schemas.InteractionMode.LECTURE_VIDEO
-                        ),
                     )
                     request.state["db"].add(thread)
                     await request.state["db"].flush()
@@ -7674,7 +7693,9 @@ async def create_run(
                     reasoning_effort=asst.reasoning_effort,
                     temperature=asst.temperature,
                     tools_available=thread.tools_available,
-                    instructions=thread.instructions,
+                    instructions=_build_run_instructions(
+                        thread, asst, request.state["session"].user.id
+                    ),
                     verbosity=asst.verbosity,
                 )
                 request.state["db"].add(run_to_complete)
@@ -8081,8 +8102,13 @@ async def send_message(
         thread.last_activity = func.now()
         thread.user_message_ct += 1
 
-        # One-time migration for threads that don't have instructions set
-        if not thread.instructions:
+        # One-time migration for threads that don't have instructions set.
+        # Lecture-video threads format fresh at run time (see _build_run_instructions)
+        # so prompt segment updates apply to existing threads.
+        if (
+            not thread.instructions
+            and thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO
+        ):
             logger.info(
                 "Thread %s does not have instructions set, migrating from assistant instructions",
                 thread.id,
@@ -8094,9 +8120,6 @@ async def send_message(
                 disable_prompt_randomization=asst.disable_prompt_randomization,
                 thread_id=thread.thread_id or str(thread.id),
                 user_id=request.state["session"].user.id,
-                lecture_video_mode=(
-                    thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
-                ),
             )
             request.state["db"].add(thread)
             await request.state["db"].flush()
@@ -8318,7 +8341,9 @@ async def send_message(
                 reasoning_effort=asst.reasoning_effort,
                 temperature=asst.temperature,
                 tools_available=thread.tools_available,
-                instructions=thread.instructions,
+                instructions=_build_run_instructions(
+                    thread, asst, request.state["session"].user.id
+                ),
                 verbosity=asst.verbosity,
                 messages=run_messages,
             )

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -1,0 +1,66 @@
+import importlib
+
+from pingpong import models, schemas
+
+server_module = importlib.import_module("pingpong.server")
+
+
+def test_build_run_instructions_for_lecture_video_with_latex_includes_say_and_followups():
+    thread = models.Thread(
+        id=42,
+        interaction_mode=schemas.InteractionMode.LECTURE_VIDEO,
+        instructions=None,
+    )
+    assistant = models.Assistant(
+        instructions="Be helpful.",
+        use_latex=True,
+        use_image_descriptions=False,
+        disable_prompt_randomization=True,
+    )
+
+    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+
+    assert instructions is not None
+    assert "Be helpful." in instructions
+    assert "---Formatting: Lecture Video LaTeX---" in instructions
+    assert "---Formatting: LaTeX---" not in instructions
+    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+
+
+def test_build_run_instructions_for_lecture_video_without_latex_skips_say_contract():
+    thread = models.Thread(
+        id=42,
+        interaction_mode=schemas.InteractionMode.LECTURE_VIDEO,
+        instructions=None,
+    )
+    assistant = models.Assistant(
+        instructions="Be helpful.",
+        use_latex=False,
+        use_image_descriptions=False,
+        disable_prompt_randomization=True,
+    )
+
+    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+
+    assert instructions is not None
+    assert "Be helpful." in instructions
+    assert "---Formatting: Lecture Video LaTeX---" not in instructions
+    assert "---Formatting: LaTeX---" not in instructions
+
+
+def test_build_run_instructions_for_non_lecture_video_uses_stored_instructions():
+    thread = models.Thread(
+        id=43,
+        interaction_mode=schemas.InteractionMode.CHAT,
+        instructions="Stored chat instructions.",
+    )
+    assistant = models.Assistant(
+        instructions="Different assistant instructions.",
+        use_latex=True,
+        use_image_descriptions=False,
+        disable_prompt_randomization=True,
+    )
+
+    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+
+    assert instructions == "Stored chat instructions."

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -1,24 +1,65 @@
-import importlib
+import pytest
 
 from pingpong import models, schemas
+from pingpong.server import _build_run_instructions
 
-server_module = importlib.import_module("pingpong.server")
+pytestmark = pytest.mark.asyncio
 
 
-def test_build_run_instructions_for_lecture_video_with_latex_includes_say_and_followups():
-    thread = models.Thread(
-        id=42,
+async def create_thread_and_assistant(
+    db,
+    *,
+    interaction_mode: schemas.InteractionMode,
+    thread_instructions: str | None,
+    assistant_instructions: str,
+    use_latex: bool,
+) -> tuple[models.Thread, models.Assistant]:
+    async with db.async_session() as session:
+        class_ = models.Class(id=1, name="Test Class")
+        session.add(class_)
+        await session.flush()
+        assistant = models.Assistant(
+            name="Test Assistant",
+            class_id=class_.id,
+            instructions=assistant_instructions,
+            interaction_mode=interaction_mode,
+            model="gpt-4o-mini",
+            tools="[]",
+            use_latex=use_latex,
+            use_image_descriptions=False,
+            disable_prompt_randomization=True,
+            version=3,
+        )
+        session.add(assistant)
+        await session.flush()
+        thread = models.Thread(
+            name="Test Thread",
+            class_id=class_.id,
+            assistant_id=assistant.id,
+            interaction_mode=interaction_mode,
+            instructions=thread_instructions,
+            private=False,
+            tools_available="[]",
+            version=3,
+            thread_id=f"thread-{assistant.id}",
+        )
+        session.add(thread)
+        await session.commit()
+        return thread, assistant
+
+
+async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_and_followups(
+    db,
+):
+    thread, assistant = await create_thread_and_assistant(
+        db,
         interaction_mode=schemas.InteractionMode.LECTURE_VIDEO,
-        instructions=None,
-    )
-    assistant = models.Assistant(
-        instructions="Be helpful.",
+        thread_instructions=None,
+        assistant_instructions="Be helpful.",
         use_latex=True,
-        use_image_descriptions=False,
-        disable_prompt_randomization=True,
     )
 
-    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+    instructions = _build_run_instructions(thread, assistant, user_id=1)
 
     assert instructions is not None
     assert "Be helpful." in instructions
@@ -27,20 +68,18 @@ def test_build_run_instructions_for_lecture_video_with_latex_includes_say_and_fo
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
 
-def test_build_run_instructions_for_lecture_video_without_latex_skips_say_contract():
-    thread = models.Thread(
-        id=42,
+async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_contract(
+    db,
+):
+    thread, assistant = await create_thread_and_assistant(
+        db,
         interaction_mode=schemas.InteractionMode.LECTURE_VIDEO,
-        instructions=None,
-    )
-    assistant = models.Assistant(
-        instructions="Be helpful.",
+        thread_instructions=None,
+        assistant_instructions="Be helpful.",
         use_latex=False,
-        use_image_descriptions=False,
-        disable_prompt_randomization=True,
     )
 
-    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+    instructions = _build_run_instructions(thread, assistant, user_id=1)
 
     assert instructions is not None
     assert "Be helpful." in instructions
@@ -48,19 +87,17 @@ def test_build_run_instructions_for_lecture_video_without_latex_skips_say_contra
     assert "---Formatting: LaTeX---" not in instructions
 
 
-def test_build_run_instructions_for_non_lecture_video_uses_stored_instructions():
-    thread = models.Thread(
-        id=43,
+async def test_build_run_instructions_for_non_lecture_video_uses_stored_instructions(
+    db,
+):
+    thread, assistant = await create_thread_and_assistant(
+        db,
         interaction_mode=schemas.InteractionMode.CHAT,
-        instructions="Stored chat instructions.",
-    )
-    assistant = models.Assistant(
-        instructions="Different assistant instructions.",
+        thread_instructions="Stored chat instructions.",
+        assistant_instructions="Different assistant instructions.",
         use_latex=True,
-        use_image_descriptions=False,
-        disable_prompt_randomization=True,
     )
 
-    instructions = server_module._build_run_instructions(thread, assistant, user_id=1)
+    instructions = _build_run_instructions(thread, assistant, user_id=1)
 
     assert instructions == "Stored chat instructions."

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1155,7 +1155,11 @@ async def test_get_thread_returns_lecture_video_session(
         headers={"Authorization": f"Bearer {valid_user_token}"},
     )
     assert response.status_code == 200
-    session_data = response.json()["lecture_video_session"]
+    data = response.json()
+    assert data["instructions"] is not None
+    assert data["instructions"].startswith("You are a lecture assistant.")
+    assert "---Formatting: Lecture Video Follow-ups---" in data["instructions"]
+    session_data = data["lecture_video_session"]
     assert session_data["state"] == "playing"
     assert session_data["last_known_offset_ms"] == 0
     assert session_data["furthest_offset_ms"] == 0

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1335,7 +1335,11 @@ async def test_send_message_creates_lecture_chat_run_with_hidden_context(
     ordered_messages = sorted(run.messages, key=lambda item: item.output_index)
     assert run.model == "gpt-4o-mini"
     assert run.tools_available == thread.tools_available
-    assert run.instructions == thread.instructions
+    # Lecture-video formatting is injected fresh into run.instructions at
+    # OpenAI request time and is not stored on the thread.
+    assert not thread.instructions
+    assert run.instructions is not None
+    assert run.instructions.startswith("You are a lecture assistant.")
     assert "The current date and time is" not in run.instructions
     assert [message.role for message in ordered_messages] == [
         schemas.MessageRole.DEVELOPER,
@@ -1409,7 +1413,7 @@ async def test_send_message_creates_lecture_chat_run_with_hidden_context(
     ]
 )
 @pytest.mark.asyncio
-async def test_lecture_video_thread_instructions_include_say_contract_only_with_latex(
+async def test_lecture_video_thread_instructions_unset_at_create_time(
     api, db, institution, valid_user_token
 ):
     async with db.async_session() as session:
@@ -1432,8 +1436,9 @@ async def test_lecture_video_thread_instructions_include_say_contract_only_with_
         thread = await models.Thread.get_by_id(session, response.json()["thread"]["id"])
 
     assert thread is not None
-    assert "---Formatting: Lecture Video LaTeX---" in thread.instructions
-    assert "---Formatting: LaTeX---" not in thread.instructions
+    # Lecture-video formatting is injected at OpenAI request time, not baked
+    # into thread.instructions at create time.
+    assert not thread.instructions
 
 
 @with_user(123)
@@ -1446,7 +1451,7 @@ async def test_lecture_video_thread_instructions_include_say_contract_only_with_
     ]
 )
 @pytest.mark.asyncio
-async def test_lecture_video_thread_instructions_omit_say_contract_without_latex(
+async def test_lecture_video_thread_instructions_unset_at_create_time_without_latex(
     api, db, institution, valid_user_token
 ):
     async with db.async_session() as session:
@@ -1466,8 +1471,7 @@ async def test_lecture_video_thread_instructions_omit_say_contract_without_latex
         thread = await models.Thread.get_by_id(session, response.json()["thread"]["id"])
 
     assert thread is not None
-    assert "---Formatting: LaTeX---" not in thread.instructions
-    assert "---Formatting: Lecture Video LaTeX---" not in thread.instructions
+    assert not thread.instructions
 
 
 @with_user(123)

--- a/pingpong/test_migrations_m11_enable_latex_for_lecture_video_assistants.py
+++ b/pingpong/test_migrations_m11_enable_latex_for_lecture_video_assistants.py
@@ -6,7 +6,7 @@ from pingpong.migrations import m11_enable_latex_for_lecture_video_assistants as
 pytestmark = pytest.mark.asyncio
 
 
-async def test_enable_latex_for_lecture_video_assistants_backfills_thread_instructions(
+async def test_enable_latex_for_lecture_video_assistants_sets_use_latex(
     db,
 ):
     async with db.async_session() as session:
@@ -46,12 +46,12 @@ async def test_enable_latex_for_lecture_video_assistants_backfills_thread_instru
     assert assistant is not None
     assert assistant.use_latex is True
     assert thread is not None
-    assert thread.instructions.startswith("Old instructions")
-    assert "Changed assistant instructions." not in thread.instructions
-    assert "---Formatting: Lecture Video LaTeX---" in thread.instructions
+    # Thread instructions should not be touched by the migration; the lecture
+    # video formatting is now injected at OpenAI request time.
+    assert thread.instructions == "Old instructions"
 
 
-async def test_enable_latex_for_lecture_video_assistants_only_updates_lv_threads(
+async def test_enable_latex_for_lecture_video_assistants_only_updates_lv_assistants(
     db,
 ):
     async with db.async_session() as session:
@@ -85,7 +85,10 @@ async def test_enable_latex_for_lecture_video_assistants_only_updates_lv_threads
     assert updated == 0
 
     async with db.async_session() as session:
+        assistant = await session.get(models.Assistant, 1)
         thread = await session.get(models.Thread, 1)
 
+    assert assistant is not None
+    assert assistant.use_latex is False
     assert thread is not None
     assert thread.instructions == "Chat instructions"

--- a/pingpong/test_migrations_m11_enable_latex_for_lecture_video_assistants.py
+++ b/pingpong/test_migrations_m11_enable_latex_for_lecture_video_assistants.py
@@ -6,7 +6,7 @@ from pingpong.migrations import m11_enable_latex_for_lecture_video_assistants as
 pytestmark = pytest.mark.asyncio
 
 
-async def test_enable_latex_for_lecture_video_assistants_sets_use_latex(
+async def test_enable_latex_for_lecture_video_assistants_sets_use_latex_and_clears_threads(
     db,
 ):
     async with db.async_session() as session:
@@ -46,9 +46,7 @@ async def test_enable_latex_for_lecture_video_assistants_sets_use_latex(
     assert assistant is not None
     assert assistant.use_latex is True
     assert thread is not None
-    # Thread instructions should not be touched by the migration; the lecture
-    # video formatting is now injected at OpenAI request time.
-    assert thread.instructions == "Old instructions"
+    assert thread.instructions is None
 
 
 async def test_enable_latex_for_lecture_video_assistants_only_updates_lv_assistants(

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from pingpong.ai import format_instructions
@@ -94,10 +95,13 @@ def test_transform_say_text_can_wrap_svg_block_for_dual_display_and_speech():
         "```"
     )
     text = "Here: " + say_payload(
-        '{"speech":"Here is a simple yellow circle.",'
-        '"display":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
-        "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
-        "fill='gold'/>\\n</svg>\\n```\"}"
+        json.dumps(
+            {
+                "speech": "Here is a simple yellow circle.",
+                "display": svg_block,
+            },
+            separators=(",", ":"),
+        )
     )
 
     assert transform_say_text(text, "display") == "Here: " + svg_block

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -31,6 +31,11 @@ def test_format_instructions_adds_say_contract_for_latex_lecture_video_only():
     assert '"speech":"ten a plus five c"' in instructions
     assert "Incorrect: One has $a$, the other has $c$." in instructions
     assert '"speech":"a","display":"$a$"' in instructions
+    assert "MUST wrap the entire fenced code block in a `say` snippet" in instructions
+    assert "Correct Mermaid diagram:" in instructions
+    assert '"display":"```mermaid\\ngraph TD' in instructions
+    assert "Correct SVG diagram:" in instructions
+    assert '"display":"```svg\\n<svg' in instructions
     assert '"speech"' in instructions
     assert '"display"' in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
@@ -78,6 +83,25 @@ def test_transform_say_text_falls_back_to_speech_when_display_missing():
     text = "Use " + say_payload('{"speech":"x squared"}') + " here."
 
     assert transform_say_text(text, "display") == "Use x squared here."
+
+
+def test_transform_say_text_can_wrap_svg_block_for_dual_display_and_speech():
+    svg_block = (
+        "```svg\n"
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>\n"
+        "  <circle cx='50' cy='50' r='40' fill='gold'/>\n"
+        "</svg>\n"
+        "```"
+    )
+    text = "Here: " + say_payload(
+        '{"speech":"Here is a simple yellow circle.",'
+        '"display":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
+        "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
+        "fill='gold'/>\\n</svg>\\n```\"}"
+    )
+
+    assert transform_say_text(text, "display") == "Here: " + svg_block
+    assert transform_say_text(text, "speech") == "Here: Here is a simple yellow circle."
 
 
 def test_say_transformer_buffers_split_deltas():

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -1113,6 +1113,7 @@ export class ThreadManager {
 		try {
 			const player = new WavStreamPlayer({
 				sampleRate: 24000,
+				stopOnEmptyBuffer: false,
 				onPlaybackStopped: () => {
 					if (this.#ttsPlayer !== player) {
 						return;
@@ -1146,6 +1147,7 @@ export class ThreadManager {
 
 	#handleTtsDone() {
 		// Keep the speaker control visible until buffered audio fully drains.
+		this.#ttsPlayer?.finish();
 		this.#ttsTrackId = null;
 	}
 

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
@@ -70,4 +70,13 @@ describe('WavStreamPlayer', () => {
 
 		expect(postMessage).toHaveBeenCalledWith({ event: 'finish' });
 	});
+
+	it('stops playback when finish is called before a stream starts', () => {
+		const onPlaybackStopped = vi.fn();
+		const player = new WavStreamPlayer({ onPlaybackStopped });
+
+		player.finish();
+
+		expect(onPlaybackStopped).toHaveBeenCalledTimes(1);
+	});
 });

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
@@ -53,4 +53,21 @@ describe('WavStreamPlayer', () => {
 		await expect(pendingOffset).resolves.toBeNull();
 		expect(postMessage).toHaveBeenCalledTimes(1);
 	});
+
+	it('can signal that no more streaming audio will be added', () => {
+		const player = new WavStreamPlayer();
+		const postMessage = vi.fn();
+
+		(
+			player as unknown as {
+				stream: { port: { postMessage: (message: object) => void } };
+			}
+		).stream = {
+			port: { postMessage }
+		};
+
+		player.finish();
+
+		expect(postMessage).toHaveBeenCalledWith({ event: 'finish' });
+	});
 });

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
@@ -44,6 +44,7 @@ export type OnAudioPartEndedProcessor = (data: {
 export type OnPlaybackStoppedProcessor = () => void;
 interface WavStreamPlayerOptions {
 	sampleRate?: number;
+	stopOnEmptyBuffer?: boolean;
 	onAudioPartStarted?: OnAudioPartStartedProcessor;
 	onAudioPartEnded?: OnAudioPartEndedProcessor;
 	onPlaybackStopped?: OnPlaybackStoppedProcessor;
@@ -71,6 +72,7 @@ export class WavStreamPlayer {
 	private gainNode: GainNode | null;
 	private trackSampleOffsets: Record<string, TrackSampleOffset>;
 	private interruptedTrackIds: Record<string, boolean>;
+	private stopOnEmptyBuffer: boolean;
 	private onAudioPartStarted: OnAudioPartStartedProcessor | null;
 	private onAudioPartEnded: OnAudioPartEndedProcessor | null;
 	private onPlaybackStopped: OnPlaybackStoppedProcessor | null;
@@ -82,6 +84,7 @@ export class WavStreamPlayer {
 	 */
 	constructor({
 		sampleRate = 44100,
+		stopOnEmptyBuffer = true,
 		onAudioPartStarted,
 		onAudioPartEnded,
 		onPlaybackStopped
@@ -94,6 +97,7 @@ export class WavStreamPlayer {
 		this.gainNode = null;
 		this.trackSampleOffsets = {};
 		this.interruptedTrackIds = {};
+		this.stopOnEmptyBuffer = stopOnEmptyBuffer;
 		this.onAudioPartStarted = onAudioPartStarted || null;
 		this.onAudioPartEnded = onAudioPartEnded || null;
 		this.onPlaybackStopped = onPlaybackStopped || null;
@@ -184,6 +188,10 @@ export class WavStreamPlayer {
 		}
 		const streamNode = new AudioWorkletNode(this.context, 'stream_processor');
 		streamNode.connect(this.gainNode || this.context.destination);
+		streamNode.port.postMessage({
+			event: 'configure',
+			stopOnEmptyBuffer: this.stopOnEmptyBuffer
+		});
 		streamNode.port.onmessage = (e) => {
 			const { event } = e.data;
 			if (event === 'stop') {
@@ -250,6 +258,13 @@ export class WavStreamPlayer {
 		}
 		this.stream?.port.postMessage({ event: 'write', buffer, trackId, eventId });
 		return buffer;
+	}
+
+	/**
+	 * Signals that no more PCM chunks will be written.
+	 */
+	finish(): void {
+		this.stream?.port.postMessage({ event: 'finish' });
 	}
 
 	/**

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
@@ -188,6 +188,8 @@ export class WavStreamPlayer {
 		}
 		const streamNode = new AudioWorkletNode(this.context, 'stream_processor');
 		streamNode.connect(this.gainNode || this.context.destination);
+		// This is queued before any write messages, so the worklet sees this
+		// configuration before it can process streamed PCM.
 		streamNode.port.postMessage({
 			event: 'configure',
 			stopOnEmptyBuffer: this.stopOnEmptyBuffer
@@ -195,9 +197,7 @@ export class WavStreamPlayer {
 		streamNode.port.onmessage = (e) => {
 			const { event } = e.data;
 			if (event === 'stop') {
-				streamNode.disconnect();
-				this.stream = null;
-				this.onPlaybackStopped?.();
+				this._handlePlaybackStopped(streamNode);
 			} else if (event === 'offset') {
 				const { requestId, trackId, offset, eventId } = e.data;
 				const currentTime = offset / this.sampleRate;
@@ -225,6 +225,14 @@ export class WavStreamPlayer {
 		}
 		this.stream = streamNode;
 		return true;
+	}
+
+	private _handlePlaybackStopped(streamNode: AudioWorkletNode | null): void {
+		streamNode?.disconnect();
+		if (!streamNode || this.stream === streamNode) {
+			this.stream = null;
+		}
+		this.onPlaybackStopped?.();
 	}
 
 	/**
@@ -264,7 +272,11 @@ export class WavStreamPlayer {
 	 * Signals that no more PCM chunks will be written.
 	 */
 	finish(): void {
-		this.stream?.port.postMessage({ event: 'finish' });
+		if (!this.stream) {
+			this._handlePlaybackStopped(null);
+			return;
+		}
+		this.stream.port.postMessage({ event: 'finish' });
 	}
 
 	/**

--- a/web/pingpong/src/lib/wavtools/lib/worklets/stream_processor.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/worklets/stream_processor.test.ts
@@ -49,8 +49,26 @@ const writePcm = (
 	});
 };
 
+const configureProcessor = (
+	processor: ReturnType<typeof createProcessor>,
+	options: { stopOnEmptyBuffer: boolean }
+) => {
+	processor.port.onmessage?.({
+		data: {
+			event: 'configure',
+			...options
+		}
+	});
+};
+
+const finishProcessor = (processor: ReturnType<typeof createProcessor>) => {
+	processor.port.onmessage?.({
+		data: { event: 'finish' }
+	});
+};
+
 const processOnce = (processor: ReturnType<typeof createProcessor>) => {
-	processor.process([], [[new Float32Array(128)]], {});
+	return processor.process([], [[new Float32Array(128)]], {});
 };
 
 const postedMessages = (processor: ReturnType<typeof createProcessor>) =>
@@ -102,5 +120,21 @@ describe('StreamProcessor worklet', () => {
 			offset: 128,
 			eventId: 'event-1'
 		});
+	});
+
+	it('keeps processing through empty gaps until explicitly finished', () => {
+		const processor = createProcessor();
+		configureProcessor(processor, { stopOnEmptyBuffer: false });
+
+		writePcm(processor, 128, 'track-1', 'event-1');
+		expect(processOnce(processor)).toBe(true);
+		expect(processOnce(processor)).toBe(true);
+		expect(postedMessages(processor).some((message) => message.event === 'stop')).toBe(false);
+
+		writePcm(processor, 128, 'track-1', 'event-1');
+		expect(processOnce(processor)).toBe(true);
+		finishProcessor(processor);
+		expect(processOnce(processor)).toBe(false);
+		expect(postedMessages(processor).some((message) => message.event === 'stop')).toBe(true);
 	});
 });

--- a/web/pingpong/src/lib/wavtools/lib/worklets/stream_processor.ts
+++ b/web/pingpong/src/lib/wavtools/lib/worklets/stream_processor.ts
@@ -47,6 +47,8 @@ class StreamProcessor extends AudioWorkletProcessor {
     this.currentlyPlayingEventId = null;
     this.processedEventIds = new Set();
     this.endedEventIds = new Set();
+    this.stopOnEmptyBuffer = true;
+    this.finishWhenDrained = false;
     this.port.onmessage = (event) => {
       if (event.data) {
         const payload = event.data;
@@ -74,6 +76,12 @@ class StreamProcessor extends AudioWorkletProcessor {
           if (payload.event === 'interrupt') {
             this.hasInterrupted = true;
           }
+        } else if (payload.event === 'configure') {
+          if (typeof payload.stopOnEmptyBuffer === 'boolean') {
+            this.stopOnEmptyBuffer = payload.stopOnEmptyBuffer;
+          }
+        } else if (payload.event === 'finish') {
+          this.finishWhenDrained = true;
         } else {
           throw new Error(\`Unhandled event "\${payload.event}"\`);
         }
@@ -173,6 +181,9 @@ class StreamProcessor extends AudioWorkletProcessor {
       return true;
     } else if (this.hasStarted) {
       if (this.flushWriteBuffer()) {
+        return true;
+      }
+      if (!this.stopOnEmptyBuffer && !this.finishWhenDrained) {
         return true;
       }
       this.port.postMessage({ event: 'stop' });


### PR DESCRIPTION
## Lecture Videos (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Videos, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
> 
> Lecture Video mode is currently visible only to institutional admins when creating an assistant.

### New Features
* Lecture Video assistants can now show Mermaid and SVG diagrams and narrate a short natural description instead of reading the diagram code aloud.

### Updates & Improvements
* Existing Lecture Video conversations use the latest assistant formatting guidance for new responses, so updates to LaTeX, diagrams, `say` snippets, and follow-up behavior apply without recreating the conversation.

### Resolved Issues
* Fixed: Spoken lecture-video responses may stop early when generated audio arrives with a brief gap between chunks.