### PR TITLE
fix(lv): dismiss "continue watching" button from player

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -180,6 +180,7 @@
 	let liveLectureVideoSession: api.LectureVideoSession | null = null;
 	let lectureVideoSessionKey: string | null = null;
 	let startingReplacementLectureThread = false;
+	let lectureChatContinuePromptDismissedByPlayback = false;
 	$: {
 		const nextKey = `${classId}:${threadId}:${lectureVideoSession?.state_version ?? 'none'}:${
 			lectureVideoSession?.state ?? 'none'
@@ -296,7 +297,9 @@
 		canSubmit && threadIsCurrentUserParticipant && !assistantDeleted && canViewAssistant;
 	$: lectureChatInputDisabled =
 		!lectureChatCanSubmit || !!$navigating || !threadLectureChatAvailable;
-	$: lectureChatContinuePromptVisible = effectiveLectureVideoSession?.state !== 'awaiting_answer';
+	$: lectureChatContinuePromptVisible =
+		effectiveLectureVideoSession?.state !== 'awaiting_answer' &&
+		!lectureChatContinuePromptDismissedByPlayback;
 	$: canDropUploadsIntoThread =
 		data.threadInteractionMode === 'chat' &&
 		assistantInteractionMode === 'chat' &&
@@ -726,6 +729,7 @@
 
 	const handleLectureChatSubmit = async (message: ChatInputMessage) => {
 		const lectureVideoPlaybackPositionMs = lectureVideoViewRef?.getPlaybackPositionMs();
+		lectureChatContinuePromptDismissedByPlayback = false;
 		void lectureVideoViewRef?.pauseForChatSubmit();
 		await postMessage({
 			...message,
@@ -740,6 +744,7 @@
 	};
 
 	const handleLecturePlaybackResumed = () => {
+		lectureChatContinuePromptDismissedByPlayback = true;
 		threadMgr.interruptTts().catch(() => {});
 	};
 

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -181,6 +181,11 @@
 	let lectureVideoSessionKey: string | null = null;
 	let startingReplacementLectureThread = false;
 	let lectureChatContinuePromptDismissedByPlayback = false;
+	let lectureChatContinuePromptDismissedThreadKey: string | null = null;
+	$: if (lectureChatContinuePromptDismissedThreadKey !== currentLectureVideoThreadKey) {
+		lectureChatContinuePromptDismissedByPlayback = false;
+		lectureChatContinuePromptDismissedThreadKey = currentLectureVideoThreadKey;
+	}
 	$: {
 		const nextKey = `${classId}:${threadId}:${lectureVideoSession?.state_version ?? 'none'}:${
 			lectureVideoSession?.state ?? 'none'

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -1425,7 +1425,6 @@
 
 	function handlePlay() {
 		clearPendingVideoRetry();
-		dispatch('playbackresumed');
 		if (!videoElement) return;
 		if (questionReviewPlaybackAllowed) {
 			if (currentQuestion && currentTimeMs >= currentQuestion.stop_offset_ms) {
@@ -1440,6 +1439,7 @@
 			videoElement.pause();
 			return;
 		}
+		dispatch('playbackresumed');
 		if (suppressPlayInteraction) {
 			suppressPlayInteraction = false;
 			return;

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -1439,11 +1439,11 @@
 			videoElement.pause();
 			return;
 		}
-		dispatch('playbackresumed');
 		if (suppressPlayInteraction) {
 			suppressPlayInteraction = false;
 			return;
 		}
+		dispatch('playbackresumed');
 		if (!controllerSessionId || !playbackInteractionAllowed) return;
 		queuePlaybackInteraction('video_resumed');
 	}


### PR DESCRIPTION
## Lecture Videos (Preview)
### Resolved Issues
* Fixed: After sending a chat message, resuming the lecture video from the player may not hide the "continue watching" prompt in the chat.