### PR TITLE
chore(dev): silence watchfiles INFO logs

### DIFF
--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -726,6 +726,7 @@ config = _load_config()
 # Configure logging, shutting up some noisy libraries
 logging.basicConfig(level=config.log_level)
 # Shut up some noisy libraries
+logging.getLogger("watchfiles").setLevel(logging.WARNING)
 logging.getLogger("azure.monitor.opentelemetry").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(


### PR DESCRIPTION
## Internal
### Updates & Improvements
* Silence `INFO:watchfiles.main:X changes detected` logs for uninteresting files when running `uvicorn --reload`. We already display `WARNING:  WatchFiles detected changes in 'X'. Reloading…` messages. Introduced after upgrading `uvicorn~=0.47.0` in #1724.