### PR TITLE
feat(lv): request audio only regeneration

### DIFF
--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1190,6 +1190,10 @@ def lecture_video_validator_update_assistant(self):
         "regenerate_audio_requested" in self.model_fields_set
     )
     overwrite_manifest_present = "overwrite_manifest" in self.model_fields_set
+    if self.regenerate_requested and self.regenerate_audio_requested:
+        raise ValueError(
+            "regenerate_requested and regenerate_audio_requested cannot both be true."
+        )
     lecture_video_payload_present = (
         lecture_video_id_present
         or lecture_video_manifest_present

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1186,6 +1186,9 @@ def lecture_video_validator_update_assistant(self):
         "video_description_duration_ms" in self.model_fields_set
     )
     regenerate_requested_present = "regenerate_requested" in self.model_fields_set
+    regenerate_audio_requested_present = (
+        "regenerate_audio_requested" in self.model_fields_set
+    )
     overwrite_manifest_present = "overwrite_manifest" in self.model_fields_set
     lecture_video_payload_present = (
         lecture_video_id_present
@@ -1194,6 +1197,7 @@ def lecture_video_validator_update_assistant(self):
         or generation_prompt_present
         or video_description_duration_ms_present
         or regenerate_requested_present
+        or regenerate_audio_requested_present
         or overwrite_manifest_present
     )
     overwrite_manifest = (
@@ -1430,6 +1434,7 @@ class UpdateAssistant(BaseModel):
     # snaps to 5-second increments.
     video_description_duration_ms: int | None = Field(None, ge=5000, le=300000)
     regenerate_requested: bool | None = None
+    regenerate_audio_requested: bool | None = None
     overwrite_manifest: bool | None = None
     model: str | None = Field(None, min_length=2)
     temperature: float | None = Field(None, ge=0.0, le=2.0)

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -10706,6 +10706,7 @@ async def update_assistant(
     )
     lecture_video_voice_id_validated = False
     regenerate_requested = bool(req.regenerate_requested)
+    regenerate_audio_requested = bool(req.regenerate_audio_requested)
     overwrite_lecture_video_manifest = (
         bool(req.overwrite_manifest)
         if "overwrite_manifest" in req.model_fields_set
@@ -10718,6 +10719,7 @@ async def update_assistant(
         or "generation_prompt" in req.model_fields_set
         or "video_description_duration_ms" in req.model_fields_set
         or "regenerate_requested" in req.model_fields_set
+        or "regenerate_audio_requested" in req.model_fields_set
         or "overwrite_manifest" in req.model_fields_set
     )
 
@@ -11756,6 +11758,7 @@ async def update_assistant(
                 manifest_changed
                 or needs_manifest_generation
                 or regenerate_requested
+                or regenerate_audio_requested
                 or voice_changed
             )
             manual_manifest_takeover_only = (
@@ -11843,7 +11846,8 @@ async def update_assistant(
                         manual_manifest=True,
                     )
                 if overwrite_lecture_video_manifest or (
-                    voice_changed and not needs_manifest_generation
+                    (voice_changed or regenerate_audio_requested)
+                    and not needs_manifest_generation
                 ):
                     if not overwrite_lecture_video_manifest:
                         if same_lecture_video:

--- a/pingpong/test_lecture_video_manifest_generation_server.py
+++ b/pingpong/test_lecture_video_manifest_generation_server.py
@@ -105,6 +105,20 @@ def test_update_assistant_allows_non_step_video_description_duration() -> None:
     assert assistant.video_description_duration_ms == 7000
 
 
+def test_update_assistant_rejects_conflicting_regeneration_requests() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        schemas.UpdateAssistant.model_validate(
+            {
+                "lecture_video_id": 1,
+                "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+                "regenerate_requested": True,
+                "regenerate_audio_requested": True,
+            }
+        )
+
+    assert "regenerate_requested and regenerate_audio_requested" in str(exc_info.value)
+
+
 def test_create_assistant_rejects_manifest_when_generation_mode_requested() -> None:
     with pytest.raises(ValidationError) as exc_info:
         schemas.CreateAssistant.model_validate(

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -9100,6 +9100,108 @@ async def test_update_assistant_with_same_lecture_video_id_and_voice_only_clones
         ("user:123", "admin", "class:1"),
     ]
 )
+async def test_update_assistant_with_regenerate_audio_only_clones_existing_manifest(
+    api, db, institution, valid_user_token, monkeypatch
+):
+    patch_lecture_video_model_list(monkeypatch)
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Lecture Class",
+            institution_id=institution.id,
+            api_key="sk-test",
+        )
+        lecture_video = make_lecture_video(
+            class_.id,
+            "audio-only-regenerate.mp4",
+            filename="audio-only-regenerate.mp4",
+            status=schemas.LectureVideoStatus.UPLOADED.value,
+        )
+        session.add_all([class_, lecture_video])
+        await create_lecture_video_copy_credentials(session, class_.id)
+        await session.commit()
+        await session.refresh(lecture_video)
+
+    create_response = api.post(
+        "/api/v1/class/1/assistant",
+        json={
+            "name": "Lecture Assistant",
+            "instructions": "Guide the learner through the lecture.",
+            "description": "Lecture presentation assistant",
+            "interaction_mode": "lecture_video",
+            "model": "gpt-4o-mini",
+            "tools": [],
+            "lecture_video_id": lecture_video.id,
+            "lecture_video_manifest": lecture_video_manifest(
+                question_text="Keep this question?"
+            ),
+            "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+            "overwrite_manifest": True,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert create_response.status_code == 200
+
+    async with db.async_session() as session:
+        created_video = await session.get(models.LectureVideo, lecture_video.id)
+        assert created_video is not None
+        created_video.manual_manifest = False
+        session.add(created_video)
+        await session.commit()
+
+    update_response = api.put(
+        "/api/v1/class/1/assistant/1",
+        json={
+            "lecture_video_id": lecture_video.id,
+            "voice_id": DEFAULT_LECTURE_VIDEO_VOICE_ID,
+            "overwrite_manifest": False,
+            "regenerate_audio_requested": True,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert update_response.status_code == 200
+    regenerated_video_id = update_response.json()["lecture_video"]["id"]
+    assert regenerated_video_id != lecture_video.id
+
+    async with db.async_session() as session:
+        assistant = await session.get(models.Assistant, 1)
+        regenerated_video = await models.LectureVideo.get_by_id_with_copy_context(
+            session, regenerated_video_id
+        )
+        processing_runs = list(
+            (
+                await session.scalars(
+                    select(models.LectureVideoProcessingRun).order_by(
+                        models.LectureVideoProcessingRun.id.asc()
+                    )
+                )
+            ).all()
+        )
+
+    assert assistant is not None
+    assert assistant.lecture_video_id == regenerated_video_id
+    assert regenerated_video is not None
+    assert regenerated_video.source_lecture_video_id_snapshot == lecture_video.id
+    assert regenerated_video.manual_manifest is False
+    assert regenerated_video.questions[0].question_text == "Keep this question?"
+    assert len(processing_runs) == 2
+    assert processing_runs[0].lecture_video_id_snapshot == lecture_video.id
+    assert processing_runs[1].lecture_video_id_snapshot == regenerated_video_id
+    assert processing_runs[1].stage == schemas.LectureVideoProcessingStage.NARRATION
+    assert processing_runs[1].status == schemas.LectureVideoProcessingRunStatus.QUEUED
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
 async def test_update_assistant_with_same_lecture_video_config_is_a_no_op(
     api, db, institution, valid_user_token, monkeypatch
 ):

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -9100,6 +9100,7 @@ async def test_update_assistant_with_same_lecture_video_id_and_voice_only_clones
         ("user:123", "admin", "class:1"),
     ]
 )
+@pytest.mark.asyncio
 async def test_update_assistant_with_regenerate_audio_only_clones_existing_manifest(
     api, db, institution, valid_user_token, monkeypatch
 ):
@@ -9188,6 +9189,9 @@ async def test_update_assistant_with_regenerate_audio_only_clones_existing_manif
     assert regenerated_video.questions[0].question_text == "Keep this question?"
     assert len(processing_runs) == 2
     assert processing_runs[0].lecture_video_id_snapshot == lecture_video.id
+    assert (
+        processing_runs[0].status == schemas.LectureVideoProcessingRunStatus.CANCELLED
+    )
     assert processing_runs[1].lecture_video_id_snapshot == regenerated_video_id
     assert processing_runs[1].stage == schemas.LectureVideoProcessingStage.NARRATION
     assert processing_runs[1].status == schemas.LectureVideoProcessingRunStatus.QUEUED

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -2627,6 +2627,7 @@ export type UpdateAssistantRequest = {
 	generation_prompt?: string | null;
 	video_description_duration_ms?: number | null;
 	regenerate_requested?: boolean;
+	regenerate_audio_requested?: boolean;
 	overwrite_manifest?: boolean;
 	create_classic_assistant?: boolean;
 	temperature?: number | null;

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -881,6 +881,9 @@
 	$: if (regenerateRequested && regenerateAudioRequested) {
 		regenerateAudioRequested = false;
 	}
+	$: if (lectureVideoGenerationTriggeredByFormChanges && regenerateAudioRequested) {
+		regenerateAudioRequested = false;
+	}
 	$: lectureVideoManifestRegenerateButtonPressed =
 		regenerateRequested || lectureVideoGenerationTriggeredByFormChanges;
 	$: lectureVideoAudioRegenerateButtonPressed =

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -164,51 +164,40 @@
 	};
 
 	type LectureVideoSaveAffordances = {
-		regenerateHelperText: string;
-		regenerateButtonLabel: string;
+		audioRegenerateHelperText: string;
+		audioRegenerateButtonLabel: string;
+		manifestRegenerateHelperText: string;
+		manifestRegenerateButtonLabel: string;
 		saveButtonLabel: string;
 	};
 
 	const deriveLectureVideoSaveAffordances = ({
-		impliedRegeneration,
-		overwriteManifest,
 		saveTriggersGeneration,
-		regenerateRequested,
-		isCreating
+		audioRegenerationTriggered,
+		audioRegenerateRequested,
+		regenerateRequested
 	}: {
-		impliedRegeneration: boolean;
-		overwriteManifest: boolean;
 		saveTriggersGeneration: boolean;
+		audioRegenerationTriggered: boolean;
+		audioRegenerateRequested: boolean;
 		regenerateRequested: boolean;
-		isCreating: boolean;
 	}): LectureVideoSaveAffordances => {
-		if (impliedRegeneration && overwriteManifest) {
-			return {
-				regenerateHelperText: 'Your changes will re-create narration clips when you save.',
-				regenerateButtonLabel: 'Regenerate audio on save',
-				saveButtonLabel: 'Save'
-			};
-		}
-		if (impliedRegeneration) {
-			return {
-				regenerateHelperText:
-					'Your changes will regenerate the manifest and re-create narration clips when you save.',
-				regenerateButtonLabel: 'Regenerate on save',
-				saveButtonLabel: saveTriggersGeneration ? 'Save & generate' : 'Save'
-			};
-		}
-		if (overwriteManifest) {
-			return {
-				regenerateHelperText: 'Re-runs narration recreation for the current manifest.',
-				regenerateButtonLabel: 'Regenerate audio',
-				saveButtonLabel: regenerateRequested ? 'Save & regenerate audio' : 'Save'
-			};
-		}
+		const saveRegeneratesAudio = audioRegenerationTriggered || audioRegenerateRequested;
 		return {
-			regenerateHelperText:
-				'Re-runs the knowledge check generation and re-creates all narration clips.',
-			regenerateButtonLabel: 'Regenerate manifest & audio',
-			saveButtonLabel: saveTriggersGeneration && isCreating ? 'Save & generate' : 'Save'
+			audioRegenerateHelperText: audioRegenerationTriggered
+				? 'Your changes will re-create narration clips when you save.'
+				: 'Re-creates narration clips from the current manifest without generating a new manifest.',
+			audioRegenerateButtonLabel: 'Regenerate audio',
+			manifestRegenerateHelperText:
+				'Re-runs knowledge check generation and then re-creates narration clips.',
+			manifestRegenerateButtonLabel: 'Regenerate manifest & audio',
+			saveButtonLabel: saveTriggersGeneration
+				? 'Save & generate'
+				: saveRegeneratesAudio
+					? 'Save & regenerate audio'
+					: regenerateRequested
+						? 'Save & generate'
+						: 'Save'
 		};
 	};
 
@@ -315,6 +304,7 @@
 	let overwriteManifest = effectiveOverwriteManifest(data.lectureVideoConfig?.overwrite_manifest);
 	let hasSetOverwriteManifest = false;
 	let regenerateRequested = false;
+	let regenerateAudioRequested = false;
 	let currentVoiceId = data.lectureVideoConfig?.voice_id || '';
 	let voiceId = '';
 	let hasSetVoiceId = false;
@@ -873,30 +863,46 @@
 			videoDescriptionDurationChanged ||
 			lastManifestRunFailed ||
 			!data.lectureVideoConfig?.lecture_video_manifest);
-	$: lectureVideoNarrationTriggeredByFormChanges =
-		isLectureMode && overwriteManifest && (lectureVideoManifestChanged || lectureVideoVoiceChanged);
-	$: lectureVideoRegenerationImpliedByFormChanges =
-		lectureVideoGenerationTriggeredByFormChanges || lectureVideoNarrationTriggeredByFormChanges;
+	$: lectureVideoAudioTriggeredByFormChanges =
+		isLectureMode &&
+		!data.isCreating &&
+		!lectureVideoGenerationTriggeredByFormChanges &&
+		(lectureVideoVoiceChanged || (overwriteManifest && lectureVideoManifestChanged));
 	$: canRegenerateLectureVideo = isLectureMode && !data.isCreating;
 	$: if (!canRegenerateLectureVideo && regenerateRequested) {
 		regenerateRequested = false;
 	}
-	$: lectureVideoRegenerateButtonPressed =
-		regenerateRequested || lectureVideoRegenerationImpliedByFormChanges;
+	$: if (!canRegenerateLectureVideo && regenerateAudioRequested) {
+		regenerateAudioRequested = false;
+	}
+	$: if (overwriteManifest && regenerateRequested) {
+		regenerateRequested = false;
+	}
+	$: if (regenerateRequested && regenerateAudioRequested) {
+		regenerateAudioRequested = false;
+	}
+	$: lectureVideoManifestRegenerateButtonPressed =
+		regenerateRequested || lectureVideoGenerationTriggeredByFormChanges;
+	$: lectureVideoAudioRegenerateButtonPressed =
+		regenerateAudioRequested || lectureVideoAudioTriggeredByFormChanges;
 	$: lectureVideoSaveTriggersGeneration =
 		isLectureMode &&
 		canGenerateLectureVideoManifest &&
 		!overwriteManifest &&
 		(regenerateRequested || lectureVideoGenerationTriggeredByFormChanges);
 	$: lectureVideoSaveAffordances = deriveLectureVideoSaveAffordances({
-		impliedRegeneration: lectureVideoRegenerationImpliedByFormChanges,
-		overwriteManifest,
 		saveTriggersGeneration: isLectureMode && lectureVideoSaveTriggersGeneration,
-		regenerateRequested,
-		isCreating: data.isCreating
+		audioRegenerationTriggered: lectureVideoAudioTriggeredByFormChanges,
+		audioRegenerateRequested: regenerateAudioRequested,
+		regenerateRequested
 	});
-	$: lectureVideoRegenerateHelperText = lectureVideoSaveAffordances.regenerateHelperText;
-	$: lectureVideoRegenerateButtonLabel = lectureVideoSaveAffordances.regenerateButtonLabel;
+	$: lectureVideoAudioRegenerateHelperText = lectureVideoSaveAffordances.audioRegenerateHelperText;
+	$: lectureVideoAudioRegenerateButtonLabel =
+		lectureVideoSaveAffordances.audioRegenerateButtonLabel;
+	$: lectureVideoManifestRegenerateHelperText =
+		lectureVideoSaveAffordances.manifestRegenerateHelperText;
+	$: lectureVideoManifestRegenerateButtonLabel =
+		lectureVideoSaveAffordances.manifestRegenerateButtonLabel;
 	$: saveButtonLabel = lectureVideoSaveAffordances.saveButtonLabel;
 	$: lectureVideoChatUnavailable = (() => {
 		try {
@@ -2082,9 +2088,10 @@
 			modifiedFields.push('video description duration');
 		}
 		if (canRegenerateLectureVideo && regenerateRequested) {
-			modifiedFields.push(
-				overwriteManifest ? 'lecture video narration' : 'lecture video generation'
-			);
+			modifiedFields.push('lecture video generation');
+		}
+		if (canRegenerateLectureVideo && regenerateAudioRequested) {
+			modifiedFields.push('lecture video narration');
 		}
 		if (overwriteManifest !== originalOverwriteManifest) {
 			modifiedFields.push('lecture video manifest mode');
@@ -2708,6 +2715,7 @@
 				videoDescriptionDurationChanged ||
 				overwriteManifestChanged ||
 				(canRegenerateLectureVideo && regenerateRequested) ||
+				(canRegenerateLectureVideo && regenerateAudioRequested) ||
 				lastManifestRunFailed;
 
 			if (data.isCreating || lectureVideoFieldsChanged) {
@@ -2722,6 +2730,7 @@
 					: undefined;
 				if (canRegenerateLectureVideo) {
 					params.regenerate_requested = regenerateRequested;
+					params.regenerate_audio_requested = regenerateAudioRequested;
 				}
 				params.overwrite_manifest = overwriteManifest;
 			} else {
@@ -2731,6 +2740,7 @@
 				delete params.generation_prompt;
 				delete params.video_description_duration_ms;
 				delete params.regenerate_requested;
+				delete params.regenerate_audio_requested;
 				delete params.overwrite_manifest;
 			}
 		}
@@ -4027,19 +4037,49 @@
 									</div>
 								{/if}
 								{#if canRegenerateLectureVideo}
-									<div class="mb-2 flex flex-wrap items-center gap-3 text-sm text-gray-600">
-										<button
-											type="button"
-											class={`${lectureVideoRegenerateButtonPressed ? 'border-blue-300 bg-blue-100 font-semibold text-blue-800 shadow-inner shadow-blue-200' : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'} rounded-lg border px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-70`}
-											disabled={preventEdits ||
-												manifestGenerationInFlight ||
-												lectureVideoRegenerationImpliedByFormChanges}
-											aria-pressed={lectureVideoRegenerateButtonPressed}
-											onclick={() => {
-												regenerateRequested = !regenerateRequested;
-											}}>{lectureVideoRegenerateButtonLabel}</button
-										>
-										<span class="text-xs text-gray-600">{lectureVideoRegenerateHelperText}</span>
+									<div class="mb-2 flex flex-col gap-2 text-sm text-gray-600">
+										<div class="flex flex-wrap items-center gap-3">
+											<button
+												type="button"
+												class={`${lectureVideoAudioRegenerateButtonPressed ? 'border-blue-300 bg-blue-100 font-semibold text-blue-800 shadow-inner shadow-blue-200' : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'} inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-70`}
+												disabled={preventEdits ||
+													manifestGenerationInFlight ||
+													lectureVideoAudioTriggeredByFormChanges ||
+													lectureVideoSaveTriggersGeneration ||
+													regenerateRequested}
+												aria-pressed={lectureVideoAudioRegenerateButtonPressed}
+												onclick={() => {
+													regenerateAudioRequested = !regenerateAudioRequested;
+												}}
+											>
+												<RefreshOutline class="h-3 w-3" />
+												<span>{lectureVideoAudioRegenerateButtonLabel}</span>
+											</button>
+											<span class="text-xs text-gray-600"
+												>{lectureVideoAudioRegenerateHelperText}</span
+											>
+										</div>
+										{#if canGenerateLectureVideoManifest && !overwriteManifest}
+											<div class="flex flex-wrap items-center gap-3">
+												<button
+													type="button"
+													class={`${lectureVideoManifestRegenerateButtonPressed ? 'border-blue-300 bg-blue-100 font-semibold text-blue-800 shadow-inner shadow-blue-200' : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'} inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-70`}
+													disabled={preventEdits ||
+														manifestGenerationInFlight ||
+														lectureVideoGenerationTriggeredByFormChanges}
+													aria-pressed={lectureVideoManifestRegenerateButtonPressed}
+													onclick={() => {
+														regenerateRequested = !regenerateRequested;
+													}}
+												>
+													<RefreshOutline class="h-3 w-3" />
+													<span>{lectureVideoManifestRegenerateButtonLabel}</span>
+												</button>
+												<span class="text-xs text-gray-600"
+													>{lectureVideoManifestRegenerateHelperText}</span
+												>
+											</div>
+										{/if}
 									</div>
 								{/if}
 								{#if lectureVideoChatUnavailable}


### PR DESCRIPTION
## Lecture Videos (Preview)
### New Features
* Request regeneration of narration tracks only, under Advanced Options. Requesting a manifest regeneration is still available and will also regenerate the narration tracks.

### Updates & Improvements
* When updating the assistant's Voice ID, the UI will note that narration tracks will be regenerated. There is no change in server behavior.