### PR TITLE
feat(connect): admin panel

### DIFF
--- a/pingpong/connectors/__init__.py
+++ b/pingpong/connectors/__init__.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 from .core.flow import begin_connect, complete_callback
+from .core.exceptions import ConnectorValidationError
 from .core.types import CallbackResult, ConnectIntent
-from .core.registry import register
+from .core.registry import register, all_connectors, get as get_connector
 from .panopto import PanoptoConnector as _PanoptoConnector
 
 register(_PanoptoConnector())
 
 __all__ = [
+    "all_connectors",
     "begin_connect",
     "CallbackResult",
     "complete_callback",
     "ConnectIntent",
+    "ConnectorValidationError",
+    "get_connector",
 ]

--- a/pingpong/connectors/__init__.py
+++ b/pingpong/connectors/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from .core.exceptions import ConnectorNotRegistered, ConnectorValidationError
 from .core.flow import begin_connect, complete_callback
-from .core.exceptions import ConnectorValidationError
 from .core.types import CallbackResult, ConnectIntent
 from .core.registry import register, all_connectors, get as get_connector
 from .panopto import PanoptoConnector as _PanoptoConnector
@@ -16,6 +16,7 @@ __all__ = [
     "CallbackResult",
     "complete_callback",
     "ConnectIntent",
+    "ConnectorNotRegistered",
     "ConnectorValidationError",
     "get_connector",
 ]

--- a/pingpong/connectors/core/base.py
+++ b/pingpong/connectors/core/base.py
@@ -77,8 +77,8 @@ async def validate_public_host(host: str) -> None:
 
     try:
         infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
-    except socket.gaierror:
-        return
+    except socket.gaierror as e:
+        raise ConnectorValidationError("host", "Could not resolve this host.") from e
     for info in infos:
         address = info[4][0]
         if isinstance(address, str) and _host_address_is_private(address):

--- a/pingpong/connectors/core/base.py
+++ b/pingpong/connectors/core/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import secrets
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -10,7 +11,7 @@ import httpx
 
 from pingpong.now import NowFn, utcnow
 
-from .exceptions import ConnectorError, TokenRefreshError
+from .exceptions import ConnectorError, ConnectorValidationError, TokenRefreshError
 from .identity import ConnectorIdentityResolver
 from .types import ConnectorTokens, PKCEPair, ProviderIdentity, expires_at_timestamp
 
@@ -20,6 +21,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 HTTP_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass
+class _TokenProbeResult:
+    ok: bool = False
+    credentials_accepted: bool = False
+    invalid_client: bool = False
+    message: str | None = None
+
+
+def friendly_network_error(exc: BaseException) -> str:
+    """Translate an httpx exception into a short, user-facing message.
+
+    The full exception is meant to be logged separately by the caller.
+    """
+    if isinstance(exc, httpx.TimeoutException):
+        return "Connection to this host timed out."
+    if isinstance(exc, httpx.ConnectError):
+        text = str(exc).lower()
+        dns_markers = (
+            "errno 8",
+            "nodename",
+            "servname",
+            "name or service",
+            "name resolution",
+        )
+        if any(m in text for m in dns_markers):
+            return "Could not resolve this host."
+        return "Could not connect to this host."
+    if isinstance(exc, httpx.HTTPError):
+        return "Could not reach this host."
+    return "Could not reach this host."
 
 
 def generate_pkce_pair() -> PKCEPair:
@@ -216,6 +249,144 @@ class OAuth2Connector:
 
     def token_dict(self, tokens: ConnectorTokens) -> dict[str, Any]:
         return self._token_dict(tokens)
+
+    async def validate_config(self, connector_config: "ConnectorConfig") -> None:
+        """Probe the upstream provider to confirm the config is usable.
+
+        Raises ConnectorValidationError(field=...) on the first failure.
+        Subclasses normally override validate_host(); the base
+        validate_credentials() works for any OIDC-style token endpoint.
+        """
+        await self.validate_host(connector_config)
+        await self.validate_credentials(connector_config)
+
+    async def validate_host(self, connector_config: "ConnectorConfig") -> None:
+        """Confirm the upstream host is reachable.
+
+        Default: resolve the token endpoint via the connector's discovery hook.
+        If a subclass uses an OIDC discovery document it should override this
+        to fetch and validate that document directly.
+        """
+        try:
+            url = await self.token_endpoint(connector_config)
+        except ConnectorError as e:
+            raise ConnectorValidationError("host", str(e)) from e
+        if not url:
+            raise ConnectorValidationError(
+                "host", "Could not resolve a token endpoint for this host."
+            )
+
+    async def validate_credentials(self, connector_config: "ConnectorConfig") -> None:
+        """Probe the token endpoint to confirm client_id/client_secret are valid.
+
+        Strategy:
+          1. Try ``grant_type=client_credentials``. Success → credentials work.
+             ``invalid_client`` → credentials are wrong; bail out.
+             Any other OAuth error (``unsupported_grant_type`` etc.) → fall
+             through to the auth_code probe.
+          2. Try ``grant_type=authorization_code`` with a dummy code:
+             - ``invalid_grant`` means the credentials authenticated and only
+               the (intentionally bad) code was rejected → credentials OK.
+             - ``invalid_client`` → credentials are wrong.
+        """
+        try:
+            token_url = await self.token_endpoint(connector_config)
+        except ConnectorError as e:
+            raise ConnectorValidationError("host", str(e)) from e
+
+        cc_result = await self._probe_token_endpoint(
+            connector_config,
+            token_url,
+            data={"grant_type": "client_credentials"},
+        )
+        if cc_result.ok:
+            return
+        if cc_result.invalid_client:
+            raise ConnectorValidationError(
+                "credentials", cc_result.message or "Invalid client credentials."
+            )
+
+        ac_result = await self._probe_token_endpoint(
+            connector_config,
+            token_url,
+            data={
+                "grant_type": "authorization_code",
+                "code": "pingpong-validation-probe",
+                "redirect_uri": "https://invalid.local/validation-probe",
+            },
+        )
+        if ac_result.invalid_client:
+            raise ConnectorValidationError(
+                "credentials", ac_result.message or "Invalid client credentials."
+            )
+        if ac_result.credentials_accepted:
+            return
+
+        raise ConnectorValidationError(
+            "credentials",
+            ac_result.message
+            or cc_result.message
+            or "Could not verify the client credentials with the provider.",
+        )
+
+    async def _probe_token_endpoint(
+        self,
+        connector_config: "ConnectorConfig",
+        token_url: str,
+        *,
+        data: dict[str, str],
+    ) -> "_TokenProbeResult":
+        auth_method = self.token_endpoint_auth_method
+        if auth_method == "client_secret_basic":
+            auth: tuple[str, str] | None = (
+                connector_config.client_id,
+                connector_config.client_secret,
+            )
+            body = dict(data)
+        else:
+            auth = None
+            body = {
+                **data,
+                "client_id": connector_config.client_id,
+                "client_secret": connector_config.client_secret,
+            }
+        try:
+            async with httpx.AsyncClient(timeout=self.http_timeout_seconds) as client:
+                response = await client.post(token_url, data=body, auth=auth)
+        except httpx.HTTPError as e:
+            logger.info("Token endpoint probe failed for %s: %s", token_url, e)
+            raise ConnectorValidationError("host", friendly_network_error(e)) from e
+
+        try:
+            payload = response.json() if response.content else {}
+        except ValueError:
+            payload = {}
+        error_code = payload.get("error") if isinstance(payload, dict) else None
+        description = (
+            payload.get("error_description") if isinstance(payload, dict) else None
+        )
+
+        if (
+            response.is_success
+            and isinstance(payload, dict)
+            and payload.get("access_token")
+        ):
+            return _TokenProbeResult(ok=True, credentials_accepted=True)
+
+        if error_code == "invalid_client" or response.status_code == 401:
+            return _TokenProbeResult(invalid_client=True, message=description)
+
+        # Any OAuth error other than invalid_client means the server authenticated
+        # the client and then rejected the request for an unrelated reason.
+        credentials_accepted = (
+            isinstance(error_code, str) and error_code != "invalid_client"
+        )
+        return _TokenProbeResult(
+            credentials_accepted=credentials_accepted,
+            message=description
+            or (error_code if isinstance(error_code, str) else None)
+            or f"Token endpoint returned HTTP {response.status_code}.",
+        )
 
     def _oauth_client(
         self,

--- a/pingpong/connectors/core/base.py
+++ b/pingpong/connectors/core/base.py
@@ -301,6 +301,8 @@ class OAuth2Connector:
         """
         try:
             url = await self.token_endpoint(connector_config)
+        except ConnectorValidationError:
+            raise
         except ConnectorError as e:
             raise ConnectorValidationError("host", str(e)) from e
         if not url:
@@ -323,6 +325,8 @@ class OAuth2Connector:
         """
         try:
             token_url = await self.token_endpoint(connector_config)
+        except ConnectorValidationError:
+            raise
         except ConnectorError as e:
             raise ConnectorValidationError("host", str(e)) from e
 
@@ -414,8 +418,15 @@ class OAuth2Connector:
         ):
             return _TokenProbeResult(ok=True, credentials_accepted=True)
 
-        if error_code == "invalid_client" or response.status_code == 401:
+        if error_code == "invalid_client":
             return _TokenProbeResult(invalid_client=True, message=description)
+        if response.status_code == 401:
+            logger.warning(
+                "Unexpected token endpoint 401 for service=%s url=%s error=%s",
+                self.slug,
+                token_url,
+                error_code,
+            )
 
         # Any OAuth error other than invalid_client means the server authenticated
         # the client and then rejected the request for an unrelated reason.

--- a/pingpong/connectors/core/base.py
+++ b/pingpong/connectors/core/base.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-import logging
-import secrets
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+import ipaddress
+import logging
+import secrets
+import socket
 from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urlparse
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 import httpx
@@ -28,6 +32,7 @@ class _TokenProbeResult:
     ok: bool = False
     credentials_accepted: bool = False
     invalid_client: bool = False
+    provider_error: bool = False
     message: str | None = None
 
 
@@ -50,9 +55,36 @@ def friendly_network_error(exc: BaseException) -> str:
         if any(m in text for m in dns_markers):
             return "Could not resolve this host."
         return "Could not connect to this host."
-    if isinstance(exc, httpx.HTTPError):
-        return "Could not reach this host."
     return "Could not reach this host."
+
+
+def _host_address_is_private(host: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return not ip.is_global
+
+
+async def validate_public_host(host: str) -> None:
+    hostname = (urlparse(f"//{host}").hostname or "").lower()
+    if not hostname:
+        raise ConnectorValidationError("host", "Host is required.")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ConnectorValidationError("host", "Host must be a public HTTPS hostname.")
+    if _host_address_is_private(hostname):
+        raise ConnectorValidationError("host", "Host must resolve to a public address.")
+
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+    except socket.gaierror:
+        return
+    for info in infos:
+        address = info[4][0]
+        if isinstance(address, str) and _host_address_is_private(address):
+            raise ConnectorValidationError(
+                "host", "Host must resolve to a public address."
+            )
 
 
 def generate_pkce_pair() -> PKCEPair:
@@ -305,6 +337,8 @@ class OAuth2Connector:
             raise ConnectorValidationError(
                 "credentials", cc_result.message or "Invalid client credentials."
             )
+        if cc_result.credentials_accepted:
+            return
 
         ac_result = await self._probe_token_endpoint(
             connector_config,
@@ -323,7 +357,9 @@ class OAuth2Connector:
             return
 
         raise ConnectorValidationError(
-            "credentials",
+            "host"
+            if cc_result.provider_error or ac_result.provider_error
+            else "credentials",
             ac_result.message
             or cc_result.message
             or "Could not verify the client credentials with the provider.",
@@ -354,7 +390,12 @@ class OAuth2Connector:
             async with httpx.AsyncClient(timeout=self.http_timeout_seconds) as client:
                 response = await client.post(token_url, data=body, auth=auth)
         except httpx.HTTPError as e:
-            logger.info("Token endpoint probe failed for %s: %s", token_url, e)
+            logger.info(
+                "Token endpoint probe failed for service=%s url=%s: %s",
+                self.slug,
+                token_url,
+                e,
+            )
             raise ConnectorValidationError("host", friendly_network_error(e)) from e
 
         try:
@@ -383,6 +424,7 @@ class OAuth2Connector:
         )
         return _TokenProbeResult(
             credentials_accepted=credentials_accepted,
+            provider_error=not credentials_accepted,
             message=description
             or (error_code if isinstance(error_code, str) else None)
             or f"Token endpoint returned HTTP {response.status_code}.",

--- a/pingpong/connectors/core/exceptions.py
+++ b/pingpong/connectors/core/exceptions.py
@@ -24,3 +24,16 @@ class TokenRefreshError(ConnectorError):
 
 class OAuthStateError(ConnectorError):
     """Raised when the OAuth2 state JWT fails to validate."""
+
+
+class ConnectorValidationError(ConnectorError):
+    """Raised when an admin-submitted connector configuration fails validation.
+
+    ``field`` names the part of the config that failed ("host" or "credentials")
+    so the API layer can surface a structured error to the UI.
+    """
+
+    def __init__(self, field: str, message: str) -> None:
+        self.field = field
+        self.message = message
+        super().__init__(f"{field}: {message}")

--- a/pingpong/connectors/panopto/connector.py
+++ b/pingpong/connectors/panopto/connector.py
@@ -38,6 +38,8 @@ class PanoptoConnector(OAuth2Connector):
     async def validate_host(self, connector_config: ConnectorConfig) -> None:
         try:
             doc = await self._discovery.document(connector_config)
+        except ConnectorValidationError:
+            raise
         except ConnectorError as e:
             logger.info(
                 "Panopto host validation failed for service=%s host=%s: %s",

--- a/pingpong/connectors/panopto/connector.py
+++ b/pingpong/connectors/panopto/connector.py
@@ -40,7 +40,8 @@ class PanoptoConnector(OAuth2Connector):
             doc = await self._discovery.document(connector_config)
         except ConnectorError as e:
             logger.info(
-                "Panopto host validation failed for %s: %s",
+                "Panopto host validation failed for service=%s host=%s: %s",
+                self.slug,
                 connector_config.host,
                 e,
             )
@@ -56,14 +57,18 @@ class PanoptoConnector(OAuth2Connector):
 
     @staticmethod
     def _friendly_discovery_error(err: ConnectorError) -> str:
-        cause = err.__cause__
-        if cause is not None:
-            return friendly_network_error(cause)
         text = str(err)
+        if "must use HTTPS" in text:
+            return "Host must use HTTPS."
+        if "must be a public" in text or "must resolve to a public" in text:
+            return text
         if "returned " in text:
             return "Host is reachable but is not a Panopto OIDC endpoint."
         if "non-JSON" in text or "non-object" in text:
             return "Host responded but did not return a valid OIDC document."
+        cause = err.__cause__
+        if cause is not None:
+            return friendly_network_error(cause)
         return "Could not reach this host."
 
     async def userinfo_endpoint(self, connector_config: ConnectorConfig) -> str | None:

--- a/pingpong/connectors/panopto/connector.py
+++ b/pingpong/connectors/panopto/connector.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import logging
+
 from pingpong.models import ConnectorConfig
 
-from pingpong.connectors.core.base import OAuth2Connector
+from pingpong.connectors.core.base import OAuth2Connector, friendly_network_error
+from pingpong.connectors.core.exceptions import (
+    ConnectorError,
+    ConnectorValidationError,
+)
 from .discovery import PanoptoDiscovery
+
+logger = logging.getLogger(__name__)
 
 
 class PanoptoConnector(OAuth2Connector):
@@ -26,6 +34,37 @@ class PanoptoConnector(OAuth2Connector):
         return await self._discovery.required_endpoint(
             connector_config, "token_endpoint"
         )
+
+    async def validate_host(self, connector_config: ConnectorConfig) -> None:
+        try:
+            doc = await self._discovery.document(connector_config)
+        except ConnectorError as e:
+            logger.info(
+                "Panopto host validation failed for %s: %s",
+                connector_config.host,
+                e,
+            )
+            raise ConnectorValidationError(
+                "host", self._friendly_discovery_error(e)
+            ) from e
+        for key in ("authorization_endpoint", "token_endpoint"):
+            if not isinstance(doc.get(key), str) or not doc[key]:
+                raise ConnectorValidationError(
+                    "host",
+                    "This host does not look like a Panopto OIDC endpoint.",
+                )
+
+    @staticmethod
+    def _friendly_discovery_error(err: ConnectorError) -> str:
+        cause = err.__cause__
+        if cause is not None:
+            return friendly_network_error(cause)
+        text = str(err)
+        if "returned " in text:
+            return "Host is reachable but is not a Panopto OIDC endpoint."
+        if "non-JSON" in text or "non-object" in text:
+            return "Host responded but did not return a valid OIDC document."
+        return "Could not reach this host."
 
     async def userinfo_endpoint(self, connector_config: ConnectorConfig) -> str | None:
         return await self._discovery.optional_endpoint(

--- a/pingpong/connectors/panopto/discovery.py
+++ b/pingpong/connectors/panopto/discovery.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from pingpong.models import ConnectorConfig
 
-from pingpong.connectors.core.base import HTTP_TIMEOUT_SECONDS
+from pingpong.connectors.core.base import HTTP_TIMEOUT_SECONDS, validate_public_host
 from pingpong.connectors.core.discovery import (
     DiscoveryDocumentCache,
     optional_string_field,
@@ -23,6 +23,7 @@ class PanoptoDiscovery:
 
     async def document(self, connector_config: ConnectorConfig) -> dict[str, Any]:
         host = self.normalize_host(connector_config.host)
+        await validate_public_host(host)
         url = f"https://{host}{DISCOVERY_PATH}"
         return await self._documents.get(url, label=DISCOVERY_LABEL)
 
@@ -43,6 +44,8 @@ class PanoptoDiscovery:
         value = host.strip()
         parsed = urlparse(value)
         if parsed.scheme and parsed.netloc:
+            if parsed.scheme != "https":
+                raise ConnectorError("Panopto host must use HTTPS")
             if (
                 parsed.path not in ("", "/")
                 or parsed.params

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1313,6 +1313,31 @@ class ConnectorConfig(Base):
 
     user_connectors = relationship("UserConnector", back_populates="connector_config")
 
+    @classmethod
+    async def list_all(cls, session: AsyncSession) -> list["ConnectorConfig"]:
+        stmt = select(ConnectorConfig)
+        result = await session.execute(stmt)
+        return [row.ConnectorConfig for row in result]
+
+    @classmethod
+    async def get_by_id(
+        cls, session: AsyncSession, id: int
+    ) -> "ConnectorConfig | None":
+        stmt = select(ConnectorConfig).where(ConnectorConfig.id == id)
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @classmethod
+    async def get_by_service_and_account_scope(
+        cls, session: AsyncSession, service: str, account_scope: str
+    ) -> "ConnectorConfig | None":
+        stmt = select(ConnectorConfig).where(
+            ConnectorConfig.service == service,
+            ConnectorConfig.account_scope == account_scope,
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
 
 class UserConnector(Base):
     __tablename__ = "user_connectors"

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -1317,13 +1317,13 @@ class ConnectorConfig(Base):
     async def list_all(cls, session: AsyncSession) -> list["ConnectorConfig"]:
         stmt = select(ConnectorConfig)
         result = await session.execute(stmt)
-        return [row.ConnectorConfig for row in result]
+        return list(result.scalars().all())
 
     @classmethod
     async def get_by_id(
-        cls, session: AsyncSession, id: int
+        cls, session: AsyncSession, id_: int
     ) -> "ConnectorConfig | None":
-        stmt = select(ConnectorConfig).where(ConnectorConfig.id == id)
+        stmt = select(ConnectorConfig).where(ConnectorConfig.id == id_)
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -3069,8 +3069,8 @@ class SessionState(BaseModel):
 
 
 class ConnectorService(BaseModel):
-    slug: str
-    display_name: str
+    slug: str = Field(..., min_length=1, pattern=r"^[a-z0-9_-]+$")
+    display_name: str = Field(..., min_length=1)
 
 
 class ConnectorServices(BaseModel):
@@ -3104,13 +3104,52 @@ class CreateConnectorConfig(BaseModel):
     client_secret: str = Field(..., min_length=1)
     enabled: bool = True
 
+    @field_validator(
+        "service",
+        "account_scope",
+        "display_name",
+        "host",
+        "client_id",
+        "client_secret",
+    )
+    @classmethod
+    def strip_required_strings(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("field must not be empty after stripping whitespace")
+        return value
+
 
 class UpdateConnectorConfig(BaseModel):
+    account_scope: str = Field(..., min_length=1)
     display_name: str = Field(..., min_length=1)
     host: str = Field(..., min_length=1)
     client_id: str = Field(..., min_length=1)
-    client_secret: str | None = None
+    client_secret: str | None = Field(
+        default=None,
+        description="Set to null to keep the existing connector secret.",
+    )
     enabled: bool
+
+    @field_validator("account_scope", "display_name", "host", "client_id")
+    @classmethod
+    def strip_required_strings(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("field must not be empty after stripping whitespace")
+        return value
+
+    @field_validator("client_secret")
+    @classmethod
+    def strip_optional_secret(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        value = v.strip()
+        if not value:
+            raise ValueError(
+                "client_secret must not be empty after stripping whitespace"
+            )
+        return value
 
 
 class Support(BaseModel):

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -3068,6 +3068,51 @@ class SessionState(BaseModel):
     agreement_id: int | None = None
 
 
+class ConnectorService(BaseModel):
+    slug: str
+    display_name: str
+
+
+class ConnectorServices(BaseModel):
+    services: list[ConnectorService]
+
+
+class ConnectorConfigSchema(BaseModel):
+    id: int
+    service: str
+    account_scope: str
+    display_name: str
+    host: str
+    client_id: str
+    enabled: bool
+    created: datetime
+    updated: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ConnectorConfigs(BaseModel):
+    configs: list[ConnectorConfigSchema]
+
+
+class CreateConnectorConfig(BaseModel):
+    service: str = Field(..., min_length=1)
+    account_scope: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    host: str = Field(..., min_length=1)
+    client_id: str = Field(..., min_length=1)
+    client_secret: str = Field(..., min_length=1)
+    enabled: bool = True
+
+
+class UpdateConnectorConfig(BaseModel):
+    display_name: str = Field(..., min_length=1)
+    host: str = Field(..., min_length=1)
+    client_id: str = Field(..., min_length=1)
+    client_secret: str | None = None
+    enabled: bool
+
+
 class Support(BaseModel):
     blurb: str
     can_post: bool

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -13251,7 +13251,7 @@ def _connector_validation_error_detail(
 ) -> dict[str, str]:
     return {
         "field": err.field,
-        "message": f"{err.field.title()}: {err.message}",
+        "message": err.message,
         "error_code": f"connector_validation_{err.field}",
     }
 
@@ -13269,7 +13269,7 @@ async def list_connector_services(request: StateRequest):
         )
         for c in all_connectors()
     ]
-    return {"services": services}
+    return schemas.ConnectorServices(services=services)
 
 
 @v1.get(
@@ -13279,7 +13279,7 @@ async def list_connector_services(request: StateRequest):
 )
 async def list_connector_configs(request: StateRequest):
     configs = await models.ConnectorConfig.list_all(request.state["db"])
-    return {"configs": configs}
+    return schemas.ConnectorConfigs(configs=configs)
 
 
 @v1.post(
@@ -13293,20 +13293,11 @@ async def create_connector_config(
 ):
     try:
         connector = get_connector(req.service)
-    except ConnectorNotRegistered:
+    except ConnectorNotRegistered as e:
         raise HTTPException(
             status_code=400,
             detail=f"Unknown connector service '{req.service}'.",
-        )
-
-    existing_config = await models.ConnectorConfig.get_by_service_and_account_scope(
-        request.state["db"], req.service, req.account_scope
-    )
-    if existing_config:
-        raise HTTPException(
-            status_code=409,
-            detail="A connector configuration already exists for this service and account scope.",
-        )
+        ) from e
 
     config_obj = models.ConnectorConfig(
         service=req.service,
@@ -13324,19 +13315,28 @@ async def create_connector_config(
         raise HTTPException(
             status_code=400,
             detail=_connector_validation_error_detail(e),
+        ) from e
+
+    existing_config = await models.ConnectorConfig.get_by_service_and_account_scope(
+        request.state["db"], req.service, req.account_scope
+    )
+    if existing_config:
+        raise HTTPException(
+            status_code=409,
+            detail="A connector configuration already exists for this service and account scope.",
         )
 
     request.state["db"].add(config_obj)
     try:
         await request.state["db"].flush()
-    except IntegrityError:
+    except IntegrityError as e:
         raise HTTPException(
             status_code=409,
             detail=(
                 "A connector configuration already exists for this service and "
                 "account scope."
             ),
-        )
+        ) from e
     return config_obj
 
 
@@ -13357,22 +13357,29 @@ async def update_connector_config(
         raise HTTPException(404, "Connector configuration not found.")
 
     host_changed = config_obj.host != req.host
+    scope_changed = config_obj.account_scope != req.account_scope
     client_id_changed = config_obj.client_id != req.client_id
     secret_provided = bool(req.client_secret)
     enabling_connector = not config_obj.enabled and req.enabled
     new_secret = req.client_secret if secret_provided else config_obj.client_secret
 
-    if host_changed or client_id_changed or secret_provided or enabling_connector:
+    if (
+        host_changed
+        or scope_changed
+        or client_id_changed
+        or secret_provided
+        or enabling_connector
+    ):
         try:
             connector = get_connector(config_obj.service)
-        except ConnectorNotRegistered:
+        except ConnectorNotRegistered as e:
             raise HTTPException(
                 status_code=400,
                 detail=f"Unknown connector service '{config_obj.service}'.",
-            )
+            ) from e
         probe = models.ConnectorConfig(
             service=config_obj.service,
-            account_scope=config_obj.account_scope,
+            account_scope=req.account_scope,
             display_name=req.display_name,
             host=req.host,
             client_id=req.client_id,
@@ -13385,8 +13392,9 @@ async def update_connector_config(
             raise HTTPException(
                 status_code=400,
                 detail=_connector_validation_error_detail(e),
-            )
+            ) from e
 
+    config_obj.account_scope = req.account_scope
     config_obj.display_name = req.display_name
     config_obj.host = req.host
     config_obj.client_id = req.client_id
@@ -13395,7 +13403,16 @@ async def update_connector_config(
     config_obj.enabled = req.enabled
 
     request.state["db"].add(config_obj)
-    await request.state["db"].flush()
+    try:
+        await request.state["db"].flush()
+    except IntegrityError as e:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A connector configuration already exists for this service and "
+                "account scope."
+            ),
+        ) from e
     return config_obj
 
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -48,6 +48,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import delete, func, select, update
 
+from pingpong.connectors import ConnectorValidationError, all_connectors, get_connector
 import pingpong.metrics as metrics
 import pingpong.models as models
 import pingpong.schemas as schemas
@@ -13238,6 +13239,151 @@ async def update_external_login_provider(
     request.state["db"].add(provider)
     await request.state["db"].flush()
     return {"status": "ok"}
+
+
+@v1.get(
+    "/admin/connectors/services",
+    dependencies=[Depends(Authz("admin"))],
+    response_model=schemas.ConnectorServices,
+)
+async def list_connector_services(request: StateRequest):
+    services = [
+        schemas.ConnectorService(
+            slug=c.slug,
+            display_name=c.display_name or c.slug.replace("_", " ").title(),
+        )
+        for c in all_connectors()
+    ]
+    return {"services": services}
+
+
+@v1.get(
+    "/admin/connectors",
+    dependencies=[Depends(Authz("admin"))],
+    response_model=schemas.ConnectorConfigs,
+)
+async def list_connector_configs(request: StateRequest):
+    configs = await models.ConnectorConfig.list_all(request.state["db"])
+    return {"configs": configs}
+
+
+@v1.post(
+    "/admin/connectors",
+    dependencies=[Depends(Authz("admin"))],
+    response_model=schemas.ConnectorConfigSchema,
+)
+async def create_connector_config(
+    req: schemas.CreateConnectorConfig,
+    request: StateRequest,
+):
+    try:
+        connector = get_connector(req.service)
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown connector service '{req.service}'.",
+        )
+
+    existing_config = await models.ConnectorConfig.get_by_service_and_account_scope(
+        request.state["db"], req.service, req.account_scope
+    )
+    if existing_config:
+        raise HTTPException(
+            status_code=409,
+            detail="A connector configuration already exists for this service and account scope.",
+        )
+
+    config_obj = models.ConnectorConfig(
+        service=req.service,
+        account_scope=req.account_scope,
+        display_name=req.display_name,
+        host=req.host,
+        client_id=req.client_id,
+        client_secret=req.client_secret,
+        enabled=req.enabled,
+    )
+
+    try:
+        await connector.validate_config(config_obj)
+    except ConnectorValidationError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"{e.field.title()}: {e.message}",
+                "error_code": f"connector_validation_{e.field}",
+            },
+        )
+
+    request.state["db"].add(config_obj)
+    try:
+        await request.state["db"].flush()
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "A connector configuration already exists for this service and "
+                "account scope."
+            ),
+        )
+    return config_obj
+
+
+@v1.put(
+    "/admin/connectors/{connector_config_id}",
+    dependencies=[Depends(Authz("admin"))],
+    response_model=schemas.ConnectorConfigSchema,
+)
+async def update_connector_config(
+    connector_config_id: str,
+    req: schemas.UpdateConnectorConfig,
+    request: StateRequest,
+):
+    config_obj = await models.ConnectorConfig.get_by_id(
+        request.state["db"], int(connector_config_id)
+    )
+    if not config_obj:
+        raise HTTPException(404, "Connector configuration not found.")
+
+    host_changed = config_obj.host != req.host
+    client_id_changed = config_obj.client_id != req.client_id
+    secret_provided = bool(req.client_secret)
+    new_secret = req.client_secret if secret_provided else config_obj.client_secret
+
+    if host_changed or client_id_changed or secret_provided:
+        try:
+            connector = get_connector(config_obj.service)
+        except Exception:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown connector service '{config_obj.service}'.",
+            )
+        probe = models.ConnectorConfig(
+            service=config_obj.service,
+            account_scope=config_obj.account_scope,
+            display_name=req.display_name,
+            host=req.host,
+            client_id=req.client_id,
+            client_secret=new_secret,
+            enabled=req.enabled,
+        )
+        try:
+            await connector.validate_config(probe)
+        except ConnectorValidationError as e:
+            raise HTTPException(
+                status_code=400,
+                detail={"field": e.field, "message": e.message},
+            )
+
+    config_obj.display_name = req.display_name
+    config_obj.host = req.host
+    config_obj.client_id = req.client_id
+    if secret_provided:
+        config_obj.client_secret = new_secret
+    config_obj.enabled = req.enabled
+
+    request.state["db"].add(config_obj)
+    await request.state["db"].flush()
+    return config_obj
 
 
 @v1.get(

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -48,7 +48,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import delete, func, select, update
 
-from pingpong.connectors import ConnectorValidationError, all_connectors, get_connector
 import pingpong.metrics as metrics
 import pingpong.models as models
 import pingpong.schemas as schemas
@@ -60,6 +59,12 @@ from pingpong.ai_models import (
     KNOWN_MODELS,
     get_reasoning_effort_map,
     supports_temperature_for_reasoning,
+)
+from pingpong.connectors import (
+    ConnectorNotRegistered,
+    ConnectorValidationError,
+    all_connectors,
+    get_connector,
 )
 from pingpong.artifacts import ArtifactStoreError
 from pingpong.audio_store import AudioStoreError
@@ -13241,6 +13246,16 @@ async def update_external_login_provider(
     return {"status": "ok"}
 
 
+def _connector_validation_error_detail(
+    err: ConnectorValidationError,
+) -> dict[str, str]:
+    return {
+        "field": err.field,
+        "message": f"{err.field.title()}: {err.message}",
+        "error_code": f"connector_validation_{err.field}",
+    }
+
+
 @v1.get(
     "/admin/connectors/services",
     dependencies=[Depends(Authz("admin"))],
@@ -13250,7 +13265,7 @@ async def list_connector_services(request: StateRequest):
     services = [
         schemas.ConnectorService(
             slug=c.slug,
-            display_name=c.display_name or c.slug.replace("_", " ").title(),
+            display_name=c.display_name,
         )
         for c in all_connectors()
     ]
@@ -13278,7 +13293,7 @@ async def create_connector_config(
 ):
     try:
         connector = get_connector(req.service)
-    except Exception:
+    except ConnectorNotRegistered:
         raise HTTPException(
             status_code=400,
             detail=f"Unknown connector service '{req.service}'.",
@@ -13308,10 +13323,7 @@ async def create_connector_config(
     except ConnectorValidationError as e:
         raise HTTPException(
             status_code=400,
-            detail={
-                "message": f"{e.field.title()}: {e.message}",
-                "error_code": f"connector_validation_{e.field}",
-            },
+            detail=_connector_validation_error_detail(e),
         )
 
     request.state["db"].add(config_obj)
@@ -13334,12 +13346,12 @@ async def create_connector_config(
     response_model=schemas.ConnectorConfigSchema,
 )
 async def update_connector_config(
-    connector_config_id: str,
+    connector_config_id: int,
     req: schemas.UpdateConnectorConfig,
     request: StateRequest,
 ):
     config_obj = await models.ConnectorConfig.get_by_id(
-        request.state["db"], int(connector_config_id)
+        request.state["db"], connector_config_id
     )
     if not config_obj:
         raise HTTPException(404, "Connector configuration not found.")
@@ -13347,12 +13359,13 @@ async def update_connector_config(
     host_changed = config_obj.host != req.host
     client_id_changed = config_obj.client_id != req.client_id
     secret_provided = bool(req.client_secret)
+    enabling_connector = not config_obj.enabled and req.enabled
     new_secret = req.client_secret if secret_provided else config_obj.client_secret
 
-    if host_changed or client_id_changed or secret_provided:
+    if host_changed or client_id_changed or secret_provided or enabling_connector:
         try:
             connector = get_connector(config_obj.service)
-        except Exception:
+        except ConnectorNotRegistered:
             raise HTTPException(
                 status_code=400,
                 detail=f"Unknown connector service '{config_obj.service}'.",
@@ -13371,7 +13384,7 @@ async def update_connector_config(
         except ConnectorValidationError as e:
             raise HTTPException(
                 status_code=400,
-                detail={"field": e.field, "message": e.message},
+                detail=_connector_validation_error_detail(e),
             )
 
     config_obj.display_name = req.display_name

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -13337,6 +13337,7 @@ async def create_connector_config(
                 "account scope."
             ),
         ) from e
+    await request.state["db"].refresh(config_obj)
     return config_obj
 
 
@@ -13413,6 +13414,7 @@ async def update_connector_config(
                 "account scope."
             ),
         ) from e
+    await request.state["db"].refresh(config_obj)
     return config_obj
 
 

--- a/pingpong/test_connectors_core.py
+++ b/pingpong/test_connectors_core.py
@@ -148,13 +148,6 @@ async def test_validate_credentials_accepts_client_credentials_oauth_error(
                 400,
                 json={"error": "unsupported_grant_type"},
             ),
-            httpx.Response(
-                400,
-                json={
-                    "error": "invalid_grant",
-                    "error_description": "Authorization code is invalid",
-                },
-            ),
         ],
     )
 

--- a/pingpong/test_connectors_core.py
+++ b/pingpong/test_connectors_core.py
@@ -11,7 +11,6 @@ from pingpong.connectors.core.base import OAuth2Connector, validate_public_host
 from pingpong.connectors.core.exceptions import ConnectorValidationError
 from pingpong.connectors.core.models import upsert_user_connector
 from pingpong.connectors.core.types import ConnectorTokens, ProviderIdentity
-from pingpong.connectors.panopto.connector import PanoptoConnector
 from pingpong.models import ConnectorConfig, User, UserConnector
 
 
@@ -221,18 +220,6 @@ async def test_validate_public_host_rejects_localhost() -> None:
 
     assert exc.value.field == "host"
     assert exc.value.message == "Host must be a public HTTPS hostname."
-
-
-@pytest.mark.asyncio
-async def test_panopto_validate_host_preserves_public_host_validation_error() -> None:
-    config = connector_config()
-    config.host = "127.0.0.1"
-
-    with pytest.raises(ConnectorValidationError) as exc:
-        await PanoptoConnector().validate_host(config)
-
-    assert exc.value.field == "host"
-    assert exc.value.message == "Host must resolve to a public address."
 
 
 @pytest.mark.asyncio

--- a/pingpong/test_connectors_core.py
+++ b/pingpong/test_connectors_core.py
@@ -11,6 +11,7 @@ from pingpong.connectors.core.base import OAuth2Connector, validate_public_host
 from pingpong.connectors.core.exceptions import ConnectorValidationError
 from pingpong.connectors.core.models import upsert_user_connector
 from pingpong.connectors.core.types import ConnectorTokens, ProviderIdentity
+from pingpong.connectors.panopto.connector import PanoptoConnector
 from pingpong.models import ConnectorConfig, User, UserConnector
 
 
@@ -220,6 +221,18 @@ async def test_validate_public_host_rejects_localhost() -> None:
 
     assert exc.value.field == "host"
     assert exc.value.message == "Host must be a public HTTPS hostname."
+
+
+@pytest.mark.asyncio
+async def test_panopto_validate_host_preserves_public_host_validation_error() -> None:
+    config = connector_config()
+    config.host = "127.0.0.1"
+
+    with pytest.raises(ConnectorValidationError) as exc:
+        await PanoptoConnector().validate_host(config)
+
+    assert exc.value.field == "host"
+    assert exc.value.message == "Host must resolve to a public address."
 
 
 @pytest.mark.asyncio

--- a/pingpong/test_connectors_core.py
+++ b/pingpong/test_connectors_core.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+import httpx
 import pytest
 from sqlalchemy import func, select
 
 from pingpong.connectors.core.base import OAuth2Connector
+from pingpong.connectors.core.exceptions import ConnectorValidationError
 from pingpong.connectors.core.models import upsert_user_connector
 from pingpong.connectors.core.types import ConnectorTokens, ProviderIdentity
 from pingpong.models import ConnectorConfig, User, UserConnector
@@ -42,6 +44,38 @@ def user_connector() -> UserConnector:
         access_token="old-access-token",
         refresh_token="stored-refresh-token",
     )
+
+
+def mock_token_probe_client(monkeypatch, responses: list[httpx.Response | Exception]):
+    posts: list[dict[str, Any]] = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout: float) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            data: dict[str, str],
+            auth: tuple[str, str] | None,
+        ) -> httpx.Response:
+            posts.append({"url": url, "data": data, "auth": auth})
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    monkeypatch.setattr(
+        "pingpong.connectors.core.base.httpx.AsyncClient", FakeAsyncClient
+    )
+    return posts
 
 
 @pytest.mark.asyncio
@@ -98,6 +132,73 @@ async def test_refresh_uses_scopeless_oauth_client() -> None:
     assert connector.include_scope is False
     assert tokens.access_token == "new-access-token"
     assert tokens.refresh_token == "stored-refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_validate_credentials_accepts_auth_code_invalid_grant(
+    monkeypatch,
+) -> None:
+    posts = mock_token_probe_client(
+        monkeypatch,
+        [
+            httpx.Response(
+                400,
+                json={"error": "unsupported_grant_type"},
+            ),
+            httpx.Response(
+                400,
+                json={
+                    "error": "invalid_grant",
+                    "error_description": "Authorization code is invalid",
+                },
+            ),
+        ],
+    )
+
+    await ScopedConnector().validate_credentials(connector_config())
+
+    assert [post["data"]["grant_type"] for post in posts] == [
+        "client_credentials",
+        "authorization_code",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_credentials_rejects_invalid_client(monkeypatch) -> None:
+    mock_token_probe_client(
+        monkeypatch,
+        [
+            httpx.Response(
+                401,
+                json={
+                    "error": "invalid_client",
+                    "error_description": "Invalid client credentials",
+                },
+            )
+        ],
+    )
+
+    with pytest.raises(ConnectorValidationError) as exc:
+        await ScopedConnector().validate_credentials(connector_config())
+
+    assert exc.value.field == "credentials"
+    assert exc.value.message == "Invalid client credentials"
+
+
+@pytest.mark.asyncio
+async def test_validate_credentials_reports_network_errors_as_host_errors(
+    monkeypatch,
+) -> None:
+    mock_token_probe_client(
+        monkeypatch,
+        [httpx.ConnectError("Connection refused")],
+    )
+
+    with pytest.raises(ConnectorValidationError) as exc:
+        await ScopedConnector().validate_credentials(connector_config())
+
+    assert exc.value.field == "host"
+    assert exc.value.message == "Could not connect to this host."
 
 
 @pytest.mark.asyncio

--- a/pingpong/test_connectors_core.py
+++ b/pingpong/test_connectors_core.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from sqlalchemy import func, select
 
-from pingpong.connectors.core.base import OAuth2Connector
+from pingpong.connectors.core.base import OAuth2Connector, validate_public_host
 from pingpong.connectors.core.exceptions import ConnectorValidationError
 from pingpong.connectors.core.models import upsert_user_connector
 from pingpong.connectors.core.types import ConnectorTokens, ProviderIdentity
@@ -46,7 +46,10 @@ def user_connector() -> UserConnector:
     )
 
 
-def mock_token_probe_client(monkeypatch, responses: list[httpx.Response | Exception]):
+def mock_token_probe_client(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[httpx.Response | Exception],
+) -> list[dict[str, Any]]:
     posts: list[dict[str, Any]] = []
 
     class FakeAsyncClient:
@@ -135,7 +138,7 @@ async def test_refresh_uses_scopeless_oauth_client() -> None:
 
 
 @pytest.mark.asyncio
-async def test_validate_credentials_accepts_auth_code_invalid_grant(
+async def test_validate_credentials_accepts_client_credentials_oauth_error(
     monkeypatch,
 ) -> None:
     posts = mock_token_probe_client(
@@ -157,10 +160,7 @@ async def test_validate_credentials_accepts_auth_code_invalid_grant(
 
     await ScopedConnector().validate_credentials(connector_config())
 
-    assert [post["data"]["grant_type"] for post in posts] == [
-        "client_credentials",
-        "authorization_code",
-    ]
+    assert [post["data"]["grant_type"] for post in posts] == ["client_credentials"]
 
 
 @pytest.mark.asyncio
@@ -199,6 +199,34 @@ async def test_validate_credentials_reports_network_errors_as_host_errors(
 
     assert exc.value.field == "host"
     assert exc.value.message == "Could not connect to this host."
+
+
+@pytest.mark.asyncio
+async def test_validate_credentials_reports_provider_errors_as_host_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_token_probe_client(
+        monkeypatch,
+        [
+            httpx.Response(500, content=b"server error"),
+            httpx.Response(500, content=b"server error"),
+        ],
+    )
+
+    with pytest.raises(ConnectorValidationError) as exc:
+        await ScopedConnector().validate_credentials(connector_config())
+
+    assert exc.value.field == "host"
+    assert exc.value.message == "Token endpoint returned HTTP 500."
+
+
+@pytest.mark.asyncio
+async def test_validate_public_host_rejects_localhost() -> None:
+    with pytest.raises(ConnectorValidationError) as exc:
+        await validate_public_host("localhost")
+
+    assert exc.value.field == "host"
+    assert exc.value.message == "Host must be a public HTTPS hostname."
 
 
 @pytest.mark.asyncio

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -31,9 +31,11 @@ export type BaseResponse = {
 export type Error = {
 	detail?: string;
 	error_code?: string;
+	field?: string;
 };
 
 type CodedErrorDetail = {
+	field?: string;
 	message?: string;
 	detail?: string;
 	error_code?: string;
@@ -117,7 +119,8 @@ export const expandResponse = <R extends BaseData>(
 				$status,
 				error: {
 					detail: detail.message ?? detail.detail,
-					error_code: detail.error_code ?? errorResponse.error_code
+					error_code: detail.error_code ?? errorResponse.error_code,
+					field: detail.field ?? errorResponse.field
 				} as Error,
 				data: null
 			};
@@ -1488,6 +1491,7 @@ export type CreateConnectorConfigRequest = {
 };
 
 export type UpdateConnectorConfigRequest = {
+	account_scope: string;
 	display_name: string;
 	host: string;
 	client_id: string;

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1452,6 +1452,82 @@ export const updateExternalLoginProvider = async (
 	return await PUT<ExternalLoginProviderUpdateRequest, GenericStatus>(f, url, data);
 };
 
+export type ConnectorService = {
+	slug: string;
+	display_name: string;
+};
+
+export type ConnectorServices = {
+	services: ConnectorService[];
+};
+
+export type ConnectorConfig = {
+	id: number;
+	service: string;
+	account_scope: string;
+	display_name: string;
+	host: string;
+	client_id: string;
+	enabled: boolean;
+	created: string;
+	updated: string;
+};
+
+export type ConnectorConfigs = {
+	configs: ConnectorConfig[];
+};
+
+export type CreateConnectorConfigRequest = {
+	service: string;
+	account_scope: string;
+	display_name: string;
+	host: string;
+	client_id: string;
+	client_secret: string;
+	enabled: boolean;
+};
+
+export type UpdateConnectorConfigRequest = {
+	display_name: string;
+	host: string;
+	client_id: string;
+	client_secret: string | null;
+	enabled: boolean;
+};
+
+/**
+ * List all registered connector services.
+ */
+export const getConnectorServices = async (f: Fetcher) => {
+	return await GET<never, ConnectorServices>(f, 'admin/connectors/services');
+};
+
+/**
+ * List all connector configurations.
+ */
+export const getConnectorConfigs = async (f: Fetcher) => {
+	return await GET<never, ConnectorConfigs>(f, 'admin/connectors');
+};
+
+/**
+ * Create a new connector configuration.
+ */
+export const createConnectorConfig = async (f: Fetcher, data: CreateConnectorConfigRequest) => {
+	return await POST<CreateConnectorConfigRequest, ConnectorConfig>(f, 'admin/connectors', data);
+};
+
+/**
+ * Update an existing connector configuration.
+ */
+export const updateConnectorConfig = async (
+	f: Fetcher,
+	connectorConfigId: number,
+	data: UpdateConnectorConfigRequest
+) => {
+	const url = `admin/connectors/${connectorConfigId}`;
+	return await PUT<UpdateConnectorConfigRequest, ConnectorConfig>(f, url, data);
+};
+
 /**
  * Api key from the server.
  */

--- a/web/pingpong/src/routes/admin/+page.svelte
+++ b/web/pingpong/src/routes/admin/+page.svelte
@@ -146,6 +146,10 @@
 					<Button class="rounded-full bg-orange text-white hover:bg-orange-dark" href="/admin/lti"
 						>Manage LTI Registrations</Button
 					>
+					<Button
+						class="rounded-full bg-orange text-white hover:bg-orange-dark"
+						href="/admin/connectors">Manage Connectors</Button
+					>
 				{/if}
 				<Button class="rounded-full bg-orange text-white hover:bg-orange-dark" href="/admin/terms"
 					>Manage User Agreements</Button

--- a/web/pingpong/src/routes/admin/connectors/+page.svelte
+++ b/web/pingpong/src/routes/admin/connectors/+page.svelte
@@ -14,6 +14,7 @@
 		Modal,
 		P,
 		Select,
+		Spinner,
 		Table,
 		TableBody,
 		TableBodyCell,
@@ -28,6 +29,7 @@
 	export let data;
 	$: connectorConfigs = data.connectorConfigs;
 	$: connectorServices = data.connectorServices;
+	$: loadError = data.loadError;
 
 	$: isNewHeaderLayout = data.forceCollapsedLayout && data.forceShowSidebarButton;
 
@@ -66,6 +68,33 @@
 		enabled: true
 	};
 	let creating = false;
+	let createHostError = '';
+	let createCredentialsError = '';
+
+	const clearCreateHostError = () => {
+		createHostError = '';
+	};
+
+	const clearCreateCredentialsError = () => {
+		createCredentialsError = '';
+	};
+
+	const errorMessage = (err: unknown, fallback: string) => {
+		return err instanceof Error && err.message ? err.message : fallback;
+	};
+
+	const applyConnectorError = (error: api.Error, target: 'create' | 'edit', fallback: string) => {
+		const message = error.detail || fallback;
+		const field = error.field || error.error_code?.replace('connector_validation_', '');
+		if (field === 'host') {
+			if (target === 'create') createHostError = message;
+			else editHostError = message;
+		} else if (field === 'credentials') {
+			if (target === 'create') createCredentialsError = message;
+			else editCredentialsError = message;
+		}
+		sadToast(message);
+	};
 
 	const openCreateModal = () => {
 		createForm = {
@@ -77,6 +106,8 @@
 			client_secret: '',
 			enabled: true
 		};
+		createHostError = '';
+		createCredentialsError = '';
 		createModalOpen = true;
 	};
 
@@ -87,22 +118,30 @@
 			sadToast('Please select a service.');
 			return;
 		}
+		createHostError = '';
+		createCredentialsError = '';
 		creating = true;
-		const result = await api.createConnectorConfig(fetch, { ...createForm });
-		const response = api.expandResponse(result);
-		creating = false;
-		if (response.error) {
-			sadToast(response.error.detail || 'Failed to create connector.');
-			return;
+		try {
+			const result = await api.createConnectorConfig(fetch, { ...createForm });
+			const response = api.expandResponse(result);
+			if (response.error) {
+				applyConnectorError(response.error, 'create', 'Failed to create connector.');
+				return;
+			}
+			happyToast('Connector created.');
+			createModalOpen = false;
+			await invalidateAll();
+		} catch (err) {
+			sadToast(errorMessage(err, 'Failed to create connector.'));
+		} finally {
+			creating = false;
 		}
-		happyToast('Connector created.');
-		createModalOpen = false;
-		invalidateAll();
 	};
 
 	let editModalOpen = false;
 	let configToEdit: api.ConnectorConfig | null = null;
 	let editForm = {
+		account_scope: '',
 		display_name: '',
 		host: '',
 		client_id: '',
@@ -110,40 +149,61 @@
 		enabled: true
 	};
 	let editing = false;
+	let editHostError = '';
+	let editCredentialsError = '';
+
+	const clearEditHostError = () => {
+		editHostError = '';
+	};
+
+	const clearEditCredentialsError = () => {
+		editCredentialsError = '';
+	};
 
 	const openEditModal = (config: api.ConnectorConfig) => {
 		configToEdit = config;
 		editForm = {
+			account_scope: config.account_scope,
 			display_name: config.display_name,
 			host: config.host,
 			client_id: config.client_id,
 			client_secret: '',
 			enabled: config.enabled
 		};
+		editHostError = '';
+		editCredentialsError = '';
 		editModalOpen = true;
 	};
 
 	const handleEdit = async (event: Event) => {
 		event.preventDefault();
 		if (editing || !configToEdit) return;
+		editHostError = '';
+		editCredentialsError = '';
 		editing = true;
-		const result = await api.updateConnectorConfig(fetch, configToEdit.id, {
-			display_name: editForm.display_name,
-			host: editForm.host,
-			client_id: editForm.client_id,
-			client_secret: editForm.client_secret ? editForm.client_secret : null,
-			enabled: editForm.enabled
-		});
-		const response = api.expandResponse(result);
-		editing = false;
-		if (response.error) {
-			sadToast(response.error.detail || 'Failed to update connector.');
-			return;
+		try {
+			const result = await api.updateConnectorConfig(fetch, configToEdit.id, {
+				account_scope: editForm.account_scope,
+				display_name: editForm.display_name,
+				host: editForm.host,
+				client_id: editForm.client_id,
+				client_secret: editForm.client_secret ? editForm.client_secret : null,
+				enabled: editForm.enabled
+			});
+			const response = api.expandResponse(result);
+			if (response.error) {
+				applyConnectorError(response.error, 'edit', 'Failed to update connector.');
+				return;
+			}
+			happyToast('Connector updated.');
+			editModalOpen = false;
+			configToEdit = null;
+			await invalidateAll();
+		} catch (err) {
+			sadToast(errorMessage(err, 'Failed to update connector.'));
+		} finally {
+			editing = false;
 		}
-		happyToast('Connector updated.');
-		editModalOpen = false;
-		configToEdit = null;
-		invalidateAll();
 	};
 
 	$: serviceOptions = connectorServices.map((s) => ({ value: s.slug, name: s.display_name }));
@@ -189,6 +249,12 @@
 
 		<div class="flex flex-col gap-4">
 			<P>Configure connectors that let users link their accounts to external services.</P>
+
+			{#if loadError}
+				<div class="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+					{loadError}
+				</div>
+			{/if}
 
 			<Table class="w-full">
 				<TableHead class="rounded-2xl bg-blue-light-40 p-1 tracking-wide text-blue-dark-50">
@@ -294,14 +360,23 @@
 				id="connector-host"
 				placeholder="example.hosted.service.com"
 				bind:value={createForm.host}
+				oninput={clearCreateHostError}
 			/>
+			{#if createHostError}
+				<p class="text-sm text-red-700">{createHostError}</p>
+			{/if}
 		</div>
 
 		<div class="flex flex-col gap-2">
 			<Label for="connector-client-id" class="text-xs tracking-wide text-gray-600 uppercase"
 				>Client ID</Label
 			>
-			<Input id="connector-client-id" autocomplete="off" bind:value={createForm.client_id} />
+			<Input
+				id="connector-client-id"
+				autocomplete="off"
+				bind:value={createForm.client_id}
+				oninput={clearCreateCredentialsError}
+			/>
 		</div>
 
 		<div class="flex flex-col gap-2">
@@ -313,7 +388,11 @@
 				type="password"
 				autocomplete="new-password"
 				bind:value={createForm.client_secret}
+				oninput={clearCreateCredentialsError}
 			/>
+			{#if createCredentialsError}
+				<p class="text-sm text-red-700">{createCredentialsError}</p>
+			{/if}
 		</div>
 
 		<div class="flex items-center gap-3">
@@ -322,6 +401,9 @@
 		</div>
 
 		<div class="flex justify-end gap-3">
+			{#if creating}
+				<p class="self-center text-sm text-gray-600">Validating with provider...</p>
+			{/if}
 			<Button color="light" onclick={() => (createModalOpen = false)}>Cancel</Button>
 			<Button
 				class="rounded-full bg-orange text-white hover:bg-orange-dark"
@@ -334,7 +416,8 @@
 					!createForm.client_secret.trim()}
 				onclick={handleCreate}
 			>
-				{creating ? 'Creating…' : 'Create'}
+				{#if creating}<Spinner color="custom" customColor="fill-white" class="mr-2 h-4 w-4" />{/if}
+				{creating ? 'Creating...' : 'Create'}
 			</Button>
 		</div>
 	</div>
@@ -355,17 +438,31 @@
 		</div>
 
 		<div class="flex flex-col gap-2">
+			<Label for="edit-connector-tenant" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Tenant</Label
+			>
+			<Input id="edit-connector-tenant" bind:value={editForm.account_scope} />
+		</div>
+
+		<div class="flex flex-col gap-2">
 			<Label for="edit-connector-host" class="text-xs tracking-wide text-gray-600 uppercase"
 				>Host</Label
 			>
-			<Input id="edit-connector-host" bind:value={editForm.host} />
+			<Input id="edit-connector-host" bind:value={editForm.host} oninput={clearEditHostError} />
+			{#if editHostError}
+				<p class="text-sm text-red-700">{editHostError}</p>
+			{/if}
 		</div>
 
 		<div class="flex flex-col gap-2">
 			<Label for="edit-connector-client-id" class="text-xs tracking-wide text-gray-600 uppercase"
 				>Client ID</Label
 			>
-			<Input id="edit-connector-client-id" bind:value={editForm.client_id} />
+			<Input
+				id="edit-connector-client-id"
+				bind:value={editForm.client_id}
+				oninput={clearEditCredentialsError}
+			/>
 		</div>
 
 		<div class="flex flex-col gap-2">
@@ -378,7 +475,11 @@
 				type="password"
 				placeholder="Leave blank to keep current secret"
 				bind:value={editForm.client_secret}
+				oninput={clearEditCredentialsError}
 			/>
+			{#if editCredentialsError}
+				<p class="text-sm text-red-700">{editCredentialsError}</p>
+			{/if}
 		</div>
 
 		<div class="flex items-center gap-3">
@@ -387,16 +488,21 @@
 		</div>
 
 		<div class="flex justify-end gap-3">
+			{#if editing}
+				<p class="self-center text-sm text-gray-600">Validating with provider...</p>
+			{/if}
 			<Button color="light" onclick={() => (editModalOpen = false)}>Cancel</Button>
 			<Button
 				class="rounded-full bg-orange text-white hover:bg-orange-dark"
 				disabled={editing ||
+					!editForm.account_scope.trim() ||
 					!editForm.display_name.trim() ||
 					!editForm.host.trim() ||
 					!editForm.client_id.trim()}
 				onclick={handleEdit}
 			>
-				{editing ? 'Saving…' : 'Save'}
+				{#if editing}<Spinner color="custom" customColor="fill-white" class="mr-2 h-4 w-4" />{/if}
+				{editing ? 'Saving...' : 'Save'}
 			</Button>
 		</div>
 	</div>

--- a/web/pingpong/src/routes/admin/connectors/+page.svelte
+++ b/web/pingpong/src/routes/admin/connectors/+page.svelte
@@ -1,0 +1,403 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import * as api from '$lib/api';
+	import DropdownBadge from '$lib/components/DropdownBadge.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { happyToast, sadToast } from '$lib/toast';
+	import {
+		Badge,
+		Button,
+		Heading,
+		Input,
+		Label,
+		Modal,
+		P,
+		Select,
+		Table,
+		TableBody,
+		TableBodyCell,
+		TableBodyRow,
+		TableHead,
+		TableHeadCell,
+		Toggle
+	} from 'flowbite-svelte';
+	import { ArrowRightOutline, PenSolid, PlusOutline } from 'flowbite-svelte-icons';
+	import { headerState } from '$lib/stores/header';
+
+	export let data;
+	$: connectorConfigs = data.connectorConfigs;
+	$: connectorServices = data.connectorServices;
+
+	$: isNewHeaderLayout = data.forceCollapsedLayout && data.forceShowSidebarButton;
+
+	$: if (isNewHeaderLayout) {
+		headerState.set({
+			kind: 'nongroup',
+			props: {
+				title: 'Connectors',
+				redirectUrl: '/admin',
+				redirectName: 'Admin page'
+			}
+		});
+	}
+
+	const serviceDisplayName = (slug: string) => {
+		const svc = connectorServices.find((s) => s.slug === slug);
+		return svc ? svc.display_name : slug;
+	};
+
+	const formatDate = (dateStr: string) => {
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	};
+
+	let createModalOpen = false;
+	let createForm = {
+		service: '',
+		account_scope: '',
+		display_name: '',
+		host: '',
+		client_id: '',
+		client_secret: '',
+		enabled: true
+	};
+	let creating = false;
+
+	const openCreateModal = () => {
+		createForm = {
+			service: connectorServices[0]?.slug ?? '',
+			account_scope: '',
+			display_name: '',
+			host: '',
+			client_id: '',
+			client_secret: '',
+			enabled: true
+		};
+		createModalOpen = true;
+	};
+
+	const handleCreate = async (event: Event) => {
+		event.preventDefault();
+		if (creating) return;
+		if (!createForm.service) {
+			sadToast('Please select a service.');
+			return;
+		}
+		creating = true;
+		const result = await api.createConnectorConfig(fetch, { ...createForm });
+		const response = api.expandResponse(result);
+		creating = false;
+		if (response.error) {
+			sadToast(response.error.detail || 'Failed to create connector.');
+			return;
+		}
+		happyToast('Connector created.');
+		createModalOpen = false;
+		invalidateAll();
+	};
+
+	let editModalOpen = false;
+	let configToEdit: api.ConnectorConfig | null = null;
+	let editForm = {
+		display_name: '',
+		host: '',
+		client_id: '',
+		client_secret: '',
+		enabled: true
+	};
+	let editing = false;
+
+	const openEditModal = (config: api.ConnectorConfig) => {
+		configToEdit = config;
+		editForm = {
+			display_name: config.display_name,
+			host: config.host,
+			client_id: config.client_id,
+			client_secret: '',
+			enabled: config.enabled
+		};
+		editModalOpen = true;
+	};
+
+	const handleEdit = async (event: Event) => {
+		event.preventDefault();
+		if (editing || !configToEdit) return;
+		editing = true;
+		const result = await api.updateConnectorConfig(fetch, configToEdit.id, {
+			display_name: editForm.display_name,
+			host: editForm.host,
+			client_id: editForm.client_id,
+			client_secret: editForm.client_secret ? editForm.client_secret : null,
+			enabled: editForm.enabled
+		});
+		const response = api.expandResponse(result);
+		editing = false;
+		if (response.error) {
+			sadToast(response.error.detail || 'Failed to update connector.');
+			return;
+		}
+		happyToast('Connector updated.');
+		editModalOpen = false;
+		configToEdit = null;
+		invalidateAll();
+	};
+
+	$: serviceOptions = connectorServices.map((s) => ({ value: s.slug, name: s.display_name }));
+</script>
+
+<div class="relative flex h-full w-full flex-col">
+	{#if !isNewHeaderLayout}
+		<PageHeader>
+			<div slot="left">
+				<h2 class="text-color-blue-dark-50 px-4 py-3 font-serif text-3xl font-bold">Connectors</h2>
+			</div>
+			<div slot="right">
+				<a
+					href={resolve('/admin')}
+					class="flex items-center gap-2 rounded-full bg-white p-2 px-4 text-sm font-medium text-blue-dark-50 transition-all hover:bg-blue-dark-40 hover:text-white"
+					>Admin page <ArrowRightOutline size="md" class="text-orange" /></a
+				>
+			</div>
+		</PageHeader>
+	{/if}
+
+	<div class="w-full p-12 pt-6">
+		<div class="mb-4 flex flex-row flex-wrap items-center justify-between gap-y-4">
+			<div class="mr-5 flex flex-wrap items-center gap-3">
+				<Heading
+					tag="h2"
+					class="text-dark-blue-40 max-w-max shrink-0 font-serif text-3xl font-medium"
+					>Manage Connectors</Heading
+				>
+				<DropdownBadge>
+					<span slot="name" class="uppercase">Under Development</span>
+				</DropdownBadge>
+			</div>
+			<Button
+				class="flex items-center gap-2 rounded-full bg-orange text-white hover:bg-orange-dark"
+				disabled={connectorServices.length === 0}
+				onclick={openCreateModal}
+			>
+				<PlusOutline size="sm" />
+				Add Connector
+			</Button>
+		</div>
+
+		<div class="flex flex-col gap-4">
+			<P>Configure connectors that let users link their accounts to external services.</P>
+
+			<Table class="w-full">
+				<TableHead class="rounded-2xl bg-blue-light-40 p-1 tracking-wide text-blue-dark-50">
+					<TableHeadCell>Service</TableHeadCell>
+					<TableHeadCell>Display name</TableHeadCell>
+					<TableHeadCell>Tenant</TableHeadCell>
+					<TableHeadCell>Host</TableHeadCell>
+					<TableHeadCell>Client ID</TableHeadCell>
+					<TableHeadCell>Enabled</TableHeadCell>
+					<TableHeadCell>Created</TableHeadCell>
+					<TableHeadCell></TableHeadCell>
+				</TableHead>
+				<TableBody>
+					{#if connectorConfigs.length === 0}
+						<TableBodyRow>
+							<TableBodyCell colspan={8} class="py-4 text-sm text-gray-500">
+								No connectors configured yet.
+							</TableBodyCell>
+						</TableBodyRow>
+					{/if}
+
+					{#each connectorConfigs as config (config.id)}
+						<TableBodyRow>
+							<TableBodyCell class="py-2">
+								<div class="flex flex-col">
+									<span class="font-medium">{serviceDisplayName(config.service)}</span>
+									<span class="font-mono text-xs text-gray-500">{config.service}</span>
+								</div>
+							</TableBodyCell>
+							<TableBodyCell class="py-2 whitespace-normal">{config.display_name}</TableBodyCell>
+							<TableBodyCell class="py-2 font-mono text-xs">{config.account_scope}</TableBodyCell>
+							<TableBodyCell class="max-w-xs py-2 break-all whitespace-normal">
+								{config.host}
+							</TableBodyCell>
+							<TableBodyCell class="max-w-xs py-2 font-mono text-xs break-all whitespace-normal">
+								{config.client_id}
+							</TableBodyCell>
+							<TableBodyCell class="py-2">
+								{#if config.enabled}
+									<Badge color="green">Enabled</Badge>
+								{:else}
+									<Badge color="dark">Disabled</Badge>
+								{/if}
+							</TableBodyCell>
+							<TableBodyCell class="py-2 text-sm text-gray-600">
+								{formatDate(config.created)}
+							</TableBodyCell>
+							<TableBodyCell class="py-2 text-right">
+								<Button
+									pill
+									size="sm"
+									class="flex w-fit shrink-0 flex-row items-center justify-center gap-1.5 rounded-full border border-blue-dark-40 bg-white p-1 px-3 text-xs text-blue-dark-40 transition-all hover:bg-blue-dark-40 hover:text-white"
+									onclick={() => openEditModal(config)}
+								>
+									<PenSolid size="sm" class="mr-1" />
+									Edit
+								</Button>
+							</TableBodyCell>
+						</TableBodyRow>
+					{/each}
+				</TableBody>
+			</Table>
+		</div>
+	</div>
+</div>
+
+<Modal bind:open={createModalOpen} size="md" onclose={() => (createModalOpen = false)}>
+	<div class="space-y-6 p-4">
+		<Heading tag="h3" class="text-xl font-semibold text-gray-900">Add Connector</Heading>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-service" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Service</Label
+			>
+			<Select id="connector-service" items={serviceOptions} bind:value={createForm.service} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-display-name" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Display name</Label
+			>
+			<Input
+				id="connector-display-name"
+				placeholder="University of Example"
+				bind:value={createForm.display_name}
+			/>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-tenant" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Tenant</Label
+			>
+			<Input
+				id="connector-tenant"
+				placeholder="example-tenant"
+				bind:value={createForm.account_scope}
+			/>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-host" class="text-xs tracking-wide text-gray-600 uppercase">Host</Label>
+			<Input
+				id="connector-host"
+				placeholder="example.hosted.service.com"
+				bind:value={createForm.host}
+			/>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-client-id" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Client ID</Label
+			>
+			<Input id="connector-client-id" autocomplete="off" bind:value={createForm.client_id} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="connector-client-secret" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Client secret</Label
+			>
+			<Input
+				id="connector-client-secret"
+				type="password"
+				autocomplete="new-password"
+				bind:value={createForm.client_secret}
+			/>
+		</div>
+
+		<div class="flex items-center gap-3">
+			<Toggle bind:checked={createForm.enabled} color="blue" />
+			<span class="text-sm">Enabled</span>
+		</div>
+
+		<div class="flex justify-end gap-3">
+			<Button color="light" onclick={() => (createModalOpen = false)}>Cancel</Button>
+			<Button
+				class="rounded-full bg-orange text-white hover:bg-orange-dark"
+				disabled={creating ||
+					!createForm.service ||
+					!createForm.display_name.trim() ||
+					!createForm.account_scope.trim() ||
+					!createForm.host.trim() ||
+					!createForm.client_id.trim() ||
+					!createForm.client_secret.trim()}
+				onclick={handleCreate}
+			>
+				{creating ? 'Creating…' : 'Create'}
+			</Button>
+		</div>
+	</div>
+</Modal>
+
+<Modal bind:open={editModalOpen} size="md" onclose={() => (configToEdit = null)}>
+	<div class="space-y-6 p-4">
+		<Heading tag="h3" class="text-xl font-semibold text-gray-900">
+			Edit <span class="font-mono">{configToEdit?.service}</span> /
+			<span class="font-mono">{configToEdit?.account_scope}</span>
+		</Heading>
+
+		<div class="flex flex-col gap-2">
+			<Label for="edit-connector-display-name" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Display name</Label
+			>
+			<Input id="edit-connector-display-name" bind:value={editForm.display_name} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="edit-connector-host" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Host</Label
+			>
+			<Input id="edit-connector-host" bind:value={editForm.host} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="edit-connector-client-id" class="text-xs tracking-wide text-gray-600 uppercase"
+				>Client ID</Label
+			>
+			<Input id="edit-connector-client-id" bind:value={editForm.client_id} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label
+				for="edit-connector-client-secret"
+				class="text-xs tracking-wide text-gray-600 uppercase">Client secret</Label
+			>
+			<Input
+				id="edit-connector-client-secret"
+				type="password"
+				placeholder="Leave blank to keep current secret"
+				bind:value={editForm.client_secret}
+			/>
+		</div>
+
+		<div class="flex items-center gap-3">
+			<Toggle bind:checked={editForm.enabled} color="blue" />
+			<span class="text-sm">Enabled</span>
+		</div>
+
+		<div class="flex justify-end gap-3">
+			<Button color="light" onclick={() => (editModalOpen = false)}>Cancel</Button>
+			<Button
+				class="rounded-full bg-orange text-white hover:bg-orange-dark"
+				disabled={editing ||
+					!editForm.display_name.trim() ||
+					!editForm.host.trim() ||
+					!editForm.client_id.trim()}
+				onclick={handleEdit}
+			>
+				{editing ? 'Saving…' : 'Save'}
+			</Button>
+		</div>
+	</div>
+</Modal>

--- a/web/pingpong/src/routes/admin/connectors/+page.ts
+++ b/web/pingpong/src/routes/admin/connectors/+page.ts
@@ -9,9 +9,11 @@ export const load: PageLoad = async ({ fetch }) => {
 
 	const configs = configsResp.error ? [] : configsResp.data.configs;
 	const services = servicesResp.error ? [] : servicesResp.data.services;
+	const loadError = configsResp.error?.detail || servicesResp.error?.detail || null;
 
 	return {
 		connectorConfigs: configs,
-		connectorServices: services
+		connectorServices: services,
+		loadError
 	};
 };

--- a/web/pingpong/src/routes/admin/connectors/+page.ts
+++ b/web/pingpong/src/routes/admin/connectors/+page.ts
@@ -1,0 +1,17 @@
+import type { PageLoad } from './$types';
+import * as api from '$lib/api';
+
+export const load: PageLoad = async ({ fetch }) => {
+	const [configsResp, servicesResp] = await Promise.all([
+		api.getConnectorConfigs(fetch).then(api.expandResponse),
+		api.getConnectorServices(fetch).then(api.expandResponse)
+	]);
+
+	const configs = configsResp.error ? [] : configsResp.data.configs;
+	const services = servicesResp.error ? [] : servicesResp.data.services;
+
+	return {
+		connectorConfigs: configs,
+		connectorServices: services
+	};
+};


### PR DESCRIPTION
## Connectors (Under Development)

### New Features
* Admins can manage connector configurations from the Admin page.
* Admins can create and edit Panopto connector configurations, including tenant, host, client ID, client secret, display name, and enabled status.
* Connector configurations are validated against the provider before they are saved, with clear errors for unreachable hosts, invalid OIDC endpoints, and invalid client credentials.