### PR TITLE
feat(lv): single pua transformer

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -3802,6 +3802,7 @@ async def run_response(
                 and (lecture_video_dual_text_mode or lecture_video_followups_mode)
                 else None
             )
+            _tts_has_unflushed_text = False
 
             async def _tts_drain_flush_signals() -> None:
                 """Forward speech->body flush signals to ElevenLabs.
@@ -3810,6 +3811,7 @@ async def run_response(
                 immediately rather than waiting for the long diagram body
                 that will produce no further TTS input.
                 """
+                nonlocal _tts_has_unflushed_text
                 if not _tts_pua_transformer or not _tts_client:
                     return
                 pending = _tts_pua_transformer.consume_flush_signals()
@@ -3820,7 +3822,7 @@ async def run_response(
                     if sanitized and _tts_chunker:
                         for tts_chunk in _tts_chunker.add(sanitized):
                             try:
-                                await _tts_client.send_text(tts_chunk)
+                                await _tts_send_text(tts_chunk)
                             except Exception:
                                 logger.warning(
                                     "TTS pre-flush send failed", exc_info=True
@@ -3829,15 +3831,17 @@ async def run_response(
                     final_chunk = _tts_chunker.flush()
                     if final_chunk:
                         try:
-                            await _tts_client.send_text(final_chunk)
+                            await _tts_send_text(final_chunk)
                         except Exception:
                             logger.warning(
                                 "TTS pre-flush chunker drain failed",
                                 exc_info=True,
                             )
                 for _ in range(pending):
+                    if not _tts_has_unflushed_text:
+                        break
                     try:
-                        await _tts_client.send_text("", flush=True)
+                        await _tts_send_text("", flush=True)
                     except Exception:
                         logger.warning("TTS snippet flush failed", exc_info=True)
 
@@ -3847,6 +3851,24 @@ async def run_response(
             _tts_audio_chunk_idx = 0
             _tts_connect_task: asyncio.Task[ElevenLabsStreamingTTS] | None = None
             _tts_input_closed = False
+
+            async def _tts_send_text(
+                text: str,
+                *,
+                flush: bool = False,
+                try_trigger_generation: bool = False,
+            ) -> None:
+                nonlocal _tts_has_unflushed_text
+                assert _tts_client is not None
+                await _tts_client.send_text(
+                    text,
+                    flush=flush,
+                    try_trigger_generation=try_trigger_generation,
+                )
+                if flush:
+                    _tts_has_unflushed_text = False
+                elif text:
+                    _tts_has_unflushed_text = True
 
             async def _tts_cleanup() -> None:
                 nonlocal _tts_client, _tts_audio_task, _tts_connect_task
@@ -4030,7 +4052,7 @@ async def run_response(
                                 try:
                                     tts_chunks = _tts_chunker.add(chunk)
                                     for tts_chunk in tts_chunks:
-                                        await _tts_client.send_text(
+                                        await _tts_send_text(
                                             tts_chunk,
                                         )
                                 except Exception:
@@ -4043,7 +4065,7 @@ async def run_response(
                             try:
                                 tts_chunks = _tts_chunker.add(remaining)
                                 for chunk in tts_chunks:
-                                    await _tts_client.send_text(
+                                    await _tts_send_text(
                                         chunk,
                                     )
                             except Exception:
@@ -4054,7 +4076,7 @@ async def run_response(
                         final_chunk = _tts_chunker.flush()
                         if final_chunk:
                             try:
-                                await _tts_client.send_text(
+                                await _tts_send_text(
                                     final_chunk,
                                     flush=True,
                                 )
@@ -4179,7 +4201,7 @@ async def run_response(
                                             try:
                                                 tts_chunks = _tts_chunker.add(chunk)
                                                 for tts_chunk in tts_chunks:
-                                                    await _tts_client.send_text(
+                                                    await _tts_send_text(
                                                         tts_chunk,
                                                     )
                                             except Exception:

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -24,8 +24,6 @@ from pingpong.files import (
     handle_create_file,
 )
 from pingpong.followup_transform import (
-    FOLLOWUP_MARKER_NAME,
-    FollowupTransformer,
     strip_followup_snippets,
 )
 from pingpong.invite import send_export_download, send_export_failed
@@ -33,10 +31,11 @@ from pingpong.log_utils import sanitize_for_log
 import pingpong.models as models
 from pingpong.prompt import replace_random_blocks
 from pingpong.say_transform import (
+    FOLLOWUP_MARKER_NAME,
+    PuaStreamTransformer,
     SAY_MARKER_END,
     SAY_MARKER_SEPARATOR,
     SAY_MARKER_START,
-    SayTransformer,
     transform_say_text,
 )
 from pingpong.schemas import (
@@ -1245,11 +1244,10 @@ class BufferedResponseStreamHandler:
         )
         self.lecture_video_dual_text_mode = lecture_video_dual_text_mode
         self.lecture_video_followups_mode = lecture_video_followups_mode
-        self._display_say_transformer = (
-            SayTransformer("display") if lecture_video_dual_text_mode else None
-        )
-        self._followup_transformer = (
-            FollowupTransformer() if lecture_video_followups_mode else None
+        self._display_transformer = (
+            PuaStreamTransformer("display")
+            if (lecture_video_dual_text_mode or lecture_video_followups_mode)
+            else None
         )
 
     def enqueue(self, data: Dict) -> None:
@@ -1319,10 +1317,10 @@ class BufferedResponseStreamHandler:
         if (
             not self.lecture_video_followups_mode
             or not self.message_id
-            or not self._followup_transformer
+            or not self._display_transformer
         ):
             return
-        suggestions = self._followup_transformer.consume_suggestions()
+        suggestions = self._display_transformer.consume_followup_suggestions()
         if not suggestions:
             return
         self.enqueue(
@@ -1497,14 +1495,9 @@ class BufferedResponseStreamHandler:
 
         await update_message_part_on_output_text_delta()
         display_delta = (
-            self._followup_transformer.add(data.delta)
-            if self._followup_transformer
+            self._display_transformer.add(data.delta)
+            if self._display_transformer
             else data.delta
-        )
-        display_delta = (
-            self._display_say_transformer.add(display_delta)
-            if self._display_say_transformer
-            else display_delta
         )
         self.enqueue_message_text_delta(display_delta)
 
@@ -1798,13 +1791,9 @@ class BufferedResponseStreamHandler:
             )
             return
 
-        display_delta = ""
-        if self._followup_transformer:
-            display_delta = self._followup_transformer.flush()
-        if self._display_say_transformer:
-            if display_delta:
-                display_delta = self._display_say_transformer.add(display_delta)
-            display_delta += self._display_say_transformer.flush()
+        display_delta = (
+            self._display_transformer.flush() if self._display_transformer else ""
+        )
         self.enqueue_message_text_delta(display_delta)
         self.enqueue_followup_suggestions()
         self.message_part_id = None
@@ -3807,16 +3796,51 @@ async def run_response(
                 else None
             )
             _tts_chunker = StreamingTTSChunker() if _tts_enabled else None
-            _tts_say_transformer = (
-                SayTransformer("speech")
-                if _tts_enabled and lecture_video_dual_text_mode
+            _tts_pua_transformer = (
+                PuaStreamTransformer("speech")
+                if _tts_enabled
+                and (lecture_video_dual_text_mode or lecture_video_followups_mode)
                 else None
             )
-            _tts_followup_transformer = (
-                FollowupTransformer()
-                if _tts_enabled and lecture_video_followups_mode
-                else None
-            )
+
+            async def _tts_drain_flush_signals() -> None:
+                """Forward speech->body flush signals to ElevenLabs.
+
+                Triggered for svg/mermaid snippets so the speech plays
+                immediately rather than waiting for the long diagram body
+                that will produce no further TTS input.
+                """
+                if not _tts_pua_transformer or not _tts_client:
+                    return
+                pending = _tts_pua_transformer.consume_flush_signals()
+                if not pending:
+                    return
+                if _tts_sanitizer:
+                    sanitized = _tts_sanitizer.flush()
+                    if sanitized and _tts_chunker:
+                        for tts_chunk in _tts_chunker.add(sanitized):
+                            try:
+                                await _tts_client.send_text(tts_chunk)
+                            except Exception:
+                                logger.warning(
+                                    "TTS pre-flush send failed", exc_info=True
+                                )
+                if _tts_chunker:
+                    final_chunk = _tts_chunker.flush()
+                    if final_chunk:
+                        try:
+                            await _tts_client.send_text(final_chunk)
+                        except Exception:
+                            logger.warning(
+                                "TTS pre-flush chunker drain failed",
+                                exc_info=True,
+                            )
+                for _ in range(pending):
+                    try:
+                        await _tts_client.send_text("", flush=True)
+                    except Exception:
+                        logger.warning("TTS snippet flush failed", exc_info=True)
+
             _tts_audio_task: asyncio.Task | None = None
             _tts_audio_done = asyncio.Event()
             _tts_audio_ready = asyncio.Event()
@@ -3998,15 +4022,9 @@ async def run_response(
 
                 async def _tts_finish_input() -> None:
                     if _tts_sanitizer and _tts_chunker and _tts_client:
-                        transformed_remaining = ""
-                        if _tts_followup_transformer:
-                            transformed_remaining = _tts_followup_transformer.flush()
-                        if _tts_say_transformer:
-                            if transformed_remaining:
-                                transformed_remaining = _tts_say_transformer.add(
-                                    transformed_remaining
-                                )
-                            transformed_remaining += _tts_say_transformer.flush()
+                        transformed_remaining = (
+                            _tts_pua_transformer.flush() if _tts_pua_transformer else ""
+                        )
                         if transformed_remaining:
                             for chunk in _tts_sanitizer.add(transformed_remaining):
                                 try:
@@ -4152,14 +4170,9 @@ async def run_response(
                                 # Feed text to TTS accumulator
                                 if _tts_sanitizer and _tts_chunker and _tts_client:
                                     tts_delta = (
-                                        _tts_followup_transformer.add(event.delta)
-                                        if _tts_followup_transformer
+                                        _tts_pua_transformer.add(event.delta)
+                                        if _tts_pua_transformer
                                         else event.delta
-                                    )
-                                    tts_delta = (
-                                        _tts_say_transformer.add(tts_delta)
-                                        if _tts_say_transformer
-                                        else tts_delta
                                     )
                                     if tts_delta:
                                         for chunk in _tts_sanitizer.add(tts_delta):
@@ -4174,6 +4187,7 @@ async def run_response(
                                                     "TTS send_text failed",
                                                     exc_info=True,
                                                 )
+                                    await _tts_drain_flush_signals()
                             case "response.output_text.annotation.added":
                                 match event.annotation["type"]:
                                     case "container_file_citation":
@@ -4736,71 +4750,99 @@ def format_instructions(
         if lecture_video_mode:
             instructions += (
                 "\n\n"
-                "---Formatting: Lecture Video LaTeX---\n"
+                "---Formatting: Lecture Video Dual Speech/Display Snippets---\n"
                 "Before producing the final answer, check whether any part of it "
                 "contains math, symbols, formulas, special characters, "
                 "notation, or any text that should be spoken differently from "
                 "how it should be displayed. If it does, you MUST emit that part "
-                "as a private-use `say` snippet.\n"
-                "Use the `display` value for what the student should read. In "
-                "`display`, use the single dollar sign $ with spaces surrounding "
-                "it for inline math. For block-level math, use double dollar "
-                "signs $$ with newlines before and after them as the opening and "
-                "closing delimiter. Do not use LaTeX inside backticks.\n"
-                "Use the `speech` value for what the student should hear, written "
-                "as natural spoken language.\n"
+                "as a private-use snippet.\n"
+                "A snippet payload is a compact JSON object with `speech` and "
+                "`content` string keys. `speech` is the natural spoken form. "
+                "`content` is the exact visible form. Use a `say` snippet for "
+                "math, symbols, formulas, special characters, abbreviations, "
+                "notation, or any text that should be spelled out for speech "
+                "but displayed differently for reading. Use a `mermaid` or "
+                "`svg` snippet to wrap a Mermaid or SVG fenced code block.\n"
+                "For math display, use the single dollar sign $ with spaces "
+                "surrounding it for inline math. For block-level math, use "
+                "double dollar signs $$ with newlines before and after them as "
+                "the opening and closing delimiter. Do not use LaTeX inside "
+                "backticks.\n"
+                "Write the spoken form as natural spoken language.\n"
                 "Do not output raw $...$ or $$...$$ math directly in normal "
                 "lecture-video answers. Do not output raw symbolic tokens like "
                 "variable names, operators, equations, inequalities, units, "
                 "abbreviations, or notation directly when their spoken form "
                 "differs from their written form. This includes short "
                 "single-symbol math like $a$ or $c$. Only leave text outside "
-                "a `say` snippet when the visible text is already exactly "
-                "natural and correct for speech as written.\n"
-                "Use a `say` snippet for math, symbols, formulas, special "
-                "characters, abbreviations, notation, or any text that should be "
-                "spelled out for speech but displayed differently for reading.\n"
-                "Use exactly this format, with U+E200 before `say`, U+E202 before "
-                "the JSON payload, and U+E201 after the JSON payload:\n"
-                '\ue200say\ue202{"speech":"a squared plus b squared equals c squared",'
-                '"display":"$$\\na^2 + b^2 = c^2\\n$$"}\ue201\n'
-                "The JSON payload must be valid and compact. `speech` is what the "
-                "student should hear. `display` is the exact text the student "
-                "should read, using the LaTeX, symbol, or normal text formatting "
-                "rules above.\n"
+                "a snippet when the visible text is already exactly natural "
+                "and correct for speech as written.\n"
+                "Use exactly this format, with U+E200 before the marker name "
+                "(`say`, `mermaid`, or `svg`), U+E202 after the marker name, a "
+                "compact JSON payload, and U+E201 to close:\n"
+                '\ue200say\ue202{"speech":"a squared plus b squared equals c '
+                'squared","content":"$$\\na^2 + b^2 = c^2\\n$$"}\ue201\n'
+                "`speech` must be a single-line JSON string of natural spoken "
+                "language. `content` must be the exact text the student should "
+                "read, using the LaTeX, symbol, or normal text formatting "
+                "rules above. Escape newlines as \\n inside JSON strings. If "
+                "the spoken and visible forms are identical, you may omit "
+                "`content`, writing only:\n"
+                '\ue200say\ue202{"speech":"alpha"}\ue201\n'
+                "and the visible form falls back to `speech`.\n"
+                "Snippet syntax is not recursive. Never put U+E200, U+E202, "
+                "or U+E201 inside the `speech` or `content` value of another "
+                "snippet. A snippet may not contain another snippet.\n"
+                "Wrap only the smallest span that needs different speech and "
+                "display. Do not wrap a whole sentence or paragraph if only "
+                "one symbol, formula, diagram, or notation span needs special "
+                "handling. If a sentence contains multiple special spans, emit "
+                "multiple separate snippets with normal prose between them.\n"
+                "Before finalizing, check that every U+E200 has exactly one "
+                "marker, one U+E202, one valid compact JSON object, and one "
+                "matching U+E201; no snippet contains another U+E200; "
+                "`speech` has no newline; `say` snippets use visible math only "
+                "in `content`; and `svg` and `mermaid` snippets put exactly "
+                "one fenced code block in `content`.\n"
+                "Incorrect: If "
+                '\ue200say\ue202{"speech":"If \ue200say\ue202x","content":"$x$"}\ue201'
+                " is two.\n"
+                'Correct: If \ue200say\ue202{"speech":"x","content":"$x$"}\ue201'
+                " is two.\n"
                 "Incorrect: They have written $ 10a + 5c $ and ask whether it "
                 "becomes $ 15ac $.\n"
                 "Correct: They have written "
                 '\ue200say\ue202{"speech":"ten a plus five c",'
-                '"display":"$ 10a + 5c $"}\ue201'
+                '"content":"$ 10a + 5c $"}\ue201'
                 " and ask whether it becomes "
                 '\ue200say\ue202{"speech":"fifteen a c",'
-                '"display":"$ 15ac $"}\ue201.\n'
+                '"content":"$ 15ac $"}\ue201.\n'
                 "Incorrect: One has $a$, the other has $c$.\n"
                 "Correct: One has "
-                '\ue200say\ue202{"speech":"a","display":"$a$"}\ue201'
+                '\ue200say\ue202{"speech":"a","content":"$a$"}\ue201'
                 ", the other has "
-                '\ue200say\ue202{"speech":"c","display":"$c$"}\ue201.\n'
+                '\ue200say\ue202{"speech":"c","content":"$c$"}\ue201.\n'
                 "When you output a Mermaid or SVG fenced code block in a "
                 "lecture-video response, you MUST wrap the entire fenced code "
-                "block in a `say` snippet. The `speech` value should be a short, "
-                "natural description of what the diagram shows, not the code. "
-                "The `display` value should be the exact fenced code block the "
-                "student should see. Use escaped newlines in the JSON string.\n"
+                "block in a `mermaid` or `svg` snippet (matching the language). "
+                "`speech` should be a short, natural description of what the "
+                "diagram shows, not the code. `content` is the exact fenced "
+                "code block the student should see, with newlines escaped as "
+                "\\n inside the JSON string.\n"
                 "Correct Mermaid diagram:\n"
-                '\ue200say\ue202{"speech":"Here is a simple flow from input to '
-                'output.","display":"```mermaid\\ngraph TD\\n    A[Input] --> '
-                'B[Output]\\n```"}\ue201\n'
+                '\ue200mermaid\ue202{"speech":"Here is a simple flow from input '
+                'to output.","content":"```mermaid\\ngraph TD\\n    A[Input] '
+                '--> B[Output]\\n```"}\ue201\n'
                 "Correct SVG diagram:\n"
-                '\ue200say\ue202{"speech":"Here is a simple yellow circle.",'
-                '"display":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
+                '\ue200svg\ue202{"speech":"Here is a simple yellow circle.",'
+                '"content":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
                 "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
                 "fill='gold'/>\\n</svg>\\n```\"}\ue201\n"
                 "If Mermaid or SVG contains labels, formulas, symbols, or "
                 "notation, the spoken description must include the natural "
                 "spoken form of those labels or symbols.\n"
-                "If you are deciding between raw LaTeX and a `say` snippet "
-                "in a lecture-video response, choose the `say` snippet.\n"
+                "If you are deciding between raw LaTeX and a snippet "
+                "in a lecture-video response, choose the snippet.\n"
                 "Do not mention the snippet syntax to the user.\n\n"
                 + diagram_formatting_instructions
             )

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -3807,7 +3807,7 @@ async def run_response(
             async def _tts_drain_flush_signals() -> None:
                 """Forward speech->body flush signals to ElevenLabs.
 
-                Triggered for svg/mermaid snippets so the speech plays
+                Triggered for svg/mermaid blocks so the speech plays
                 immediately rather than waiting for the long diagram body
                 that will produce no further TTS input.
                 """
@@ -3818,8 +3818,9 @@ async def run_response(
                 if not pending:
                     return
                 if _tts_sanitizer:
-                    sanitized = _tts_sanitizer.flush()
-                    if sanitized and _tts_chunker:
+                    for sanitized in _tts_sanitizer.drain_ready():
+                        if not _tts_chunker:
+                            continue
                         for tts_chunk in _tts_chunker.add(sanitized):
                             try:
                                 await _tts_send_text(tts_chunk)
@@ -3843,7 +3844,7 @@ async def run_response(
                     try:
                         await _tts_send_text("", flush=True)
                     except Exception:
-                        logger.warning("TTS snippet flush failed", exc_info=True)
+                        logger.warning("TTS block flush failed", exc_info=True)
 
             _tts_audio_task: asyncio.Task | None = None
             _tts_audio_done = asyncio.Event()
@@ -4772,19 +4773,25 @@ def format_instructions(
         if lecture_video_mode:
             instructions += (
                 "\n\n"
-                "---Formatting: Lecture Video Dual Speech/Display Snippets---\n"
+                "---Formatting: Lecture Video Dual Speech/Display Blocks---\n"
                 "Before producing the final answer, check whether any part of it "
                 "contains math, symbols, formulas, special characters, "
                 "notation, or any text that should be spoken differently from "
                 "how it should be displayed. If it does, you MUST emit that part "
-                "as a private-use snippet.\n"
-                "A snippet payload is a compact JSON object with `speech` and "
-                "`content` string keys. `speech` is the natural spoken form. "
-                "`content` is the exact visible form. Use a `say` snippet for "
-                "math, symbols, formulas, special characters, abbreviations, "
-                "notation, or any text that should be spelled out for speech "
-                "but displayed differently for reading. Use a `mermaid` or "
-                "`svg` snippet to wrap a Mermaid or SVG fenced code block.\n"
+                "as a private-use block.\n"
+                "A block payload is a compact JSON object with at least one "
+                "of `speech` or `content`. `speech` is the natural spoken "
+                "form. `content` is the exact visible form. Include both keys "
+                "when text should be spoken one way and displayed another way. "
+                "Use only `speech` when the spoken and visible forms are "
+                "identical. Use only `content` when something should be shown "
+                "but not spoken. Do not write an empty `speech` key for "
+                "show-only content; omit `speech` instead. Use a `say` block "
+                "for math, symbols, formulas, special characters, "
+                "abbreviations, notation, or any text that should be spelled "
+                "out for speech but displayed differently for reading. Use a "
+                "`mermaid` or `svg` block to wrap a Mermaid or SVG fenced "
+                "code block.\n"
                 "For math display, use the single dollar sign $ with spaces "
                 "surrounding it for inline math. For block-level math, use "
                 "double dollar signs $$ with newlines before and after them as "
@@ -4797,7 +4804,7 @@ def format_instructions(
                 "abbreviations, or notation directly when their spoken form "
                 "differs from their written form. This includes short "
                 "single-symbol math like $a$ or $c$. Only leave text outside "
-                "a snippet when the visible text is already exactly natural "
+                "a block when the visible text is already exactly natural "
                 "and correct for speech as written.\n"
                 "Use exactly this format, with U+E200 before the marker name "
                 "(`say`, `mermaid`, or `svg`), U+E202 after the marker name, a "
@@ -4807,27 +4814,36 @@ def format_instructions(
                 "`speech` must be a single-line JSON string of natural spoken "
                 "language. `content` must be the exact text the student should "
                 "read, using the LaTeX, symbol, or normal text formatting "
-                "rules above. The snippet payload must be valid JSON: escape "
+                "rules above. The block payload must be valid JSON: escape "
                 "newlines as \\n and write LaTeX backslashes in `content` as "
                 "`\\\\`, for example `\\\\frac`, not `\\frac`. If "
-                "the spoken and visible forms are identical, you may omit "
-                "`content`, writing only:\n"
+                "the spoken and visible forms are identical, omit `content`, "
+                "writing only:\n"
                 '\ue200say\ue202{"speech":"alpha"}\ue201\n'
-                "and the visible form falls back to `speech`.\n"
-                "Snippet syntax is not recursive. Never put U+E200, U+E202, "
-                "or U+E201 inside the `speech` or `content` value of another "
-                "snippet. A snippet may not contain another snippet.\n"
+                "and the visible form falls back to `speech`. If content "
+                "should be displayed silently, omit `speech`, writing only:\n"
+                '\ue200say\ue202{"content":"$x^2$"}\ue201\n'
+                "Block syntax is not recursive. Block values must be "
+                "plain JSON strings only. Never put U+E200, U+E202, or U+E201 "
+                "inside the `speech` or `content` value of another block. A "
+                "block may not contain another block. If multiple spans "
+                "need blocks, close one block before opening the next. Do "
+                "not place blocks inside markdown links, emphasis, inline "
+                "code, or fenced code blocks; put the block outside those "
+                "markdown constructs.\n"
                 "Wrap only the smallest span that needs different speech and "
                 "display. Do not wrap a whole sentence or paragraph if only "
                 "one symbol, formula, diagram, or notation span needs special "
                 "handling. If a sentence contains multiple special spans, emit "
-                "multiple separate snippets with normal prose between them.\n"
+                "multiple separate blocks with normal prose between them.\n"
                 "Before finalizing, check that every U+E200 has exactly one "
                 "marker, one U+E202, one valid compact JSON object, and one "
-                "matching U+E201; no snippet contains another U+E200; "
-                "`speech` has no newline; `say` snippets use visible math only "
-                "in `content`; and `svg` and `mermaid` snippets put exactly "
-                "one fenced code block in `content`.\n"
+                "matching U+E201; no block contains another U+E200; "
+                "`speech`, when present, has no newline; `say` blocks use "
+                "visible math only in `content`; content-only blocks are "
+                "used only when the content should be shown silently; and "
+                "`svg` and `mermaid` blocks put exactly one fenced code "
+                "block in `content`.\n"
                 "Incorrect: If "
                 '\ue200say\ue202{"speech":"If \ue200say\ue202x","content":"$x$"}\ue201'
                 " is two.\n"
@@ -4848,11 +4864,12 @@ def format_instructions(
                 '\ue200say\ue202{"speech":"c","content":"$c$"}\ue201.\n'
                 "When you output a Mermaid or SVG fenced code block in a "
                 "lecture-video response, you MUST wrap the entire fenced code "
-                "block in a `mermaid` or `svg` snippet (matching the language). "
-                "`speech` should be a short, natural description of what the "
-                "diagram shows, not the code. `content` is the exact fenced "
-                "code block the student should see, with newlines escaped as "
-                "\\n inside the JSON string.\n"
+                "block in a `mermaid` or `svg` block (matching the language). "
+                "If the diagram should be spoken about, `speech` should be a "
+                "short, natural description of what the diagram shows, not the "
+                "code. If the diagram should be shown silently, omit `speech`. "
+                "`content` is the exact fenced code block the student should "
+                "see, with newlines escaped as \\n inside the JSON string.\n"
                 "Correct Mermaid diagram:\n"
                 '\ue200mermaid\ue202{"speech":"Here is a simple flow from input '
                 'to output.","content":"```mermaid\\ngraph TD\\n    A[Input] '
@@ -4862,12 +4879,15 @@ def format_instructions(
                 '"content":"```svg\\n<svg xmlns=\'http://www.w3.org/2000/svg\' '
                 "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
                 "fill='gold'/>\\n</svg>\\n```\"}\ue201\n"
-                "If Mermaid or SVG contains labels, formulas, symbols, or "
-                "notation, the spoken description must include the natural "
-                "spoken form of those labels or symbols.\n"
-                "If you are deciding between raw LaTeX and a snippet "
-                "in a lecture-video response, choose the snippet.\n"
-                "Do not mention the snippet syntax to the user.\n\n"
+                "Correct silent display-only math:\n"
+                '\ue200say\ue202{"content":"$x^2$"}\ue201\n'
+                "If a Mermaid or SVG block includes `speech` and contains "
+                "labels, formulas, symbols, or notation, the spoken "
+                "description must include the natural spoken form of those "
+                "labels or symbols.\n"
+                "If you are deciding between raw LaTeX and a block "
+                "in a lecture-video response, choose the block.\n"
+                "Do not mention the block syntax to the user.\n\n"
                 + diagram_formatting_instructions
             )
         else:
@@ -4971,14 +4991,14 @@ def format_instructions(
             f"{SAY_MARKER_START}{FOLLOWUP_MARKER_NAME}{SAY_MARKER_SEPARATOR}"
             '{"responses":["Can you explain that another way?",'
             f'"Show me a quick example from what we just covered."]}}{SAY_MARKER_END}\n'
-            "If no follow-up responses would help, omit the snippet or return "
+            "If no follow-up responses would help, omit the block or return "
             f"an empty array like {SAY_MARKER_START}{FOLLOWUP_MARKER_NAME}"
             f'{SAY_MARKER_SEPARATOR}{{"responses":[]}}{SAY_MARKER_END}. '
             "The JSON payload must be valid and compact. Include only the "
             "`responses` array with at most 3 strings. Do not duplicate the "
             "answer text or provide multiple phrasings of the same next step. "
             "Do not include answers, hints, clues, or narrowed choices for "
-            "restricted knowledge checks or quizzes. Do not mention the snippet "
+            "restricted knowledge checks or quizzes. Do not mention the block "
             "syntax to the user."
         )
 

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -3842,7 +3842,7 @@ async def run_response(
                     if not _tts_has_unflushed_text:
                         break
                     try:
-                        await _tts_send_text("", flush=True)
+                        await _tts_send_text(" ", flush=True)
                     except Exception:
                         logger.warning("TTS block flush failed", exc_info=True)
 
@@ -4803,7 +4803,7 @@ def format_instructions(
                 "variable names, operators, equations, inequalities, units, "
                 "abbreviations, or notation directly when their spoken form "
                 "differs from their written form. This includes short "
-                "single-symbol math like $a$ or $c$. Only leave text outside "
+                "single-symbol math like $ a $ or $ c $. Only leave text outside "
                 "a block when the visible text is already exactly natural "
                 "and correct for speech as written.\n"
                 "Use exactly this format, with U+E200 before the marker name "
@@ -4822,7 +4822,7 @@ def format_instructions(
                 '\ue200say\ue202{"speech":"alpha"}\ue201\n'
                 "and the visible form falls back to `speech`. If content "
                 "should be displayed silently, omit `speech`, writing only:\n"
-                '\ue200say\ue202{"content":"$x^2$"}\ue201\n'
+                '\ue200say\ue202{"content":"$ x^2 $"}\ue201\n'
                 "Block syntax is not recursive. Block values must be "
                 "plain JSON strings only. Never put U+E200, U+E202, or U+E201 "
                 "inside the `speech` or `content` value of another block. A "
@@ -4845,9 +4845,9 @@ def format_instructions(
                 "`svg` and `mermaid` blocks put exactly one fenced code "
                 "block in `content`.\n"
                 "Incorrect: If "
-                '\ue200say\ue202{"speech":"If \ue200say\ue202x","content":"$x$"}\ue201'
+                '\ue200say\ue202{"speech":"If \ue200say\ue202x","content":"$ x $"}\ue201'
                 " is two.\n"
-                'Correct: If \ue200say\ue202{"speech":"x","content":"$x$"}\ue201'
+                'Correct: If \ue200say\ue202{"speech":"x","content":"$ x $"}\ue201'
                 " is two.\n"
                 "Incorrect: They have written $ 10a + 5c $ and ask whether it "
                 "becomes $ 15ac $.\n"
@@ -4857,11 +4857,11 @@ def format_instructions(
                 " and ask whether it becomes "
                 '\ue200say\ue202{"speech":"fifteen a c",'
                 '"content":"$ 15ac $"}\ue201.\n'
-                "Incorrect: One has $a$, the other has $c$.\n"
+                "Incorrect: One has $ a $, the other has $ c $.\n"
                 "Correct: One has "
-                '\ue200say\ue202{"speech":"a","content":"$a$"}\ue201'
+                '\ue200say\ue202{"speech":"a","content":"$ a $"}\ue201'
                 ", the other has "
-                '\ue200say\ue202{"speech":"c","content":"$c$"}\ue201.\n'
+                '\ue200say\ue202{"speech":"c","content":"$ c $"}\ue201.\n'
                 "When you output a Mermaid or SVG fenced code block in a "
                 "lecture-video response, you MUST wrap the entire fenced code "
                 "block in a `mermaid` or `svg` block (matching the language). "
@@ -4880,7 +4880,7 @@ def format_instructions(
                 "viewBox='0 0 100 100'>\\n  <circle cx='50' cy='50' r='40' "
                 "fill='gold'/>\\n</svg>\\n```\"}\ue201\n"
                 "Correct silent display-only math:\n"
-                '\ue200say\ue202{"content":"$x^2$"}\ue201\n'
+                '\ue200say\ue202{"content":"$ x^2 $"}\ue201\n'
                 "If a Mermaid or SVG block includes `speech` and contains "
                 "labels, formulas, symbols, or notation, the spoken "
                 "description must include the natural spoken form of those "

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -4785,7 +4785,9 @@ def format_instructions(
                 "`speech` must be a single-line JSON string of natural spoken "
                 "language. `content` must be the exact text the student should "
                 "read, using the LaTeX, symbol, or normal text formatting "
-                "rules above. Escape newlines as \\n inside JSON strings. If "
+                "rules above. The snippet payload must be valid JSON: escape "
+                "newlines as \\n and write LaTeX backslashes in `content` as "
+                "`\\\\`, for example `\\\\frac`, not `\\frac`. If "
                 "the spoken and visible forms are identical, you may omit "
                 "`content`, writing only:\n"
                 '\ue200say\ue202{"speech":"alpha"}\ue201\n'

--- a/pingpong/elevenlabs.py
+++ b/pingpong/elevenlabs.py
@@ -388,6 +388,10 @@ class StreamingMarkdownSanitizer:
         self._pending += text
         return self._drain_ready()
 
+    def drain_ready(self) -> list[str]:
+        """Return currently safe text without clearing incomplete markdown state."""
+        return self._drain_ready()
+
     def flush(self) -> str | None:
         """Return any remaining text after best-effort markdown cleanup."""
         if not self._pending:

--- a/pingpong/followup_transform.py
+++ b/pingpong/followup_transform.py
@@ -43,15 +43,20 @@ def strip_followup_snippets(text: str) -> str:
 
         separator_index = text.find(SAY_MARKER_SEPARATOR, start_index + 1)
         if separator_index < 0:
-            output_parts.append(text[start_index:])
-            break
-
-        end_index = text.find(SAY_MARKER_END, separator_index + 1)
-        if end_index < 0:
+            marker_prefix = text[start_index + 1 :].strip()
+            if marker_prefix and FOLLOWUP_MARKER_NAME.startswith(marker_prefix):
+                break
             output_parts.append(text[start_index:])
             break
 
         marker_name = text[start_index + 1 : separator_index].strip()
+        end_index = text.find(SAY_MARKER_END, separator_index + 1)
+        if end_index < 0:
+            if marker_name == FOLLOWUP_MARKER_NAME:
+                break
+            output_parts.append(text[start_index:])
+            break
+
         if marker_name == FOLLOWUP_MARKER_NAME:
             cursor = end_index + 1
             continue

--- a/pingpong/followup_transform.py
+++ b/pingpong/followup_transform.py
@@ -20,6 +20,10 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+def _is_marker_name_char(ch: str) -> bool:
+    return ch.isalnum() or ch == "_"
+
+
 def strip_followup_snippets(text: str) -> str:
     """Remove followup snippets from `text`, preserving all other content.
 
@@ -41,19 +45,38 @@ def strip_followup_snippets(text: str) -> str:
         if start_index > cursor:
             output_parts.append(text[cursor:start_index])
 
-        separator_index = text.find(SAY_MARKER_SEPARATOR, start_index + 1)
-        if separator_index < 0:
-            marker_prefix = text[start_index + 1 :].strip()
-            if marker_prefix and FOLLOWUP_MARKER_NAME.startswith(marker_prefix):
+        marker_start = start_index + 1
+        separator_index = text.find(SAY_MARKER_SEPARATOR, marker_start)
+        next_start_index = text.find(SAY_MARKER_START, marker_start)
+        if separator_index < 0 or (
+            next_start_index >= 0 and next_start_index < separator_index
+        ):
+            marker_end = marker_start
+            while marker_end < len(text):
+                ch = text[marker_end]
+                if ch == SAY_MARKER_START or not _is_marker_name_char(ch):
+                    break
+                marker_end += 1
+            marker_name = text[marker_start:marker_end]
+            if marker_name and FOLLOWUP_MARKER_NAME.startswith(marker_name):
                 break
+            if next_start_index >= 0:
+                output_parts.append(text[start_index:next_start_index])
+                cursor = next_start_index
+                continue
             output_parts.append(text[start_index:])
             break
 
-        marker_name = text[start_index + 1 : separator_index].strip()
+        marker_name = text[marker_start:separator_index].strip()
         end_index = text.find(SAY_MARKER_END, separator_index + 1)
-        if end_index < 0:
+        next_start_index = text.find(SAY_MARKER_START, separator_index + 1)
+        if end_index < 0 or (next_start_index >= 0 and next_start_index < end_index):
             if marker_name == FOLLOWUP_MARKER_NAME:
                 break
+            if next_start_index >= 0:
+                output_parts.append(text[start_index:next_start_index])
+                cursor = next_start_index
+                continue
             output_parts.append(text[start_index:])
             break
 

--- a/pingpong/followup_transform.py
+++ b/pingpong/followup_transform.py
@@ -1,156 +1,71 @@
-import json
 import logging
 
 from pingpong.say_transform import (
+    FOLLOWUP_MARKER_NAME,
+    MAX_FOLLOWUP_SUGGESTIONS,
+    PuaStreamTransformer,
     SAY_MARKER_END,
     SAY_MARKER_SEPARATOR,
     SAY_MARKER_START,
 )
 
+__all__ = [
+    "FOLLOWUP_MARKER_NAME",
+    "MAX_FOLLOWUP_SUGGESTIONS",
+    "extract_followup_suggestions",
+    "strip_followup_snippets",
+]
 
-FOLLOWUP_MARKER_NAME = "followups"
-MAX_FOLLOWUP_SUGGESTIONS = 3
 
 logger = logging.getLogger(__name__)
 
 
-class FollowupTransformer:
-    """Streaming transformer for PUA-delimited follow-up suggestion snippets."""
-
-    def __init__(self, *, max_buffer_chars: int = 4096):
-        self._buffer_parts: list[str] = []
-        self.max_buffer_chars = max_buffer_chars
-        self.suggestions: list[str] = []
-
-    def add(self, text: str) -> str:
-        if not text:
-            return ""
-        self._buffer_parts.append(text)
-        buffer = "".join(self._buffer_parts)
-        output_parts: list[str] = []
-        cursor = 0
-
-        while cursor < len(buffer):
-            start_index = buffer.find(SAY_MARKER_START, cursor)
-            if start_index < 0:
-                output_parts.append(buffer[cursor:])
-                cursor = len(buffer)
-                break
-
-            if start_index > cursor:
-                output_parts.append(buffer[cursor:start_index])
-                cursor = start_index
-
-            separator_index = buffer.find(SAY_MARKER_SEPARATOR, start_index + 1)
-            if separator_index < 0:
-                break
-
-            end_index = buffer.find(SAY_MARKER_END, separator_index + 1)
-            if end_index < 0:
-                break
-
-            marker_name = buffer[start_index + 1 : separator_index].strip()
-            payload = buffer[separator_index + 1 : end_index]
-            if marker_name == FOLLOWUP_MARKER_NAME:
-                self._add_suggestions(_extract_payload(payload))
-            else:
-                output_parts.append(buffer[start_index : end_index + 1])
-            cursor = end_index + 1
-
-        if cursor >= len(buffer):
-            self._buffer_parts = []
-        else:
-            self._buffer_parts = [buffer[cursor:]]
-            if len(self._buffer_parts[0]) > self.max_buffer_chars:
-                if _is_incomplete_followup_marker(self._buffer_parts[0]):
-                    logger.warning(
-                        "Dropping oversized incomplete followups snippet buffer"
-                    )
-                else:
-                    logger.warning(
-                        "Emitting oversized incomplete non-followups snippet buffer as raw text"
-                    )
-                    output_parts.append(self._buffer_parts[0])
-                self._buffer_parts = []
-
-        return "".join(output_parts)
-
-    def flush(self) -> str:
-        output = ""
-        buffer = "".join(self._buffer_parts)
-        if buffer:
-            if _is_incomplete_followup_marker(buffer):
-                logger.warning("Dropping incomplete followups snippet buffer")
-            else:
-                output = buffer
-        self._buffer_parts = []
-        return output
-
-    def _add_suggestions(self, suggestions: list[str]) -> None:
-        for suggestion in suggestions:
-            if suggestion in self.suggestions:
-                continue
-            if len(self.suggestions) >= MAX_FOLLOWUP_SUGGESTIONS:
-                break
-            self.suggestions.append(suggestion)
-
-    def consume_suggestions(self) -> list[str]:
-        suggestions = list(self.suggestions)
-        self.suggestions.clear()
-        return suggestions
-
-
 def strip_followup_snippets(text: str) -> str:
-    transformer = FollowupTransformer()
-    return transformer.add(text) + transformer.flush()
+    """Remove followup snippets from `text`, preserving all other content.
+
+    Unlike the streaming transformer used in the live response pipeline,
+    this leaves say/svg/mermaid snippets intact so callers can apply
+    further display- or speech-target transforms afterward.
+    """
+
+    if not text:
+        return ""
+    output_parts: list[str] = []
+    cursor = 0
+    while cursor < len(text):
+        start_index = text.find(SAY_MARKER_START, cursor)
+        if start_index < 0:
+            output_parts.append(text[cursor:])
+            break
+
+        if start_index > cursor:
+            output_parts.append(text[cursor:start_index])
+
+        separator_index = text.find(SAY_MARKER_SEPARATOR, start_index + 1)
+        if separator_index < 0:
+            output_parts.append(text[start_index:])
+            break
+
+        end_index = text.find(SAY_MARKER_END, separator_index + 1)
+        if end_index < 0:
+            output_parts.append(text[start_index:])
+            break
+
+        marker_name = text[start_index + 1 : separator_index].strip()
+        if marker_name == FOLLOWUP_MARKER_NAME:
+            cursor = end_index + 1
+            continue
+
+        output_parts.append(text[start_index : end_index + 1])
+        cursor = end_index + 1
+
+    return "".join(output_parts)
 
 
 def extract_followup_suggestions(text: str) -> list[str]:
-    transformer = FollowupTransformer()
+    if not text:
+        return []
+    transformer = PuaStreamTransformer("display")
     transformer.add(text)
     transformer.flush()
-    return transformer.suggestions
-
-
-def _extract_payload(payload: str) -> list[str]:
-    try:
-        data = json.loads(payload)
-    except json.JSONDecodeError:
-        logger.debug("Dropping malformed followups snippet with invalid JSON")
-        return []
-
-    if not isinstance(data, dict):
-        logger.debug("Dropping malformed followups snippet with non-object payload")
-        return []
-
-    responses = data.get("responses")
-    if not isinstance(responses, list):
-        logger.debug("Dropping malformed followups snippet with missing responses list")
-        return []
-
-    suggestions: list[str] = []
-    for response in responses:
-        if not isinstance(response, str):
-            logger.debug("Dropping non-string followups response")
-            continue
-        suggestion = response.strip()
-        if not suggestion or suggestion in suggestions:
-            continue
-        suggestions.append(suggestion)
-    return suggestions
-
-
-def _is_incomplete_followup_marker(buffer: str) -> bool:
-    followup_prefix = f"{SAY_MARKER_START}{FOLLOWUP_MARKER_NAME}"
-    if buffer.startswith(followup_prefix):
-        next_index = len(followup_prefix)
-        next_char = buffer[next_index] if next_index < len(buffer) else ""
-        return next_index == len(buffer) or not _is_identifier_continuation(next_char)
-    if not buffer.startswith(SAY_MARKER_START):
-        return False
-    marker_prefix = buffer[1:].strip()
-    return len(marker_prefix) >= 2 and FOLLOWUP_MARKER_NAME.startswith(marker_prefix)
-
-
-def _is_identifier_continuation(char: str) -> bool:
-    return char == "_" or char.isalnum()
+    return transformer.consume_followup_suggestions()

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -50,6 +50,7 @@ class _StreamingSnippetJsonParser:
         self.literal_buf = ""
         self.escape = False
         self.unicode_escape: str | None = None
+        self.pending_high_surrogate: int | None = None
         self.display_speech_fallback = ""
         self.display_speech_fallback_overflowed = False
         self.saw_content = False
@@ -93,6 +94,7 @@ class _StreamingSnippetJsonParser:
                 self.current_key = ""
                 self.escape = False
                 self.unicode_escape = None
+                self.pending_high_surrogate = None
                 self.state = self._KEY
                 return False
             return self._invalidate("expected object key")
@@ -123,6 +125,7 @@ class _StreamingSnippetJsonParser:
             if ch == '"':
                 self.escape = False
                 self.unicode_escape = None
+                self.pending_high_surrogate = None
                 self.state = self._VALUE_STRING
                 if self.current_value_key == "content":
                     self.saw_content = True
@@ -224,7 +227,7 @@ class _StreamingSnippetJsonParser:
                 return None, False
             self.unicode_escape += ch
             if len(self.unicode_escape) == 4:
-                decoded = chr(int(self.unicode_escape, 16))
+                decoded = self._decode_unicode_escape(int(self.unicode_escape, 16))
                 self.unicode_escape = None
                 self.escape = False
                 return decoded, False
@@ -232,6 +235,9 @@ class _StreamingSnippetJsonParser:
 
         if self.escape:
             self.escape = False
+            if self.pending_high_surrogate is not None and ch != "u":
+                self._invalidate("invalid unicode surrogate pair")
+                return None, False
             match ch:
                 case '"':
                     return '"', False
@@ -259,12 +265,42 @@ class _StreamingSnippetJsonParser:
                     self._invalidate("invalid string escape")
                     return None, False
 
+        if self.pending_high_surrogate is not None:
+            if ch != "\\":
+                self._invalidate("invalid unicode surrogate pair")
+                return None, False
+            self.escape = True
+            return None, False
+
         if ch == "\\":
             self.escape = True
             return None, False
         if ch == '"':
             return "", True
         return ch, False
+
+    def _decode_unicode_escape(self, code_unit: int) -> str | None:
+        if 0xD800 <= code_unit <= 0xDBFF:
+            if self.pending_high_surrogate is not None:
+                self._invalidate("invalid unicode surrogate pair")
+                return None
+            self.pending_high_surrogate = code_unit
+            return None
+
+        if 0xDC00 <= code_unit <= 0xDFFF:
+            if self.pending_high_surrogate is None:
+                self._invalidate("invalid unicode surrogate pair")
+                return None
+            high = self.pending_high_surrogate
+            self.pending_high_surrogate = None
+            code_point = 0x10000 + ((high - 0xD800) << 10) + (code_unit - 0xDC00)
+            return chr(code_point)
+
+        if self.pending_high_surrogate is not None:
+            self._invalidate("invalid unicode surrogate pair")
+            return None
+
+        return chr(code_unit)
 
     def _consume_value_char(self, ch: str, out: list[str]) -> None:
         if self.current_value_key == "speech":

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -7,105 +7,549 @@ SAY_MARKER_START = "\ue200"
 SAY_MARKER_SEPARATOR = "\ue202"
 SAY_MARKER_END = "\ue201"
 
-SayTransformTarget = Literal["display", "speech"]
+SNIPPET_MARKERS = frozenset({"say", "svg", "mermaid"})
+FLUSH_MARKERS = frozenset({"svg", "mermaid"})
+FOLLOWUP_MARKER_NAME = "followups"
+MAX_FOLLOWUP_SUGGESTIONS = 3
+
+SUPPORTED_MARKERS = SNIPPET_MARKERS | {FOLLOWUP_MARKER_NAME}
+
+PuaStreamTarget = Literal["display", "speech"]
+SnippetTransformTarget = PuaStreamTarget
+
 logger = logging.getLogger(__name__)
 
 
-class SayTransformer:
-    """Streaming transformer for PUA-delimited `say` snippets."""
+class _StreamingSnippetJsonParser:
+    """Incrementally parse snippet JSON and stream selected string fields."""
 
-    def __init__(self, target: SayTransformTarget, *, max_buffer_chars: int = 4096):
+    _EXPECT_OBJECT_START = "expect_object_start"
+    _EXPECT_KEY_OR_END = "expect_key_or_end"
+    _KEY = "key"
+    _AFTER_KEY = "after_key"
+    _BEFORE_VALUE = "before_value"
+    _VALUE_STRING = "value_string"
+    _VALUE_LITERAL = "value_literal"
+    _AFTER_VALUE = "after_value"
+    _DONE = "done"
+    _INVALID = "invalid"
+
+    def __init__(
+        self,
+        *,
+        target: PuaStreamTarget,
+        marker_name: str,
+        max_speech_buffer_chars: int,
+    ):
         self.target = target
-        self._buffer_parts: list[str] = []
-        self.max_buffer_chars = max_buffer_chars
+        self.marker_name = marker_name
+        self.max_speech_buffer_chars = max_speech_buffer_chars
+        self.state = self._EXPECT_OBJECT_START
+        self.current_key = ""
+        self.current_value_key: str | None = None
+        self.literal_buf = ""
+        self.escape = False
+        self.unicode_escape: str | None = None
+        self.display_speech_fallback = ""
+        self.saw_content = False
+        self.started_content = False
+        self.invalid_reason: str | None = None
+
+    @property
+    def done(self) -> bool:
+        return self.state == self._DONE
+
+    @property
+    def invalid(self) -> bool:
+        return self.state == self._INVALID
+
+    @property
+    def in_string(self) -> bool:
+        return self.state in {self._KEY, self._VALUE_STRING}
+
+    def feed(self, ch: str, out: list[str]) -> bool:
+        """Consume one char. Return True when a TTS flush signal should fire."""
+        if self.invalid or self.done:
+            return False
+
+        if self.state == self._EXPECT_OBJECT_START:
+            if ch.isspace():
+                return False
+            if ch == "{":
+                self.state = self._EXPECT_KEY_OR_END
+                return False
+            return self._invalidate("expected JSON object")
+
+        if self.state == self._EXPECT_KEY_OR_END:
+            if ch.isspace():
+                return False
+            if ch == "}":
+                self.state = self._DONE
+                return False
+            if ch == '"':
+                self.current_key = ""
+                self.escape = False
+                self.unicode_escape = None
+                self.state = self._KEY
+                return False
+            return self._invalidate("expected object key")
+
+        if self.state == self._KEY:
+            decoded = self._feed_json_string_char(ch)
+            if decoded is None:
+                return False
+            if decoded == "":
+                self.state = self._AFTER_KEY
+                return False
+            self.current_key += decoded
+            return False
+
+        if self.state == self._AFTER_KEY:
+            if ch.isspace():
+                return False
+            if ch == ":":
+                self.state = self._BEFORE_VALUE
+                return False
+            return self._invalidate("expected ':' after object key")
+
+        if self.state == self._BEFORE_VALUE:
+            if ch.isspace():
+                return False
+            self.current_value_key = self.current_key
+            if ch == '"':
+                self.escape = False
+                self.unicode_escape = None
+                self.state = self._VALUE_STRING
+                if self.current_value_key == "content":
+                    self.started_content = True
+                    return self.marker_name in FLUSH_MARKERS
+                return False
+            if ch in "{[":
+                return self._invalidate("snippet JSON values must be strings")
+            self.literal_buf = ch
+            self.state = self._VALUE_LITERAL
+            return False
+
+        if self.state == self._VALUE_STRING:
+            decoded = self._feed_json_string_char(ch)
+            if decoded is None:
+                return False
+            if decoded == "":
+                self.state = self._AFTER_VALUE
+                self.current_value_key = None
+                return False
+            self._consume_value_char(decoded, out)
+            return False
+
+        if self.state == self._VALUE_LITERAL:
+            if ch in ",}":
+                if self.literal_buf.strip() not in {"null", "true", "false"}:
+                    return self._invalidate("snippet JSON values must be strings")
+                self.current_value_key = None
+                if ch == ",":
+                    self.state = self._EXPECT_KEY_OR_END
+                else:
+                    self.state = self._DONE
+                return False
+            if ch.isspace():
+                if self.literal_buf.strip() not in {"null", "true", "false"}:
+                    return self._invalidate("snippet JSON values must be strings")
+                self.current_value_key = None
+                self.state = self._AFTER_VALUE
+                return False
+            self.literal_buf += ch
+            return False
+
+        if self.state == self._AFTER_VALUE:
+            if ch.isspace():
+                return False
+            if ch == ",":
+                self.state = self._EXPECT_KEY_OR_END
+                return False
+            if ch == "}":
+                self.state = self._DONE
+                return False
+            return self._invalidate("expected ',' or '}' after object value")
+
+        return False
+
+    def flush_output(self) -> str:
+        if self.target == "display" and not self.saw_content:
+            return self.display_speech_fallback
+        return ""
+
+    def _feed_json_string_char(self, ch: str) -> str | None:
+        if self.unicode_escape is not None:
+            if ch.lower() not in "0123456789abcdef":
+                self._invalidate("invalid unicode escape")
+                return None
+            self.unicode_escape += ch
+            if len(self.unicode_escape) == 4:
+                decoded = chr(int(self.unicode_escape, 16))
+                self.unicode_escape = None
+                self.escape = False
+                return decoded
+            return None
+
+        if self.escape:
+            self.escape = False
+            match ch:
+                case '"':
+                    return '"'
+                case "\\":
+                    return "\\"
+                case "/":
+                    return "/"
+                case "b":
+                    return "\b"
+                case "f":
+                    return "\f"
+                case "n":
+                    return "\n"
+                case "r":
+                    return "\r"
+                case "t":
+                    if (
+                        self.current_value_key == "content"
+                        and self._looks_like_latex_escape(ch)
+                    ):
+                        return "\\" + ch
+                    return "\t"
+                case "u":
+                    self.unicode_escape = ""
+                    self.escape = True
+                    return None
+                case _:
+                    if (
+                        self.current_value_key == "content"
+                        and self._looks_like_latex_escape(ch)
+                    ):
+                        return "\\" + ch
+                    self._invalidate("invalid string escape")
+                    return None
+
+        if ch == "\\":
+            self.escape = True
+            return None
+        if ch == '"':
+            return ""
+        return ch
+
+    def _looks_like_latex_escape(self, ch: str) -> bool:
+        # Models often emit LaTeX in JSON content as "\times" or "\frac"
+        # instead of JSON-escaping the slash. Be lenient only for display
+        # content, where preserving the backslash is more useful than decoding
+        # a JSON control escape such as \t or \f.
+        return ch.isalpha()
+
+    def _consume_value_char(self, ch: str, out: list[str]) -> None:
+        if self.current_value_key == "speech":
+            if self.target == "speech":
+                out.append(ch)
+                return
+            if not self.saw_content:
+                self.display_speech_fallback += ch
+                if len(self.display_speech_fallback) > self.max_speech_buffer_chars:
+                    logger.warning(
+                        "Speech fallback buffer exceeded cap; emitting as display"
+                    )
+                    out.append(self.display_speech_fallback)
+                    self.display_speech_fallback = ""
+            return
+
+        if self.current_value_key == "content":
+            self.saw_content = True
+            if self.target == "display":
+                out.append(ch)
+
+    def _invalidate(self, reason: str) -> bool:
+        self.state = self._INVALID
+        self.invalid_reason = reason
+        return False
+
+
+class PuaStreamTransformer:
+    """Streaming transformer for PUA-delimited snippets.
+
+    Snippet shape::
+
+        \\ue200<marker>\\ue202{"speech":"spoken text","content":"visible text"}\\ue201
+
+    Known markers:
+
+    - ``say``, ``svg``, ``mermaid`` — JSON snippets using common ``speech`` and
+      ``content`` keys. The speech target streams ``speech`` string characters
+      as they decode. The display target streams ``content`` string characters
+      as they decode. If ``content`` is omitted, display falls back to
+      ``speech``. For ``svg`` and ``mermaid``, starting the ``content`` field
+      emits a flush signal so TTS can play speech before long silent content.
+
+    - ``followups`` — payload is buffered until the end marker, then parsed as
+      JSON. Suggestions are collected via ``consume_followup_suggestions``.
+
+    Unknown markers pass through verbatim so downstream consumers can handle
+    them.
+    """
+
+    _OUTSIDE = "outside"
+    _MARKER = "marker"
+    _SNIPPET_JSON = "snippet_json"
+    _FOLLOWUP_PAYLOAD = "followup_payload"
+    _PASSTHROUGH = "passthrough"
+
+    def __init__(
+        self,
+        target: PuaStreamTarget,
+        *,
+        max_marker_chars: int = 64,
+        max_speech_buffer_chars: int = 1024,
+        max_followup_buffer_chars: int = 4096,
+    ):
+        self.target = target
+        self.max_marker_chars = max_marker_chars
+        self.max_speech_buffer_chars = max_speech_buffer_chars
+        self.max_followup_buffer_chars = max_followup_buffer_chars
+        self._buffer = ""
+        self._state = self._OUTSIDE
+        self._marker_buf = ""
+        self._marker_name: str | None = None
+        self._json_parser: _StreamingSnippetJsonParser | None = None
+        self._followup_buf = ""
+        self._pending_flushes = 0
+        self._followup_suggestions: list[str] = []
 
     def add(self, text: str) -> str:
         if not text:
             return ""
-        self._buffer_parts.append(text)
-        buffer = "".join(self._buffer_parts)
-        output_parts: list[str] = []
-        cursor = 0
-
-        while cursor < len(buffer):
-            start_index = buffer.find(SAY_MARKER_START, cursor)
-            if start_index < 0:
-                output_parts.append(buffer[cursor:])
-                cursor = len(buffer)
-                break
-
-            if start_index > cursor:
-                output_parts.append(buffer[cursor:start_index])
-                cursor = start_index
-
-            separator_index = buffer.find(SAY_MARKER_SEPARATOR, start_index + 1)
-            if separator_index < 0:
-                break
-
-            end_index = buffer.find(SAY_MARKER_END, separator_index + 1)
-            if end_index < 0:
-                break
-
-            marker_name = buffer[start_index + 1 : separator_index].strip()
-            payload = buffer[separator_index + 1 : end_index]
-            if marker_name == "say":
-                transformed = _transform_payload(payload, self.target)
-                if transformed is not None:
-                    output_parts.append(transformed)
-            cursor = end_index + 1
-
-        if cursor >= len(buffer):
-            self._buffer_parts = []
-        else:
-            self._buffer_parts = [buffer[cursor:]]
-            if len(self._buffer_parts[0]) > self.max_buffer_chars:
-                logger.warning(
-                    "Emitting oversized incomplete say snippet buffer as raw text"
-                )
-                output_parts.append(self._buffer_parts[0])
-                self._buffer_parts = []
-
-        return "".join(output_parts)
+        self._buffer += text
+        out: list[str] = []
+        while self._advance(out):
+            pass
+        return "".join(out)
 
     def flush(self) -> str:
-        output = ""
-        buffer = "".join(self._buffer_parts)
-        if buffer:
-            if SAY_MARKER_START in buffer:
-                logger.warning("Emitting incomplete say snippet buffer as raw text")
-            output = buffer
-        self._buffer_parts = []
-        return output
+        out: list[str] = []
+        if self._state == self._OUTSIDE:
+            if self._buffer:
+                out.append(self._buffer)
+                self._buffer = ""
+        elif self._state == self._MARKER:
+            logger.warning("Flushing incomplete snippet (marker phase) as raw text")
+            out.append(SAY_MARKER_START + self._marker_buf + self._buffer)
+            self._buffer = ""
+            self._reset()
+        elif self._state == self._SNIPPET_JSON:
+            logger.warning("Flushing incomplete snippet JSON")
+            if self._json_parser:
+                out.append(self._json_parser.flush_output())
+            self._buffer = ""
+            self._reset()
+        elif self._state == self._FOLLOWUP_PAYLOAD:
+            logger.warning("Dropping incomplete followups snippet buffer")
+            self._buffer = ""
+            self._followup_buf = ""
+            self._reset()
+        elif self._state == self._PASSTHROUGH:
+            out.append(self._buffer)
+            self._buffer = ""
+            self._reset()
+        return "".join(out)
+
+    def consume_flush_signals(self) -> int:
+        n = self._pending_flushes
+        self._pending_flushes = 0
+        return n
+
+    def consume_followup_suggestions(self) -> list[str]:
+        suggestions = list(self._followup_suggestions)
+        self._followup_suggestions.clear()
+        return suggestions
+
+    def _advance(self, out: list[str]) -> bool:
+        if self._state == self._OUTSIDE:
+            return self._step_outside(out)
+        if self._state == self._MARKER:
+            return self._step_marker(out)
+        if self._state == self._SNIPPET_JSON:
+            return self._step_snippet_json(out)
+        if self._state == self._FOLLOWUP_PAYLOAD:
+            return self._step_followup(out)
+        if self._state == self._PASSTHROUGH:
+            return self._step_passthrough(out)
+        return False
+
+    def _step_outside(self, out: list[str]) -> bool:
+        idx = self._buffer.find(SAY_MARKER_START)
+        if idx < 0:
+            if self._buffer:
+                out.append(self._buffer)
+                self._buffer = ""
+            return False
+        if idx > 0:
+            out.append(self._buffer[:idx])
+        self._buffer = self._buffer[idx + 1 :]
+        self._state = self._MARKER
+        self._marker_buf = ""
+        return True
+
+    def _step_marker(self, out: list[str]) -> bool:
+        sep_idx = self._buffer.find(SAY_MARKER_SEPARATOR)
+        if sep_idx < 0:
+            self._marker_buf += self._buffer
+            self._buffer = ""
+            if len(self._marker_buf) > self.max_marker_chars:
+                logger.warning("Dropping snippet with oversized marker name buffer")
+                out.append(SAY_MARKER_START + self._marker_buf)
+                self._reset()
+                return True
+            return False
+        self._marker_buf += self._buffer[:sep_idx]
+        self._buffer = self._buffer[sep_idx + 1 :]
+        marker_name = self._marker_buf.strip()
+        if marker_name in SNIPPET_MARKERS:
+            self._marker_name = marker_name
+            self._json_parser = _StreamingSnippetJsonParser(
+                target=self.target,
+                marker_name=marker_name,
+                max_speech_buffer_chars=self.max_speech_buffer_chars,
+            )
+            self._state = self._SNIPPET_JSON
+        elif marker_name == FOLLOWUP_MARKER_NAME:
+            self._marker_name = marker_name
+            self._state = self._FOLLOWUP_PAYLOAD
+            self._followup_buf = ""
+            if self.target == "speech":
+                self._pending_flushes += 1
+        else:
+            out.append(SAY_MARKER_START + self._marker_buf + SAY_MARKER_SEPARATOR)
+            self._marker_buf = ""
+            self._marker_name = None
+            self._state = self._PASSTHROUGH
+        return True
+
+    def _step_snippet_json(self, out: list[str]) -> bool:
+        if not self._buffer:
+            return False
+        parser = self._json_parser
+        if parser is None:
+            self._reset()
+            return True
+
+        while self._buffer:
+            ch = self._buffer[0]
+            self._buffer = self._buffer[1:]
+
+            if ch == SAY_MARKER_END and parser.done:
+                out.append(parser.flush_output())
+                self._reset()
+                return True
+
+            if ch == SAY_MARKER_END and not parser.in_string:
+                logger.debug("Dropping malformed snippet JSON before complete object")
+                self._reset()
+                return True
+
+            should_flush = parser.feed(ch, out)
+            if should_flush:
+                self._pending_flushes += 1
+            if parser.invalid:
+                logger.debug(
+                    "Dropping malformed snippet JSON: %s",
+                    parser.invalid_reason,
+                )
+                self._drop_until_marker_end()
+                return bool(self._buffer)
+
+        return False
+
+    def _drop_until_marker_end(self) -> None:
+        end_idx = self._buffer.find(SAY_MARKER_END)
+        if end_idx < 0:
+            self._buffer = ""
+        else:
+            self._buffer = self._buffer[end_idx + 1 :]
+        self._reset()
+
+    def _step_followup(self, out: list[str]) -> bool:
+        if not self._buffer:
+            return False
+        end_idx = self._buffer.find(SAY_MARKER_END)
+        if end_idx < 0:
+            self._followup_buf += self._buffer
+            self._buffer = ""
+            if len(self._followup_buf) > self.max_followup_buffer_chars:
+                logger.warning("Dropping oversized incomplete followups snippet buffer")
+                self._followup_buf = ""
+                self._reset()
+                return True
+            return False
+        self._followup_buf += self._buffer[:end_idx]
+        self._buffer = self._buffer[end_idx + 1 :]
+        self._collect_followup_payload(self._followup_buf)
+        self._followup_buf = ""
+        self._reset()
+        return True
+
+    def _collect_followup_payload(self, payload: str) -> None:
+        for suggestion in _extract_followup_responses(payload):
+            if suggestion in self._followup_suggestions:
+                continue
+            if len(self._followup_suggestions) >= MAX_FOLLOWUP_SUGGESTIONS:
+                break
+            self._followup_suggestions.append(suggestion)
+
+    def _step_passthrough(self, out: list[str]) -> bool:
+        if not self._buffer:
+            return False
+        end_idx = self._buffer.find(SAY_MARKER_END)
+        if end_idx < 0:
+            out.append(self._buffer)
+            self._buffer = ""
+            return False
+        out.append(self._buffer[: end_idx + 1])
+        self._buffer = self._buffer[end_idx + 1 :]
+        self._reset()
+        return True
+
+    def _reset(self) -> None:
+        self._state = self._OUTSIDE
+        self._marker_buf = ""
+        self._marker_name = None
+        self._json_parser = None
 
 
-def transform_say_text(text: str, target: SayTransformTarget) -> str:
-    transformer = SayTransformer(target)
+SnippetTransformer = PuaStreamTransformer
+SayTransformer = PuaStreamTransformer
+
+
+def transform_say_text(text: str, target: PuaStreamTarget) -> str:
+    transformer = PuaStreamTransformer(target)
     return transformer.add(text) + transformer.flush()
 
 
-def _transform_payload(payload: str, target: SayTransformTarget) -> str | None:
+def _extract_followup_responses(payload: str) -> list[str]:
     try:
         data = json.loads(payload)
     except json.JSONDecodeError:
-        logger.debug("Dropping malformed say snippet with invalid JSON")
-        return None
+        logger.debug("Dropping malformed followups snippet with invalid JSON")
+        return []
 
     if not isinstance(data, dict):
-        logger.debug("Dropping malformed say snippet with non-object payload")
-        return None
+        logger.debug("Dropping malformed followups snippet with non-object payload")
+        return []
 
-    speech = data.get("speech")
-    if not isinstance(speech, str):
-        logger.debug("Dropping malformed say snippet with missing speech string")
-        return None
+    responses = data.get("responses")
+    if not isinstance(responses, list):
+        logger.debug("Dropping malformed followups snippet with missing responses list")
+        return []
 
-    if target == "speech":
-        return speech
-
-    display = data.get("display")
-    if display is None and "display" not in data:
-        return speech
-    if not isinstance(display, str):
-        logger.debug("Dropping malformed say snippet with missing display string")
-        return None
-    return display
+    suggestions: list[str] = []
+    for response in responses:
+        if not isinstance(response, str):
+            logger.debug("Dropping non-string followups response")
+            continue
+        suggestion = response.strip()
+        if not suggestion or suggestion in suggestions:
+            continue
+        suggestions.append(suggestion)
+    return suggestions

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -51,8 +51,11 @@ class _StreamingSnippetJsonParser:
         self.escape = False
         self.unicode_escape: str | None = None
         self.display_speech_fallback = ""
+        self.display_speech_fallback_overflowed = False
         self.saw_content = False
+        self.saw_speech = False
         self.started_content = False
+        self.emitted_flush_signal = False
         self.invalid_reason: str | None = None
 
     @property
@@ -95,13 +98,14 @@ class _StreamingSnippetJsonParser:
             return self._invalidate("expected object key")
 
         if self.state == self._KEY:
-            decoded = self._feed_json_string_char(ch)
+            decoded, ended = self._feed_json_string_char(ch)
+            if decoded:
+                self.current_key += decoded
             if decoded is None:
                 return False
-            if decoded == "":
+            if ended:
                 self.state = self._AFTER_KEY
                 return False
-            self.current_key += decoded
             return False
 
         if self.state == self._AFTER_KEY:
@@ -122,8 +126,10 @@ class _StreamingSnippetJsonParser:
                 self.state = self._VALUE_STRING
                 if self.current_value_key == "content":
                     self.started_content = True
-                    return self.marker_name in FLUSH_MARKERS
+                    return self._should_flush_before_content()
                 return False
+            if self.current_value_key in {"content", "speech"}:
+                return self._invalidate("snippet speech/content values must be strings")
             if ch in "{[":
                 return self._invalidate("snippet JSON values must be strings")
             self.literal_buf = ch
@@ -131,19 +137,28 @@ class _StreamingSnippetJsonParser:
             return False
 
         if self.state == self._VALUE_STRING:
-            decoded = self._feed_json_string_char(ch)
+            decoded, ended = self._feed_json_string_char(ch)
+            if decoded:
+                self._consume_value_char(decoded, out)
             if decoded is None:
                 return False
-            if decoded == "":
+            if ended:
+                should_flush = (
+                    self.current_value_key == "speech"
+                    and self.started_content
+                    and self._should_flush_after_speech()
+                )
                 self.state = self._AFTER_VALUE
                 self.current_value_key = None
-                return False
-            self._consume_value_char(decoded, out)
+                return should_flush
             return False
 
         if self.state == self._VALUE_LITERAL:
             if ch in ",}":
-                if self.literal_buf.strip() not in {"null", "true", "false"}:
+                if (
+                    self.current_value_key in {"content", "speech"}
+                    or not self.literal_buf.strip()
+                ):
                     return self._invalidate("snippet JSON values must be strings")
                 self.current_value_key = None
                 if ch == ",":
@@ -152,7 +167,10 @@ class _StreamingSnippetJsonParser:
                     self.state = self._DONE
                 return False
             if ch.isspace():
-                if self.literal_buf.strip() not in {"null", "true", "false"}:
+                if (
+                    self.current_value_key in {"content", "speech"}
+                    or not self.literal_buf.strip()
+                ):
                     return self._invalidate("snippet JSON values must be strings")
                 self.current_value_key = None
                 self.state = self._AFTER_VALUE
@@ -174,76 +192,82 @@ class _StreamingSnippetJsonParser:
         return False
 
     def flush_output(self) -> str:
-        if self.target == "display" and not self.saw_content:
+        if (
+            self.target == "display"
+            and not self.saw_content
+            and not self.display_speech_fallback_overflowed
+        ):
             return self.display_speech_fallback
         return ""
 
-    def _feed_json_string_char(self, ch: str) -> str | None:
+    def _should_flush_before_content(self) -> bool:
+        if self.target != "speech" or self.marker_name not in FLUSH_MARKERS:
+            return False
+        if not self.saw_speech or self.emitted_flush_signal:
+            return False
+        self.emitted_flush_signal = True
+        return True
+
+    def _should_flush_after_speech(self) -> bool:
+        if self.target != "speech" or self.marker_name not in FLUSH_MARKERS:
+            return False
+        if not self.saw_speech or self.emitted_flush_signal:
+            return False
+        self.emitted_flush_signal = True
+        return True
+
+    def _feed_json_string_char(self, ch: str) -> tuple[str | None, bool]:
         if self.unicode_escape is not None:
             if ch.lower() not in "0123456789abcdef":
                 self._invalidate("invalid unicode escape")
-                return None
+                return None, False
             self.unicode_escape += ch
             if len(self.unicode_escape) == 4:
                 decoded = chr(int(self.unicode_escape, 16))
                 self.unicode_escape = None
                 self.escape = False
-                return decoded
-            return None
+                return decoded, False
+            return None, False
 
         if self.escape:
             self.escape = False
             match ch:
                 case '"':
-                    return '"'
+                    return '"', False
                 case "\\":
-                    return "\\"
+                    return "\\", False
                 case "/":
-                    return "/"
+                    return "/", False
                 case "b":
-                    return "\b"
+                    return "\b", False
                 case "f":
-                    return "\f"
+                    return "\f", False
                 case "n":
-                    return "\n"
+                    return "\n", False
                 case "r":
-                    return "\r"
+                    return "\r", False
                 case "t":
-                    if (
-                        self.current_value_key == "content"
-                        and self._looks_like_latex_escape(ch)
-                    ):
-                        return "\\" + ch
-                    return "\t"
+                    return "\t", False
                 case "u":
                     self.unicode_escape = ""
                     self.escape = True
-                    return None
+                    return None, False
                 case _:
-                    if (
-                        self.current_value_key == "content"
-                        and self._looks_like_latex_escape(ch)
-                    ):
-                        return "\\" + ch
+                    if self.current_value_key == "content":
+                        return "\\" + ch, False
                     self._invalidate("invalid string escape")
-                    return None
+                    return None, False
 
         if ch == "\\":
             self.escape = True
-            return None
+            return None, False
         if ch == '"':
-            return ""
-        return ch
-
-    def _looks_like_latex_escape(self, ch: str) -> bool:
-        # Models often emit LaTeX in JSON content as "\times" or "\frac"
-        # instead of JSON-escaping the slash. Be lenient only for display
-        # content, where preserving the backslash is more useful than decoding
-        # a JSON control escape such as \t or \f.
-        return ch.isalpha()
+            return "", True
+        return ch, False
 
     def _consume_value_char(self, ch: str, out: list[str]) -> None:
         if self.current_value_key == "speech":
+            self.saw_speech = True
             if self.target == "speech":
                 out.append(ch)
                 return
@@ -251,10 +275,10 @@ class _StreamingSnippetJsonParser:
                 self.display_speech_fallback += ch
                 if len(self.display_speech_fallback) > self.max_speech_buffer_chars:
                     logger.warning(
-                        "Speech fallback buffer exceeded cap; emitting as display"
+                        "Speech fallback buffer exceeded cap; dropping fallback"
                     )
-                    out.append(self.display_speech_fallback)
                     self.display_speech_fallback = ""
+                    self.display_speech_fallback_overflowed = True
             return
 
         if self.current_value_key == "content":
@@ -287,15 +311,15 @@ class PuaStreamTransformer:
     - ``followups`` — payload is buffered until the end marker, then parsed as
       JSON. Suggestions are collected via ``consume_followup_suggestions``.
 
-    Unknown markers pass through verbatim so downstream consumers can handle
-    them.
+    Unknown markers are dropped so raw private-use delimiters do not leak into
+    display or speech output.
     """
 
     _OUTSIDE = "outside"
     _MARKER = "marker"
     _SNIPPET_JSON = "snippet_json"
     _FOLLOWUP_PAYLOAD = "followup_payload"
-    _PASSTHROUGH = "passthrough"
+    _RECOVERING = "recovering"
 
     def __init__(
         self,
@@ -349,8 +373,8 @@ class PuaStreamTransformer:
             self._buffer = ""
             self._followup_buf = ""
             self._reset()
-        elif self._state == self._PASSTHROUGH:
-            out.append(self._buffer)
+        elif self._state == self._RECOVERING:
+            logger.warning("Dropping incomplete malformed snippet buffer")
             self._buffer = ""
             self._reset()
         return "".join(out)
@@ -374,8 +398,8 @@ class PuaStreamTransformer:
             return self._step_snippet_json(out)
         if self._state == self._FOLLOWUP_PAYLOAD:
             return self._step_followup(out)
-        if self._state == self._PASSTHROUGH:
-            return self._step_passthrough(out)
+        if self._state == self._RECOVERING:
+            return self._step_recovering()
         return False
 
     def _step_outside(self, out: list[str]) -> bool:
@@ -421,10 +445,8 @@ class PuaStreamTransformer:
             if self.target == "speech":
                 self._pending_flushes += 1
         else:
-            out.append(SAY_MARKER_START + self._marker_buf + SAY_MARKER_SEPARATOR)
-            self._marker_buf = ""
-            self._marker_name = None
-            self._state = self._PASSTHROUGH
+            logger.debug("Dropping snippet with unknown marker name: %s", marker_name)
+            self._drop_until_marker_end()
         return True
 
     def _step_snippet_json(self, out: list[str]) -> bool:
@@ -439,12 +461,22 @@ class PuaStreamTransformer:
             ch = self._buffer[0]
             self._buffer = self._buffer[1:]
 
+            if ch == SAY_MARKER_START and parser.done:
+                self._buffer = ch + self._buffer
+                self._reset()
+                return True
+
             if ch == SAY_MARKER_END and parser.done:
                 out.append(parser.flush_output())
                 self._reset()
                 return True
 
-            if ch == SAY_MARKER_END and not parser.in_string:
+            if ch == SAY_MARKER_END and parser.in_string:
+                logger.debug("Dropping malformed snippet JSON with embedded end marker")
+                self._recover_after_invalid()
+                return bool(self._buffer)
+
+            if ch == SAY_MARKER_END:
                 logger.debug("Dropping malformed snippet JSON before complete object")
                 self._reset()
                 return True
@@ -457,7 +489,7 @@ class PuaStreamTransformer:
                     "Dropping malformed snippet JSON: %s",
                     parser.invalid_reason,
                 )
-                self._drop_until_marker_end()
+                self._recover_after_invalid()
                 return bool(self._buffer)
 
         return False
@@ -466,8 +498,23 @@ class PuaStreamTransformer:
         end_idx = self._buffer.find(SAY_MARKER_END)
         if end_idx < 0:
             self._buffer = ""
+            self._state = self._RECOVERING
         else:
             self._buffer = self._buffer[end_idx + 1 :]
+            self._reset()
+
+    def _recover_after_invalid(self) -> None:
+        start_idx = self._buffer.find(SAY_MARKER_START)
+        end_idx = self._buffer.find(SAY_MARKER_END)
+        if start_idx < 0 and end_idx < 0:
+            self._buffer = ""
+            self._state = self._RECOVERING
+            return
+        if end_idx >= 0 and (start_idx < 0 or end_idx < start_idx):
+            self._buffer = self._buffer[end_idx + 1 :]
+            self._reset()
+            return
+        self._buffer = self._buffer[start_idx:]
         self._reset()
 
     def _step_followup(self, out: list[str]) -> bool:
@@ -498,16 +545,18 @@ class PuaStreamTransformer:
                 break
             self._followup_suggestions.append(suggestion)
 
-    def _step_passthrough(self, out: list[str]) -> bool:
+    def _step_recovering(self) -> bool:
         if not self._buffer:
             return False
+        start_idx = self._buffer.find(SAY_MARKER_START)
         end_idx = self._buffer.find(SAY_MARKER_END)
-        if end_idx < 0:
-            out.append(self._buffer)
+        if start_idx < 0 and end_idx < 0:
             self._buffer = ""
             return False
-        out.append(self._buffer[: end_idx + 1])
-        self._buffer = self._buffer[end_idx + 1 :]
+        if end_idx >= 0 and (start_idx < 0 or end_idx < start_idx):
+            self._buffer = self._buffer[end_idx + 1 :]
+        else:
+            self._buffer = self._buffer[start_idx:]
         self._reset()
         return True
 

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class _StreamingSnippetJsonParser:
-    """Incrementally parse snippet JSON and stream selected string fields."""
+    """Incrementally parse block JSON and stream selected string fields."""
 
     _EXPECT_OBJECT_START = "expect_object_start"
     _EXPECT_KEY_OR_END = "expect_key_or_end"
@@ -330,21 +330,22 @@ class _StreamingSnippetJsonParser:
 
 
 class PuaStreamTransformer:
-    """Streaming transformer for PUA-delimited snippets.
+    """Streaming transformer for PUA-delimited blocks.
 
-    Snippet shape::
+    Block shape::
 
         \\ue200<marker>\\ue202{"speech":"spoken text","content":"visible text"}\\ue201
 
     Known markers:
 
-    - ``say``, ``svg``, ``mermaid`` — JSON snippets using common ``speech`` and
+    - ``say``, ``svg``, ``mermaid`` — JSON blocks using common ``speech`` and
       ``content`` keys. The speech target streams ``speech`` string characters
       as they decode. The display target streams ``content`` string characters
       as they decode. If ``content`` is omitted, display falls back to
-      ``speech``. An empty ``content`` string is an explicit empty display. For
-      ``svg`` and ``mermaid``, starting the ``content`` field emits a flush
-      signal so TTS can play speech before long silent content.
+      ``speech``. If ``speech`` is omitted, the speech target emits nothing.
+      An empty ``content`` string is an explicit empty display. For ``svg`` and
+      ``mermaid``, starting the ``content`` field emits a flush signal so TTS
+      can play speech before long silent content.
 
     - ``followups`` — payload is buffered until the end marker, then parsed as
       JSON. Suggestions are collected via ``consume_followup_suggestions``.

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -125,6 +125,7 @@ class _StreamingSnippetJsonParser:
                 self.unicode_escape = None
                 self.state = self._VALUE_STRING
                 if self.current_value_key == "content":
+                    self.saw_content = True
                     self.started_content = True
                     return self._should_flush_before_content()
                 return False
@@ -305,8 +306,9 @@ class PuaStreamTransformer:
       ``content`` keys. The speech target streams ``speech`` string characters
       as they decode. The display target streams ``content`` string characters
       as they decode. If ``content`` is omitted, display falls back to
-      ``speech``. For ``svg`` and ``mermaid``, starting the ``content`` field
-      emits a flush signal so TTS can play speech before long silent content.
+      ``speech``. An empty ``content`` string is an explicit empty display. For
+      ``svg`` and ``mermaid``, starting the ``content`` field emits a flush
+      signal so TTS can play speech before long silent content.
 
     - ``followups`` — payload is buffered until the end marker, then parsed as
       JSON. Suggestions are collected via ``consume_followup_suggestions``.

--- a/pingpong/say_transform.py
+++ b/pingpong/say_transform.py
@@ -397,8 +397,7 @@ class PuaStreamTransformer:
                 out.append(self._buffer)
                 self._buffer = ""
         elif self._state == self._MARKER:
-            logger.warning("Flushing incomplete snippet (marker phase) as raw text")
-            out.append(SAY_MARKER_START + self._marker_buf + self._buffer)
+            logger.warning("Dropping incomplete snippet (marker phase)")
             self._buffer = ""
             self._reset()
         elif self._state == self._SNIPPET_JSON:
@@ -462,8 +461,8 @@ class PuaStreamTransformer:
             self._buffer = ""
             if len(self._marker_buf) > self.max_marker_chars:
                 logger.warning("Dropping snippet with oversized marker name buffer")
-                out.append(SAY_MARKER_START + self._marker_buf)
                 self._reset()
+                self._state = self._RECOVERING
                 return True
             return False
         self._marker_buf += self._buffer[:sep_idx]
@@ -502,6 +501,7 @@ class PuaStreamTransformer:
 
             if ch == SAY_MARKER_START and parser.done:
                 self._buffer = ch + self._buffer
+                out.append(parser.flush_output())
                 self._reset()
                 return True
 
@@ -519,6 +519,13 @@ class PuaStreamTransformer:
                 logger.debug("Dropping malformed snippet JSON before complete object")
                 self._reset()
                 return True
+
+            if parser.done:
+                if ch.isspace():
+                    continue
+                logger.debug("Dropping malformed snippet JSON after complete object")
+                self._recover_after_invalid()
+                return bool(self._buffer)
 
             should_flush = parser.feed(ch, out)
             if should_flush:
@@ -567,6 +574,7 @@ class PuaStreamTransformer:
                 logger.warning("Dropping oversized incomplete followups snippet buffer")
                 self._followup_buf = ""
                 self._reset()
+                self._state = self._RECOVERING
                 return True
             return False
         self._followup_buf += self._buffer[:end_idx]

--- a/pingpong/test_class_credentials.py
+++ b/pingpong/test_class_credentials.py
@@ -1578,6 +1578,17 @@ def test_streaming_markdown_sanitizer_flushes_incomplete_markdown_best_effort():
     assert sanitizer.flush() == "an unfinished link"
 
 
+def test_streaming_markdown_sanitizer_drain_ready_preserves_incomplete_markdown():
+    sanitizer = elevenlabs_module.StreamingMarkdownSanitizer()
+
+    assert sanitizer.add("See [diagram ") == ["See "]
+    assert sanitizer.add("Diagram now.") == []
+    assert sanitizer.drain_ready() == []
+    assert sanitizer.add(" details](https://example.com) done.") == [
+        "diagram Diagram now. details done."
+    ]
+
+
 def test_streaming_markdown_sanitizer_can_strip_latex_delimiters():
     sanitizer = elevenlabs_module.StreamingMarkdownSanitizer(
         strip_latex_delimiters=True

--- a/pingpong/test_export_tool_call_reports.py
+++ b/pingpong/test_export_tool_call_reports.py
@@ -288,7 +288,11 @@ def test_process_message_content_v3_links_container_file_citations():
 
 
 def test_process_message_content_v3_transforms_assistant_say_snippets_for_display():
-    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
+    raw_snippet = (
+        "\ue200say\ue202"
+        '{"speech":"x squared plus y squared","content":"$ x^2 + y^2 $"}'
+        "\ue201"
+    )
     message = make_message(
         role=schemas.MessageRole.ASSISTANT,
         output_index=1,
@@ -333,7 +337,11 @@ def test_process_message_content_v3_strips_assistant_followup_snippets():
 
 
 def test_process_message_content_v3_leaves_user_say_snippets_raw():
-    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
+    raw_snippet = (
+        "\ue200say\ue202"
+        '{"speech":"x squared plus y squared","content":"$ x^2 + y^2 $"}'
+        "\ue201"
+    )
     message = make_message(
         role=schemas.MessageRole.USER,
         output_index=1,

--- a/pingpong/test_export_tool_call_reports.py
+++ b/pingpong/test_export_tool_call_reports.py
@@ -288,11 +288,7 @@ def test_process_message_content_v3_links_container_file_citations():
 
 
 def test_process_message_content_v3_transforms_assistant_say_snippets_for_display():
-    raw_snippet = (
-        "\ue200say\ue202"
-        '{"speech":"x squared plus y squared","display":"$ x^2 + y^2 $"}'
-        "\ue201"
-    )
+    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
     message = make_message(
         role=schemas.MessageRole.ASSISTANT,
         output_index=1,
@@ -337,11 +333,7 @@ def test_process_message_content_v3_strips_assistant_followup_snippets():
 
 
 def test_process_message_content_v3_leaves_user_say_snippets_raw():
-    raw_snippet = (
-        "\ue200say\ue202"
-        '{"speech":"x squared plus y squared","display":"$ x^2 + y^2 $"}'
-        "\ue201"
-    )
+    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
     message = make_message(
         role=schemas.MessageRole.USER,
         output_index=1,

--- a/pingpong/test_followup_transform.py
+++ b/pingpong/test_followup_transform.py
@@ -1,7 +1,6 @@
 import logging
 
 from pingpong.followup_transform import (
-    FollowupTransformer,
     extract_followup_suggestions,
     strip_followup_snippets,
 )
@@ -16,14 +15,23 @@ def followup_payload(payload: str) -> str:
     return f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
 
 
-def say_payload(payload: str) -> str:
-    return f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
+def say_payload(speech: str, body: str) -> str:
+    return (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{speech}\n{body}{SAY_MARKER_END}"
+    )
 
 
 def test_strip_followup_snippets_removes_private_payload():
     text = "Done. " + followup_payload('{"responses":["Explain more."]}')
 
     assert strip_followup_snippets(text) == "Done. "
+
+
+def test_strip_followup_snippets_preserves_say_snippets():
+    say = say_payload("x squared", "$ x^2 $")
+    text = "Use " + say + " then " + followup_payload('{"responses":["More?"]}')
+
+    assert strip_followup_snippets(text) == "Use " + say + " then "
 
 
 def test_extract_followup_suggestions_caps_trims_and_dedupes():
@@ -39,75 +47,16 @@ def test_extract_followup_suggestions_caps_trims_and_dedupes():
     ]
 
 
-def test_followup_transformer_consume_returns_and_clears_suggestions():
-    transformer = FollowupTransformer()
-    transformer.add(followup_payload('{"responses":["Explain more."]}'))
-
-    assert transformer.consume_suggestions() == ["Explain more."]
-    assert transformer.consume_suggestions() == []
-
-
-def test_followup_transformer_buffers_split_deltas_and_preserves_say_snippets():
-    transformer = FollowupTransformer()
-    snippet = followup_payload('{"responses":["What happens next?"]}')
-    say_snippet = say_payload('{"speech":"x squared","display":"$ x^2 $"}')
-
-    assert transformer.add("Use " + say_snippet + " " + snippet[:12]) == (
-        "Use " + say_snippet + " "
-    )
-    assert transformer.add(snippet[12:25]) == ""
-    assert transformer.add(snippet[25:] + ".") == "."
-    assert transformer.flush() == ""
-    assert transformer.suggestions == ["What happens next?"]
-
-
-def test_followup_transformer_drops_malformed_json(caplog):
+def test_extract_followup_suggestions_drops_malformed_json(caplog):
     text = "Before " + followup_payload('{"responses":') + " after"
 
-    with caplog.at_level(logging.DEBUG, logger="pingpong.followup_transform"):
-        assert strip_followup_snippets(text) == "Before  after"
+    with caplog.at_level(logging.DEBUG, logger="pingpong.say_transform"):
+        assert extract_followup_suggestions(text) == []
 
     assert "Dropping malformed followups snippet with invalid JSON" in caplog.text
 
 
-def test_followup_transformer_drops_incomplete_followup_on_flush(caplog):
-    transformer = FollowupTransformer()
+def test_strip_followup_snippets_keeps_incomplete_followup_marker():
+    text = f'Before {SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{{"responses"'
 
-    assert transformer.add('Before \ue200followups\ue202{"responses"') == "Before "
-    with caplog.at_level(logging.WARNING, logger="pingpong.followup_transform"):
-        assert transformer.flush() == ""
-
-    assert "Dropping incomplete followups snippet buffer" in caplog.text
-
-
-def test_followup_transformer_preserves_non_followup_marker_with_same_prefix(caplog):
-    for suffix in ("_extra", "1"):
-        transformer = FollowupTransformer()
-        text = f"{SAY_MARKER_START}followups{suffix}"
-
-        assert transformer.add(text) == ""
-        with caplog.at_level(logging.WARNING, logger="pingpong.followup_transform"):
-            assert transformer.flush() == text
-
-        assert "Dropping incomplete followups snippet buffer" not in caplog.text
-
-
-def test_followup_transformer_preserves_single_character_marker_prefix(caplog):
-    transformer = FollowupTransformer()
-    text = f"{SAY_MARKER_START}f"
-
-    assert transformer.add(text) == ""
-    with caplog.at_level(logging.WARNING, logger="pingpong.followup_transform"):
-        assert transformer.flush() == text
-
-    assert "Dropping incomplete followups snippet buffer" not in caplog.text
-
-
-def test_followup_transformer_treats_lone_marker_as_non_followup_on_flush(caplog):
-    transformer = FollowupTransformer()
-
-    assert transformer.add(SAY_MARKER_START) == ""
-    with caplog.at_level(logging.WARNING, logger="pingpong.followup_transform"):
-        assert transformer.flush() == SAY_MARKER_START
-
-    assert "Dropping incomplete followups snippet buffer" not in caplog.text
+    assert strip_followup_snippets(text) == text

--- a/pingpong/test_followup_transform.py
+++ b/pingpong/test_followup_transform.py
@@ -17,7 +17,8 @@ def followup_payload(payload: str) -> str:
 
 def say_payload(speech: str, body: str) -> str:
     return (
-        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{speech}\n{body}{SAY_MARKER_END}"
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        f'{{"speech":"{speech}","content":"{body}"}}{SAY_MARKER_END}'
     )
 
 
@@ -56,7 +57,13 @@ def test_extract_followup_suggestions_drops_malformed_json(caplog):
     assert "Dropping malformed followups snippet with invalid JSON" in caplog.text
 
 
-def test_strip_followup_snippets_keeps_incomplete_followup_marker():
+def test_strip_followup_snippets_drops_incomplete_followup_marker():
     text = f'Before {SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{{"responses"'
 
-    assert strip_followup_snippets(text) == text
+    assert strip_followup_snippets(text) == "Before "
+
+
+def test_strip_followup_snippets_drops_truncated_followup_marker_prefix():
+    text = f"Before {SAY_MARKER_START}follow"
+
+    assert strip_followup_snippets(text) == "Before "

--- a/pingpong/test_followup_transform.py
+++ b/pingpong/test_followup_transform.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from pingpong.followup_transform import (
@@ -16,10 +17,8 @@ def followup_payload(payload: str) -> str:
 
 
 def say_payload(speech: str, body: str) -> str:
-    return (
-        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
-        f'{{"speech":"{speech}","content":"{body}"}}{SAY_MARKER_END}'
-    )
+    payload = json.dumps({"speech": speech, "content": body}, separators=(",", ":"))
+    return f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
 
 
 def test_strip_followup_snippets_removes_private_payload():
@@ -65,5 +64,18 @@ def test_strip_followup_snippets_drops_incomplete_followup_marker():
 
 def test_strip_followup_snippets_drops_truncated_followup_marker_prefix():
     text = f"Before {SAY_MARKER_START}follow"
+
+    assert strip_followup_snippets(text) == "Before "
+
+
+def test_strip_followup_snippets_drops_incomplete_followup_name_token():
+    text = f'Before {SAY_MARKER_START}followups{{"responses"'
+
+    assert strip_followup_snippets(text) == "Before "
+
+
+def test_strip_followup_snippets_does_not_merge_across_next_marker():
+    say = say_payload("x squared", "$ x^2 $")
+    text = f"Before {SAY_MARKER_START}followups" + say + " after"
 
     assert strip_followup_snippets(text) == "Before "

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -63,7 +63,9 @@ async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_
 
     assert instructions is not None
     assert "Be helpful." in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
+    )
     assert "---Formatting: LaTeX---" not in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
@@ -83,7 +85,10 @@ async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_
 
     assert instructions is not None
     assert "Be helpful." in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" not in instructions
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
+        not in instructions
+    )
     assert "---Formatting: LaTeX---" not in instructions
 
 

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -63,9 +63,7 @@ async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_
 
     assert instructions is not None
     assert "Be helpful." in instructions
-    assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
-    )
+    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
@@ -86,8 +84,7 @@ async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_
     assert instructions is not None
     assert "Be helpful." in instructions
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
-        not in instructions
+        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
     )
     assert "---Formatting: LaTeX---" not in instructions
 

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -63,7 +63,7 @@ async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_
 
     assert instructions is not None
     assert "Be helpful." in instructions
-    assert "---Formatting: Lecture Video LaTeX---" in instructions
+    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
@@ -83,7 +83,7 @@ async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_
 
     assert instructions is not None
     assert "Be helpful." in instructions
-    assert "---Formatting: Lecture Video LaTeX---" not in instructions
+    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" not in instructions
     assert "---Formatting: LaTeX---" not in instructions
 
 

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1509,11 +1509,7 @@ async def test_get_thread_transforms_lecture_video_say_history_after_latex_disab
     thread_id = create_response.json()["thread"]["id"]
     await grant_thread_permissions(config, thread_id, 123)
 
-    raw_snippet = (
-        "\ue200say\ue202"
-        '{"speech":"x squared plus y squared","display":"$ x^2 + y^2 $"}'
-        "\ue201"
-    )
+    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
     async with db.async_session() as session:
         run = models.Run(
             status=schemas.RunStatus.COMPLETED,

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1509,7 +1509,11 @@ async def test_get_thread_transforms_lecture_video_say_history_after_latex_disab
     thread_id = create_response.json()["thread"]["id"]
     await grant_thread_permissions(config, thread_id, 123)
 
-    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
+    raw_snippet = (
+        "\ue200say\ue202"
+        '{"speech":"x squared plus y squared","content":"$ x^2 + y^2 $"}'
+        "\ue201"
+    )
     async with db.async_session() as session:
         run = models.Run(
             status=schemas.RunStatus.COMPLETED,

--- a/pingpong/test_multi_message.py
+++ b/pingpong/test_multi_message.py
@@ -340,7 +340,7 @@ async def test_run_response_sends_say_speech_text_to_tts(db, monkeypatch):
     spoken_text = "".join(text for text, _, _ in sent_tts_text)
     assert "Use x squared plus y squared." in spoken_text
     assert "Can you show another example?" not in spoken_text
-    assert all(text or flush for text, _, flush in sent_tts_text)
+    assert all(text for text, _, _ in sent_tts_text)
     assert all("\ue200" not in text for text, _, _ in sent_tts_text)
     streamed_events = [
         orjson.loads(line)

--- a/pingpong/test_multi_message.py
+++ b/pingpong/test_multi_message.py
@@ -125,7 +125,11 @@ async def test_dual_text_stream_handler_stores_raw_say_snippet_and_streams_displ
     message_part_id = handler.message_part_id
     assert message_part_id is not None
 
-    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
+    raw_snippet = (
+        "\ue200say\ue202"
+        '{"speech":"x squared plus y squared","content":"$ x^2 + y^2 $"}'
+        "\ue201"
+    )
     raw_followups = (
         "\ue200followups\ue202"
         '{"responses":["Can you show another example?","What happens next?"]}'
@@ -219,7 +223,11 @@ async def test_run_response_sends_say_speech_text_to_tts(db, monkeypatch):
         async def get_client(self):
             yield AsyncMock()
 
-    raw_snippet = "\ue200say\ue202x squared plus y squared.\n$ x^2 + y^2 $\ue201"
+    raw_snippet = (
+        "\ue200say\ue202"
+        '{"speech":"x squared plus y squared.","content":"$ x^2 + y^2 $"}'
+        "\ue201"
+    )
     raw_followups = (
         '\ue200followups\ue202{"responses":["Can you show another example?"]}\ue201'
     )
@@ -332,7 +340,7 @@ async def test_run_response_sends_say_speech_text_to_tts(db, monkeypatch):
     spoken_text = "".join(text for text, _, _ in sent_tts_text)
     assert "Use x squared plus y squared." in spoken_text
     assert "Can you show another example?" not in spoken_text
-    assert all(text for text, _, _ in sent_tts_text)
+    assert all(text or flush for text, _, flush in sent_tts_text)
     assert all("\ue200" not in text for text, _, _ in sent_tts_text)
     streamed_events = [
         orjson.loads(line)

--- a/pingpong/test_multi_message.py
+++ b/pingpong/test_multi_message.py
@@ -125,11 +125,7 @@ async def test_dual_text_stream_handler_stores_raw_say_snippet_and_streams_displ
     message_part_id = handler.message_part_id
     assert message_part_id is not None
 
-    raw_snippet = (
-        "\ue200say\ue202"
-        '{"speech":"x squared plus y squared","display":"$ x^2 + y^2 $"}'
-        "\ue201"
-    )
+    raw_snippet = "\ue200say\ue202x squared plus y squared\n$ x^2 + y^2 $\ue201"
     raw_followups = (
         "\ue200followups\ue202"
         '{"responses":["Can you show another example?","What happens next?"]}'
@@ -223,11 +219,7 @@ async def test_run_response_sends_say_speech_text_to_tts(db, monkeypatch):
         async def get_client(self):
             yield AsyncMock()
 
-    raw_snippet = (
-        "\ue200say\ue202"
-        '{"speech":"x squared plus y squared.","display":"$ x^2 + y^2 $"}'
-        "\ue201"
-    )
+    raw_snippet = "\ue200say\ue202x squared plus y squared.\n$ x^2 + y^2 $\ue201"
     raw_followups = (
         '\ue200followups\ue202{"responses":["Can you show another example?"]}\ue201'
     )

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -38,6 +38,9 @@ def test_format_instructions_adds_snippet_contract_for_lecture_video_latex_only(
     assert "---Formatting: LaTeX---" not in instructions
     assert "MUST emit that part as a private-use snippet" in instructions
     assert "JSON object with `speech` and `content` string keys" in instructions
+    assert "The snippet payload must be valid JSON" in instructions
+    assert "write LaTeX backslashes in `content` as `\\\\`" in instructions
+    assert "`\\\\frac`, not `\\frac`" in instructions
     assert "For block-level math, use double dollar signs $$" in instructions
     assert "Do not output raw $...$ or $$...$$ math directly" in instructions
     assert "Incorrect: They have written $ 10a + 5c $" in instructions
@@ -103,15 +106,60 @@ def test_transform_returns_body_for_display():
     assert transform_say_text(text, "display") == "Use $ x^2 $ here."
 
 
-def test_transform_preserves_unescaped_latex_commands_in_json_content():
+def test_transform_decodes_json_escapes_in_content_without_latex_heuristics():
     text = (
         f"Use {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
         '{"speech":"x times x","content":"$ x \\times x $"}'
         f"{SAY_MARKER_END} here."
     )
 
-    assert transform_say_text(text, "display") == "Use $ x \\times x $ here."
+    assert transform_say_text(text, "display") == "Use $ x " + "\t" + "imes x $ here."
     assert transform_say_text(text, "speech") == "Use x times x here."
+
+
+def test_transform_preserves_json_escaped_latex_commands_in_content():
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"the expression",'
+        '"content":"$ \\\\frac{\\\\beta}{\\\\nu} + \\\\nabla f + '
+        '\\\\rangle + \\\\rightarrow $"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert (
+        transform_say_text(text, "display")
+        == "$ \\frac{\\beta}{\\nu} + \\nabla f + \\rangle + \\rightarrow $"
+    )
+
+
+def test_transform_leaves_invalid_content_escape_literal():
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"alpha","content":"$ \\alpha $"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert transform_say_text(text, "display") == "$ \\alpha $"
+
+
+def test_transform_still_decodes_escaped_newlines_in_content():
+    text = (
+        f"{SAY_MARKER_START}mermaid{SAY_MARKER_SEPARATOR}"
+        '{"speech":"A flow.","content":"```mermaid\\ngraph TD\\n  A-->B\\n```"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert transform_say_text(text, "display") == "```mermaid\ngraph TD\n  A-->B\n```"
+
+
+def test_transform_decodes_json_newline_before_letter():
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"two lines","content":"first\\nuser input"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert transform_say_text(text, "display") == "first\nuser input"
 
 
 def test_transform_returns_speech_for_speech_target():
@@ -158,7 +206,7 @@ def test_display_streams_body_chars_immediately():
 
     body = "```mermaid\ngraph TD\n  A-->B\n```"
     assert "".join(emitted) == body
-    assert len([e for e in emitted if e]) >= len(body)
+    assert len([e for e in emitted if e]) > 1
 
 
 def test_display_transformer_streams_svg_body_then_drops_followups():
@@ -177,7 +225,7 @@ def test_display_transformer_streams_svg_body_then_drops_followups():
     emitted.append(transformer.flush())
 
     assert "".join(emitted) == body
-    assert len([e for e in emitted if e]) >= len(body)
+    assert len([e for e in emitted if e]) > 1
     assert transformer.consume_followup_suggestions() == ["Try a smaller example."]
 
 
@@ -286,7 +334,7 @@ def test_pua_transformer_buffers_split_deltas():
     assert out == "$\\alpha$"
 
 
-def test_pua_transformer_passes_through_unknown_markers():
+def test_pua_transformer_drops_unknown_markers():
     transformer = PuaStreamTransformer("display")
     payload = (
         f"{SAY_MARKER_START}unknown{SAY_MARKER_SEPARATOR}arbitrary content"
@@ -295,7 +343,39 @@ def test_pua_transformer_passes_through_unknown_markers():
     text = "before " + payload + " after"
 
     out = transformer.add(text) + transformer.flush()
-    assert out == text
+    assert out == "before  after"
+
+
+def test_pua_transformer_drops_malformed_snippet_but_keeps_followups_afterward():
+    transformer = PuaStreamTransformer("display")
+    assert (
+        transformer.add(
+            f'{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{{"speech":"x","extra":99}}'
+        )
+        == ""
+    )
+    assert (
+        transformer.add(
+            f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}"
+            '{"responses":["Try X"]}'
+            f"{SAY_MARKER_END} next sentence"
+        )
+        == " next sentence"
+    )
+    assert transformer.consume_followup_suggestions() == ["Try X"]
+
+
+def test_pua_transformer_keeps_followups_after_malformed_snippet_in_same_delta():
+    transformer = PuaStreamTransformer("display")
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}x"
+        f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}"
+        '{"responses":["Try X"]}'
+        f"{SAY_MARKER_END} next sentence"
+    )
+
+    assert transformer.add(text) + transformer.flush() == " next sentence"
+    assert transformer.consume_followup_suggestions() == ["Try X"]
 
 
 def test_pua_transformer_drops_invalid_snippet_in_speech_phase_on_flush(caplog):
@@ -307,6 +387,70 @@ def test_pua_transformer_drops_invalid_snippet_in_speech_phase_on_flush(caplog):
     with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
         assert transformer.flush() == "partial speech"
     assert "Flushing incomplete snippet JSON" in caplog.text
+
+
+def test_pua_transformer_discards_malformed_snippet_across_split_deltas():
+    transformer = PuaStreamTransformer("display")
+    assert (
+        transformer.add(f"Before {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}x")
+        == "Before "
+    )
+    assert transformer.add(f" squared\n$ x^2 ${SAY_MARKER_END} after") == " after"
+    assert transformer.flush() == ""
+
+
+def test_display_speech_fallback_overflow_does_not_leak_before_content(caplog):
+    transformer = PuaStreamTransformer("display", max_speech_buffer_chars=4)
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"spoken words","content":"$ x $"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
+        assert transformer.add(text) + transformer.flush() == "$ x $"
+
+    assert "Speech fallback buffer exceeded cap; dropping fallback" in caplog.text
+
+
+def test_display_drops_non_string_content_instead_of_falling_back_to_speech():
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"x","content":null}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert transform_say_text(text, "display") == ""
+
+
+def test_content_first_diagram_flushes_after_speech_not_before():
+    transformer = PuaStreamTransformer("speech")
+    text = (
+        f"{SAY_MARKER_START}mermaid{SAY_MARKER_SEPARATOR}"
+        '{"content":"```mermaid\\ngraph TD\\n  A-->B\\n```","speech":"A flow."}'
+        f"{SAY_MARKER_END}"
+    )
+    flushes_by_delta: list[int] = []
+    emitted = ""
+    for ch in text:
+        emitted += transformer.add(ch)
+        flushes_by_delta.append(transformer.consume_flush_signals())
+
+    assert emitted == "A flow."
+    assert sum(flushes_by_delta) == 1
+    first_flush_index = next(i for i, flushes in enumerate(flushes_by_delta) if flushes)
+    assert first_flush_index > text.index('"speech"')
+
+
+def test_embedded_end_marker_inside_json_string_recovers_downstream_text():
+    transformer = PuaStreamTransformer("display")
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        f'{{"speech":"hello","content":"x{SAY_MARKER_END}y"}}'
+        f"{SAY_MARKER_END} more text"
+    )
+
+    assert transformer.add(text) + transformer.flush() == "x more text"
 
 
 def test_pua_transformer_emits_oversized_marker_buffer(caplog):

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -21,24 +21,35 @@ def snippet(marker: str, speech: str, body: str | None = None) -> str:
     )
 
 
+def content_snippet(marker: str, body: str) -> str:
+    payload = {"content": body}
+    return (
+        f"{SAY_MARKER_START}{marker}{SAY_MARKER_SEPARATOR}"
+        f"{json.dumps(payload, separators=(',', ':'))}{SAY_MARKER_END}"
+    )
+
+
 def followup_snippet(payload: str) -> str:
     return f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
 
 
-def test_format_instructions_adds_snippet_contract_for_lecture_video_latex_only():
+def test_format_instructions_adds_block_contract_for_lecture_video_latex_only():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=True,
         lecture_video_mode=True,
     )
 
-    assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
-    )
+    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
-    assert "MUST emit that part as a private-use snippet" in instructions
-    assert "JSON object with `speech` and `content` string keys" in instructions
-    assert "The snippet payload must be valid JSON" in instructions
+    assert "MUST emit that part as a private-use block" in instructions
+    assert "JSON object with at least one of `speech` or `content`" in instructions
+    assert (
+        "Use only `content` when something should be shown but not spoken"
+        in instructions
+    )
+    assert "omit `speech` instead" in instructions
+    assert "The block payload must be valid JSON" in instructions
     assert "write LaTeX backslashes in `content` as `\\\\`" in instructions
     assert "`\\\\frac`, not `\\frac`" in instructions
     assert "For block-level math, use double dollar signs $$" in instructions
@@ -65,12 +76,20 @@ def test_format_instructions_adds_snippet_contract_for_lecture_video_latex_only(
         f"{SAY_MARKER_START}svg{SAY_MARKER_SEPARATOR}"
         '{"speech":"Here is a simple yellow circle.'
     ) in instructions
+    assert "Correct silent display-only math:" in instructions
+    assert (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"content":"$x^2$"}'
+        f"{SAY_MARKER_END}"
+    ) in instructions
+    assert "A block may not contain another block" in instructions
+    assert "Do not place blocks inside markdown links" in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
     assert f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}" in instructions
     assert '"responses"' in instructions
 
 
-def test_format_instructions_does_not_add_snippet_contract_for_normal_latex_chat():
+def test_format_instructions_does_not_add_block_contract_for_normal_latex_chat():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=True,
@@ -79,13 +98,12 @@ def test_format_instructions_does_not_add_snippet_contract_for_normal_latex_chat
 
     assert "---Formatting: LaTeX---" in instructions
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
-        not in instructions
+        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
     )
     assert "---Formatting: Lecture Video Follow-ups---" not in instructions
 
 
-def test_format_instructions_does_not_add_snippet_contract_without_latex():
+def test_format_instructions_does_not_add_block_contract_without_latex():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=False,
@@ -94,8 +112,7 @@ def test_format_instructions_does_not_add_snippet_contract_without_latex():
 
     assert "---Formatting: LaTeX---" not in instructions
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
-        not in instructions
+        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
     )
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
@@ -104,6 +121,13 @@ def test_transform_returns_body_for_display():
     text = "Use " + snippet("say", "x squared", "$ x^2 $") + " here."
 
     assert transform_say_text(text, "display") == "Use $ x^2 $ here."
+
+
+def test_transform_accepts_content_only_snippet_for_silent_display():
+    text = "Show " + content_snippet("say", "$x^2$") + " only."
+
+    assert transform_say_text(text, "display") == "Show $x^2$ only."
+    assert transform_say_text(text, "speech") == "Show  only."
 
 
 def test_transform_decodes_json_escapes_in_content_without_latex_heuristics():

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -3,48 +3,71 @@ import logging
 
 from pingpong.ai import format_instructions
 from pingpong.say_transform import (
+    PuaStreamTransformer,
     SAY_MARKER_END,
     SAY_MARKER_SEPARATOR,
     SAY_MARKER_START,
-    SayTransformer,
     transform_say_text,
 )
 
 
-def say_payload(payload: str) -> str:
-    return f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
+def snippet(marker: str, speech: str, body: str | None = None) -> str:
+    payload = {"speech": speech}
+    if body is not None:
+        payload["content"] = body
+    return (
+        f"{SAY_MARKER_START}{marker}{SAY_MARKER_SEPARATOR}"
+        f"{json.dumps(payload, separators=(',', ':'))}{SAY_MARKER_END}"
+    )
 
 
-def test_format_instructions_adds_say_contract_for_latex_lecture_video_only():
+def followup_snippet(payload: str) -> str:
+    return f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{payload}{SAY_MARKER_END}"
+
+
+def test_format_instructions_adds_snippet_contract_for_lecture_video_latex_only():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=True,
         lecture_video_mode=True,
     )
 
-    assert "---Formatting: Lecture Video LaTeX---" in instructions
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions
+    )
     assert "---Formatting: LaTeX---" not in instructions
-    assert "MUST emit that part as a private-use `say`" in instructions
-    assert "Use the `display` value for what the student should read" in instructions
+    assert "MUST emit that part as a private-use snippet" in instructions
+    assert "JSON object with `speech` and `content` string keys" in instructions
     assert "For block-level math, use double dollar signs $$" in instructions
     assert "Do not output raw $...$ or $$...$$ math directly" in instructions
     assert "Incorrect: They have written $ 10a + 5c $" in instructions
-    assert '"speech":"ten a plus five c"' in instructions
+    assert (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"ten a plus five c","content":"$ 10a + 5c $"}'
+        f"{SAY_MARKER_END}"
+    ) in instructions
     assert "Incorrect: One has $a$, the other has $c$." in instructions
-    assert '"speech":"a","display":"$a$"' in instructions
-    assert "MUST wrap the entire fenced code block in a `say` snippet" in instructions
+    assert (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"a","content":"$a$"}'
+        f"{SAY_MARKER_END}"
+    ) in instructions
     assert "Correct Mermaid diagram:" in instructions
-    assert '"display":"```mermaid\\ngraph TD' in instructions
+    assert (
+        f"{SAY_MARKER_START}mermaid{SAY_MARKER_SEPARATOR}"
+        '{"speech":"Here is a simple flow'
+    ) in instructions
     assert "Correct SVG diagram:" in instructions
-    assert '"display":"```svg\\n<svg' in instructions
-    assert '"speech"' in instructions
-    assert '"display"' in instructions
+    assert (
+        f"{SAY_MARKER_START}svg{SAY_MARKER_SEPARATOR}"
+        '{"speech":"Here is a simple yellow circle.'
+    ) in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
-    assert "\ue200followups\ue202" in instructions
+    assert f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}" in instructions
     assert '"responses"' in instructions
 
 
-def test_format_instructions_does_not_add_say_contract_for_normal_latex_chat():
+def test_format_instructions_does_not_add_snippet_contract_for_normal_latex_chat():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=True,
@@ -52,11 +75,14 @@ def test_format_instructions_does_not_add_say_contract_for_normal_latex_chat():
     )
 
     assert "---Formatting: LaTeX---" in instructions
-    assert "---Formatting: Lecture Video LaTeX---" not in instructions
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
+        not in instructions
+    )
     assert "---Formatting: Lecture Video Follow-ups---" not in instructions
 
 
-def test_format_instructions_does_not_add_say_contract_without_latex():
+def test_format_instructions_does_not_add_snippet_contract_without_latex():
     instructions = format_instructions(
         "Be helpful.",
         use_latex=False,
@@ -64,29 +90,44 @@ def test_format_instructions_does_not_add_say_contract_without_latex():
     )
 
     assert "---Formatting: LaTeX---" not in instructions
-    assert "---Formatting: Lecture Video LaTeX---" not in instructions
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
+        not in instructions
+    )
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
 
-def test_transform_say_text_returns_display_string():
-    text = "Use " + say_payload('{"speech":"x squared","display":"$ x^2 $"}') + " here."
+def test_transform_returns_body_for_display():
+    text = "Use " + snippet("say", "x squared", "$ x^2 $") + " here."
 
     assert transform_say_text(text, "display") == "Use $ x^2 $ here."
 
 
-def test_transform_say_text_returns_speech_string():
-    text = "Use " + say_payload('{"speech":"x squared","display":"$ x^2 $"}') + " here."
+def test_transform_preserves_unescaped_latex_commands_in_json_content():
+    text = (
+        f"Use {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"x times x","content":"$ x \\times x $"}'
+        f"{SAY_MARKER_END} here."
+    )
+
+    assert transform_say_text(text, "display") == "Use $ x \\times x $ here."
+    assert transform_say_text(text, "speech") == "Use x times x here."
+
+
+def test_transform_returns_speech_for_speech_target():
+    text = "Use " + snippet("say", "x squared", "$ x^2 $") + " here."
 
     assert transform_say_text(text, "speech") == "Use x squared here."
 
 
-def test_transform_say_text_falls_back_to_speech_when_display_missing():
-    text = "Use " + say_payload('{"speech":"x squared"}') + " here."
+def test_transform_falls_back_to_speech_for_single_line_snippet():
+    text = "Use " + snippet("say", "alpha") + " here."
 
-    assert transform_say_text(text, "display") == "Use x squared here."
+    assert transform_say_text(text, "display") == "Use alpha here."
+    assert transform_say_text(text, "speech") == "Use alpha here."
 
 
-def test_transform_say_text_can_wrap_svg_block_for_dual_display_and_speech():
+def test_transform_can_wrap_svg_block_for_dual_display_and_speech():
     svg_block = (
         "```svg\n"
         "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>\n"
@@ -94,66 +135,195 @@ def test_transform_say_text_can_wrap_svg_block_for_dual_display_and_speech():
         "</svg>\n"
         "```"
     )
-    text = "Here: " + say_payload(
-        json.dumps(
-            {
-                "speech": "Here is a simple yellow circle.",
-                "display": svg_block,
-            },
-            separators=(",", ":"),
-        )
-    )
+    text = "Here: " + snippet("svg", "Here is a simple yellow circle.", svg_block)
 
     assert transform_say_text(text, "display") == "Here: " + svg_block
     assert transform_say_text(text, "speech") == "Here: Here is a simple yellow circle."
 
 
-def test_say_transformer_buffers_split_deltas():
-    transformer = SayTransformer("display")
-    snippet = say_payload('{"speech":"alpha","display":"α"}')
+def test_display_streams_body_chars_immediately():
+    """The whole point of the redesign: body chars come out as they arrive."""
+    transformer = PuaStreamTransformer("display")
+    full = snippet(
+        "mermaid",
+        "A simple flow.",
+        "```mermaid\ngraph TD\n  A-->B\n```",
+    )
+    emitted: list[str] = []
+    for ch in full:
+        chunk = transformer.add(ch)
+        if chunk:
+            emitted.append(chunk)
+    emitted.append(transformer.flush())
 
-    assert transformer.add("Greek " + snippet[:8]) == "Greek "
-    assert transformer.add(snippet[8:20]) == ""
-    assert transformer.add(snippet[20:] + ".") == "α."
-    assert transformer.flush() == ""
+    body = "```mermaid\ngraph TD\n  A-->B\n```"
+    assert "".join(emitted) == body
+    assert len([e for e in emitted if e]) >= len(body)
 
 
-def test_say_transformer_suppresses_malformed_json(caplog):
-    text = "Before " + say_payload('{"speech":') + " after"
-
-    with caplog.at_level(logging.DEBUG, logger="pingpong.say_transform"):
-        assert transform_say_text(text, "display") == "Before  after"
-
-    assert "Dropping malformed say snippet with invalid JSON" in caplog.text
-
-
-def test_say_transformer_suppresses_non_string_display():
-    text = (
-        "Before "
-        + say_payload('{"speech":"x squared","display":{"type":"math_inline"}}')
-        + " after"
+def test_display_transformer_streams_svg_body_then_drops_followups():
+    """A mixed stream containing svg followed by followups behaves correctly."""
+    transformer = PuaStreamTransformer("display")
+    body = "```svg\n<svg viewBox='0 0 10 10'></svg>\n```"
+    full = snippet("svg", "A simple circle.", body) + followup_snippet(
+        '{"responses":["Try a smaller example."]}'
     )
 
-    assert transform_say_text(text, "display") == "Before  after"
+    emitted: list[str] = []
+    for ch in full:
+        delta = transformer.add(ch)
+        if delta:
+            emitted.append(delta)
+    emitted.append(transformer.flush())
+
+    assert "".join(emitted) == body
+    assert len([e for e in emitted if e]) >= len(body)
+    assert transformer.consume_followup_suggestions() == ["Try a smaller example."]
 
 
-def test_say_transformer_emits_incomplete_snippet_on_flush(caplog):
-    transformer = SayTransformer("display")
-    text = 'Before \ue200say\ue202{"speech":"x"'
+def test_display_transformer_strips_followup_snippets_and_collects_suggestions():
+    transformer = PuaStreamTransformer("display")
+    payload = followup_snippet('{"responses":["Try a smaller example."]}')
 
+    out = ""
+    for ch in "before " + payload + " after":
+        out += transformer.add(ch)
+    out += transformer.flush()
+
+    assert out == "before  after"
+    assert transformer.consume_followup_suggestions() == ["Try a smaller example."]
+
+
+def test_speech_transformer_streams_speech_and_flushes_for_diagrams():
+    transformer = PuaStreamTransformer("speech")
+    full = snippet("svg", "A simple circle.", "```svg\n<svg/>\n```")
+
+    emitted: list[str] = []
+    flushes = 0
+    for ch in full:
+        delta = transformer.add(ch)
+        if delta:
+            emitted.append(delta)
+        flushes += transformer.consume_flush_signals()
+    emitted.append(transformer.flush())
+
+    assert "".join(emitted) == "A simple circle."
+    assert len([e for e in emitted if e]) >= len("A simple circle.")
+    assert flushes == 1
+
+
+def test_speech_transformer_drops_followup_snippets():
+    transformer = PuaStreamTransformer("speech")
+    payload = followup_snippet('{"responses":["Try a smaller example."]}')
+
+    out = ""
+    flushes = 0
+    for ch in "before " + payload + " after":
+        out += transformer.add(ch)
+        flushes += transformer.consume_flush_signals()
+    out += transformer.flush()
+
+    assert out == "before  after"
+    assert flushes == 1
+
+
+def test_speech_streams_chars_immediately():
+    transformer = PuaStreamTransformer("speech")
+    full = snippet("say", "ten a plus five c", "$ 10a + 5c $")
+    emitted: list[str] = []
+    for ch in full:
+        chunk = transformer.add(ch)
+        if chunk:
+            emitted.append(chunk)
+    emitted.append(transformer.flush())
+
+    assert "".join(emitted) == "ten a plus five c"
+    assert len([e for e in emitted if e]) >= len("ten a plus five c")
+
+
+def test_flush_signal_fires_for_mermaid_at_speech_to_body_transition():
+    transformer = PuaStreamTransformer("speech")
+    full = snippet("mermaid", "A flow.", "```mermaid\ngraph TD\n  A-->B\n```")
+
+    flushes_before_body = 0
+    content_marker = ',"content":"'
+    pre_content, _, rest = full.partition(content_marker)
+    transformer.add(pre_content)
+    flushes_before_body += transformer.consume_flush_signals()
+    assert flushes_before_body == 0
+
+    transformer.add(content_marker)
+    assert transformer.consume_flush_signals() == 1
+
+    transformer.add(rest)
+    assert transformer.consume_flush_signals() == 0
+
+
+def test_flush_signal_fires_for_svg():
+    transformer = PuaStreamTransformer("speech")
+    transformer.add(snippet("svg", "A circle.", "```svg\n<svg/>\n```"))
+    assert transformer.consume_flush_signals() == 1
+
+
+def test_flush_signal_does_not_fire_for_say():
+    transformer = PuaStreamTransformer("speech")
+    transformer.add(snippet("say", "x squared", "$ x^2 $"))
+    assert transformer.consume_flush_signals() == 0
+
+
+def test_flush_signal_does_not_fire_for_single_line_snippet():
+    transformer = PuaStreamTransformer("speech")
+    transformer.add(snippet("mermaid", "A flow."))
+    assert transformer.consume_flush_signals() == 0
+
+
+def test_pua_transformer_buffers_split_deltas():
+    transformer = PuaStreamTransformer("display")
+    full = snippet("say", "alpha", "$\\alpha$")
+
+    pieces = [full[:5], full[5:12], full[12:]]
+    out = "".join(transformer.add(p) for p in pieces) + transformer.flush()
+    assert out == "$\\alpha$"
+
+
+def test_pua_transformer_passes_through_unknown_markers():
+    transformer = PuaStreamTransformer("display")
+    payload = (
+        f"{SAY_MARKER_START}unknown{SAY_MARKER_SEPARATOR}arbitrary content"
+        f"{SAY_MARKER_END}"
+    )
+    text = "before " + payload + " after"
+
+    out = transformer.add(text) + transformer.flush()
+    assert out == text
+
+
+def test_pua_transformer_drops_invalid_snippet_in_speech_phase_on_flush(caplog):
+    transformer = PuaStreamTransformer("display")
+    text = (
+        f'Before {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}{{"speech":"partial speech"'
+    )
     assert transformer.add(text) == "Before "
     with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
-        assert transformer.flush() == '\ue200say\ue202{"speech":"x"'
+        assert transformer.flush() == "partial speech"
+    assert "Flushing incomplete snippet JSON" in caplog.text
 
-    assert "Emitting incomplete say snippet buffer as raw text" in caplog.text
 
-
-def test_say_transformer_emits_oversized_incomplete_buffer(caplog):
-    transformer = SayTransformer("display", max_buffer_chars=10)
+def test_pua_transformer_emits_oversized_marker_buffer(caplog):
+    transformer = PuaStreamTransformer("display", max_marker_chars=4)
 
     with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
-        assert transformer.add("Before \ue200unfinished tail") == (
-            "Before \ue200unfinished tail"
-        )
+        out = transformer.add(f"Before {SAY_MARKER_START}toolongmarker")
 
-    assert "Emitting oversized incomplete say snippet buffer as raw text" in caplog.text
+    assert out.startswith("Before ")
+    assert "oversized marker name buffer" in caplog.text
+
+
+def test_pua_transformer_drops_incomplete_followup_payload_on_flush(caplog):
+    transformer = PuaStreamTransformer("display")
+    text = f'Before {SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{{"responses"'
+    assert transformer.add(text) == "Before "
+    with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
+        assert transformer.flush() == ""
+    assert "Dropping incomplete followups snippet buffer" in caplog.text
+    assert transformer.consume_followup_suggestions() == []

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -162,6 +162,38 @@ def test_transform_decodes_json_newline_before_letter():
     assert transform_say_text(text, "display") == "first\nuser input"
 
 
+def test_transform_combines_json_unicode_surrogate_pair():
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"smile","content":"\\uD83D\\uDE00"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    out = transform_say_text(text, "display")
+    assert out == "😀"
+    assert out.encode("utf-8") == b"\xf0\x9f\x98\x80"
+
+
+def test_transform_rejects_unpaired_unicode_high_surrogate():
+    text = (
+        f"before {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"smile","content":"\\uD83Dx"}'
+        f"{SAY_MARKER_END} after"
+    )
+
+    assert transform_say_text(text, "display") == "before  after"
+
+
+def test_transform_rejects_lone_unicode_low_surrogate():
+    text = (
+        f"before {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"smile","content":"\\uDE00"}'
+        f"{SAY_MARKER_END} after"
+    )
+
+    assert transform_say_text(text, "display") == "before  after"
+
+
 def test_transform_returns_speech_for_speech_target():
     text = "Use " + snippet("say", "x squared", "$ x^2 $") + " here."
 

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -423,6 +423,13 @@ def test_display_drops_non_string_content_instead_of_falling_back_to_speech():
     assert transform_say_text(text, "display") == ""
 
 
+def test_display_keeps_empty_content_instead_of_falling_back_to_speech():
+    text = snippet("say", "hello", "")
+
+    assert transform_say_text(text, "display") == ""
+    assert transform_say_text(text, "speech") == "hello"
+
+
 def test_content_first_diagram_flushes_after_speech_not_before():
     transformer = PuaStreamTransformer("speech")
     text = (

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -60,10 +60,10 @@ def test_format_instructions_adds_block_contract_for_lecture_video_latex_only():
         '{"speech":"ten a plus five c","content":"$ 10a + 5c $"}'
         f"{SAY_MARKER_END}"
     ) in instructions
-    assert "Incorrect: One has $a$, the other has $c$." in instructions
+    assert "Incorrect: One has $ a $, the other has $ c $." in instructions
     assert (
         f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
-        '{"speech":"a","content":"$a$"}'
+        '{"speech":"a","content":"$ a $"}'
         f"{SAY_MARKER_END}"
     ) in instructions
     assert "Correct Mermaid diagram:" in instructions
@@ -79,7 +79,7 @@ def test_format_instructions_adds_block_contract_for_lecture_video_latex_only():
     assert "Correct silent display-only math:" in instructions
     assert (
         f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
-        '{"content":"$x^2$"}'
+        '{"content":"$ x^2 $"}'
         f"{SAY_MARKER_END}"
     ) in instructions
     assert "A block may not contain another block" in instructions
@@ -402,7 +402,7 @@ def test_pua_transformer_drops_unknown_markers():
     assert out == "before  after"
 
 
-def test_pua_transformer_drops_malformed_snippet_but_keeps_followups_afterward():
+def test_pua_transformer_flushes_complete_snippet_before_followups_afterward():
     transformer = PuaStreamTransformer("display")
     assert (
         transformer.add(
@@ -416,7 +416,7 @@ def test_pua_transformer_drops_malformed_snippet_but_keeps_followups_afterward()
             '{"responses":["Try X"]}'
             f"{SAY_MARKER_END} next sentence"
         )
-        == " next sentence"
+        == "x next sentence"
     )
     assert transformer.consume_followup_suggestions() == ["Try X"]
 
@@ -516,14 +516,52 @@ def test_embedded_end_marker_inside_json_string_recovers_downstream_text():
     assert transformer.add(text) + transformer.flush() == "x more text"
 
 
-def test_pua_transformer_emits_oversized_marker_buffer(caplog):
+def test_pua_transformer_drops_trailing_chars_after_complete_json(caplog):
+    transformer = PuaStreamTransformer("display")
+    text = (
+        f"Before {SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"alpha"}oops'
+        f"{SAY_MARKER_END} after"
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="pingpong.say_transform"):
+        assert transformer.add(text) + transformer.flush() == "Before  after"
+
+    assert "Dropping malformed snippet JSON after complete object" in caplog.text
+
+
+def test_pua_transformer_flushes_speech_fallback_before_new_marker():
+    transformer = PuaStreamTransformer("display")
+    text = (
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"alpha"}'
+        f"{SAY_MARKER_START}say{SAY_MARKER_SEPARATOR}"
+        '{"speech":"beta"}'
+        f"{SAY_MARKER_END}"
+    )
+
+    assert transformer.add(text) + transformer.flush() == "alphabeta"
+
+
+def test_pua_transformer_drops_oversized_marker_buffer(caplog):
     transformer = PuaStreamTransformer("display", max_marker_chars=4)
 
     with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
         out = transformer.add(f"Before {SAY_MARKER_START}toolongmarker")
 
-    assert out.startswith("Before ")
+    assert out == "Before "
+    assert SAY_MARKER_START not in out
     assert "oversized marker name buffer" in caplog.text
+
+
+def test_pua_transformer_drops_incomplete_marker_on_flush(caplog):
+    transformer = PuaStreamTransformer("display")
+
+    assert transformer.add(f"Before {SAY_MARKER_START}say") == "Before "
+    with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
+        assert transformer.flush() == ""
+
+    assert "Dropping incomplete snippet (marker phase)" in caplog.text
 
 
 def test_pua_transformer_drops_incomplete_followup_payload_on_flush(caplog):
@@ -533,4 +571,18 @@ def test_pua_transformer_drops_incomplete_followup_payload_on_flush(caplog):
     with caplog.at_level(logging.WARNING, logger="pingpong.say_transform"):
         assert transformer.flush() == ""
     assert "Dropping incomplete followups snippet buffer" in caplog.text
+    assert transformer.consume_followup_suggestions() == []
+
+
+def test_pua_transformer_recovers_after_followup_buffer_overflow():
+    transformer = PuaStreamTransformer("display", max_followup_buffer_chars=12)
+
+    assert (
+        transformer.add(
+            f'Before {SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}{{"responses":'
+        )
+        == "Before "
+    )
+    assert transformer.add(f'["leaked"]}}{SAY_MARKER_END} after') == " after"
+    assert transformer.flush() == ""
     assert transformer.consume_followup_suggestions() == []

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1893,7 +1893,7 @@ async def test_preview_assistant_instructions_includes_lecture_video_say_contrac
     assert response.status_code == 200
     instructions_preview = response.json()["instructions_preview"]
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
+        "---Formatting: Lecture Video Dual Speech/Display Blocks---"
         in instructions_preview
     )
 

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1892,7 +1892,10 @@ async def test_preview_assistant_instructions_includes_lecture_video_say_contrac
 
     assert response.status_code == 200
     instructions_preview = response.json()["instructions_preview"]
-    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions_preview
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Snippets---"
+        in instructions_preview
+    )
 
 
 @with_user(123)

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1892,7 +1892,7 @@ async def test_preview_assistant_instructions_includes_lecture_video_say_contrac
 
     assert response.status_code == 200
     instructions_preview = response.json()["instructions_preview"]
-    assert "---Formatting: Lecture Video LaTeX---" in instructions_preview
+    assert "---Formatting: Lecture Video Dual Speech/Display Snippets---" in instructions_preview
 
 
 @with_user(123)


### PR DESCRIPTION
## Lecture Videos (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Videos, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
> 
> Lecture Video mode is currently visible only to institutional admins when creating an assistant.

### New Features
* Lecture Video assistant instructions now use a unified speech/display block format for math, symbols, Mermaid diagrams, SVG diagrams, and follow-up suggestions.

### Updates & Improvements
* Improved Lecture Video response formatting so math, symbols, Mermaid diagrams, and SVG diagrams can have separate spoken and visible versions.
* Lecture Video responses can now include display-only content without requiring silent speech text.
* Lecture Video text-to-speech now flushes spoken audio before long visual-only diagram content and follow-up suggestions.

### Resolved Issues
* Fixed: Some Lecture Video responses with malformed, incomplete, or split speech/display formatting may leak internal formatting markers or drop later follow-up suggestions.
* Fixed: Spoken narration before Mermaid or SVG diagrams may be delayed while the system waits for the full diagram content.
* Fixed: Lecture Video text-to-speech state may carry over incorrectly after a mid-response flush.
* Fixed: Lecture Video responses with missing speech text in display-only blocks may be treated as malformed.
* Fixed: Emoji and other characters represented by Unicode surrogate pairs may not render correctly in Lecture Video speech/display formatting.