### PR TITLE
feat(slide): implement lecture slide control endpoints

### DIFF
--- a/alembic/versions/a2d9e4f6b7c8_add_lecture_slide_interaction_mode.py
+++ b/alembic/versions/a2d9e4f6b7c8_add_lecture_slide_interaction_mode.py
@@ -1,0 +1,168 @@
+"""Add lecture slide interaction mode
+
+Revision ID: a2d9e4f6b7c8
+Revises: 8fb2a14e9c6d
+Create Date: 2026-05-29 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a2d9e4f6b7c8"
+down_revision: Union[str, None] = "8fb2a14e9c6d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+enum_name = "interactionmode"
+temp_enum_name = f"temp_{enum_name}"
+old_values = ("CHAT", "VOICE", "LECTURE_VIDEO")
+new_values = (*old_values, "LECTURE_SLIDES")
+old_type = sa.Enum(*old_values, name=enum_name)
+new_type = sa.Enum(*new_values, name=enum_name)
+temp_type = sa.Enum(*new_values, name=temp_enum_name)
+
+column_name = "interaction_mode"
+
+assistants_table = "assistants"
+assistants_simplified = sa.sql.table(
+    assistants_table, sa.Column(column_name, new_type, nullable=False)
+)
+
+threads_table = "threads"
+threads_simplified = sa.sql.table(
+    threads_table, sa.Column(column_name, new_type, nullable=False)
+)
+
+
+def upgrade() -> None:
+    # Resolves CodeQL's py/unused-global-variable
+    _ = revision, down_revision, branch_labels, depends_on
+
+    op.execute(
+        f"ALTER TABLE {assistants_table} ALTER COLUMN {column_name} DROP DEFAULT"
+    )
+    op.execute(f"ALTER TABLE {threads_table} ALTER COLUMN {column_name} DROP DEFAULT")
+
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table(assistants_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"{column_name}::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table(threads_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=old_type,
+            type_=temp_type,
+            postgresql_using=f"{column_name}::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    old_type.drop(op.get_bind(), checkfirst=False)
+    new_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table(assistants_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"{column_name}::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table(threads_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=temp_type,
+            type_=new_type,
+            postgresql_using=f"{column_name}::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)
+
+    op.execute(
+        f"ALTER TABLE {assistants_table} ALTER COLUMN {column_name} SET DEFAULT 'CHAT'::{enum_name}"
+    )
+    op.execute(
+        f"ALTER TABLE {threads_table} ALTER COLUMN {column_name} SET DEFAULT 'CHAT'::{enum_name}"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        threads_simplified.delete().where(
+            threads_simplified.c.interaction_mode == "LECTURE_SLIDES"
+        )
+    )
+    op.execute(
+        assistants_simplified.delete().where(
+            assistants_simplified.c.interaction_mode == "LECTURE_SLIDES"
+        )
+    )
+
+    op.execute(
+        f"ALTER TABLE {assistants_table} ALTER COLUMN {column_name} DROP DEFAULT"
+    )
+    op.execute(f"ALTER TABLE {threads_table} ALTER COLUMN {column_name} DROP DEFAULT")
+
+    temp_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table(assistants_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"{column_name}::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table(threads_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=new_type,
+            type_=temp_type,
+            postgresql_using=f"{column_name}::text::{temp_enum_name}",
+            existing_nullable=False,
+        )
+
+    new_type.drop(op.get_bind(), checkfirst=False)
+    old_type.create(op.get_bind(), checkfirst=False)
+
+    with op.batch_alter_table(assistants_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"{column_name}::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table(threads_table) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=temp_type,
+            type_=old_type,
+            postgresql_using=f"{column_name}::text::{enum_name}",
+            existing_nullable=False,
+        )
+
+    temp_type.drop(op.get_bind(), checkfirst=False)
+
+    op.execute(
+        f"ALTER TABLE {assistants_table} ALTER COLUMN {column_name} SET DEFAULT 'CHAT'::{enum_name}"
+    )
+    op.execute(
+        f"ALTER TABLE {threads_table} ALTER COLUMN {column_name} SET DEFAULT 'CHAT'::{enum_name}"
+    )

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -428,7 +428,7 @@ class InteractionMode(StrEnum):
     CHAT = "chat"
     VOICE = "voice"
     LECTURE_VIDEO = "lecture_video"
-    LECTURE_SLIDE = "lecture_slide"
+    LECTURE_SLIDES = "lecture_slides"
 
 
 class RealtimeEagerness(StrEnum):

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -428,6 +428,7 @@ class InteractionMode(StrEnum):
     CHAT = "chat"
     VOICE = "voice"
     LECTURE_VIDEO = "lecture_video"
+    LECTURE_SLIDE = "lecture_slide"
 
 
 class RealtimeEagerness(StrEnum):
@@ -637,6 +638,28 @@ class InteractiveLessonSession(BaseModel):
     controller: InteractiveLessonSessionController
 
 
+class InteractiveLessonControlAcquireResponse(BaseModel):
+    controller_session_id: str
+    interactive_lesson_session: InteractiveLessonSession
+
+
+class InteractiveLessonControlReleaseRequest(BaseModel):
+    controller_session_id: str = Field(..., min_length=1)
+
+
+class InteractiveLessonControlReleaseResponse(BaseModel):
+    interactive_lesson_session: InteractiveLessonSession
+
+
+class InteractiveLessonControlRenewRequest(BaseModel):
+    controller_session_id: str = Field(..., min_length=1)
+
+
+class InteractiveLessonControlRenewResponse(BaseModel):
+    lease_expires_at: datetime
+    lease_duration_ms: int = Field(..., ge=0)
+
+
 class InteractiveLessonInteractionRequestBase(BaseModel):
     controller_session_id: str = Field(..., min_length=1)
     expected_state_version: int = Field(..., ge=1)
@@ -697,6 +720,10 @@ InteractiveLessonInteractionRequest: TypeAlias = Annotated[
     ],
     PropertyInfo(discriminator="type"),
 ]
+
+
+class InteractiveLessonInteractionResponse(BaseModel):
+    interactive_lesson_session: InteractiveLessonSession
 
 
 class AnonymousLink(BaseModel):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -585,7 +585,7 @@ async def get_lecture_slide_thread_or_404(
     )
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
-    if thread.interaction_mode != schemas.InteractionMode.LECTURE_SLIDE:
+    if thread.interaction_mode != schemas.InteractionMode.LECTURE_SLIDES:
         raise HTTPException(status_code=404, detail="Lecture slide thread not found.")
     return thread
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -120,6 +120,7 @@ from pingpong.video_store import VideoStoreError
 
 from . import (
     assistant_service,
+    lecture_slide_runtime,
     lecture_video_chat,
     lecture_video_manifest_generation,
     lecture_video_processing,
@@ -546,6 +547,23 @@ def _raise_lecture_video_runtime_http_error(
     raise HTTPException(status_code=500, detail=err.detail)
 
 
+def _raise_lecture_slide_runtime_http_error(
+    err: lecture_slide_runtime.LectureSlideRuntimeError,
+) -> NoReturn:
+    if isinstance(err, lecture_slide_runtime.LectureSlideNotFoundError):
+        raise HTTPException(status_code=404, detail=err.detail)
+    if isinstance(err, lecture_slide_runtime.LectureSlideValidationError):
+        raise HTTPException(status_code=422, detail=err.detail)
+    if isinstance(err, lecture_slide_runtime.LectureSlideConflictError):
+        if err.error_code is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={"message": err.detail, "error_code": err.error_code},
+            )
+        raise HTTPException(status_code=409, detail=err.detail)
+    raise HTTPException(status_code=500, detail=err.detail)
+
+
 async def get_lecture_video_thread_or_404(
     db: Any, class_id: str, thread_id: str
 ) -> models.Thread:
@@ -556,6 +574,19 @@ async def get_lecture_video_thread_or_404(
         raise HTTPException(status_code=404, detail="Thread not found")
     if thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO:
         raise HTTPException(status_code=404, detail="Lecture video thread not found.")
+    return thread
+
+
+async def get_lecture_slide_thread_or_404(
+    db: Any, class_id: str, thread_id: str
+) -> models.Thread:
+    thread = await models.Thread.get_by_id_for_class_with_interaction_mode(
+        db, int(class_id), int(thread_id)
+    )
+    if thread is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+    if thread.interaction_mode != schemas.InteractionMode.LECTURE_SLIDE:
+        raise HTTPException(status_code=404, detail="Lecture slide thread not found.")
     return thread
 
 
@@ -5194,6 +5225,122 @@ async def post_lecture_video_interaction(
     except lecture_video_runtime.LectureVideoRuntimeError as err:
         _raise_lecture_video_runtime_http_error(err)
     return {"lecture_video_session": lecture_video_session}
+
+
+@v1.post(
+    "/class/{class_id}/thread/{thread_id}/lecture-slide/control/acquire",
+    dependencies=[Depends(Authz("can_participate", "thread:{thread_id}"))],
+    response_model=schemas.InteractiveLessonControlAcquireResponse,
+)
+async def acquire_lecture_slide_control(
+    class_id: str,
+    thread_id: str,
+    request: StateRequest,
+):
+    thread = await get_lecture_slide_thread_or_404(
+        request.state["db"], class_id, thread_id
+    )
+    try:
+        (
+            controller_session_id,
+            interactive_lesson_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            request.state["db"],
+            thread.id,
+            request.state["session"].user.id,
+            nowfn=get_now_fn(request),
+        )
+    except lecture_slide_runtime.LectureSlideRuntimeError as err:
+        _raise_lecture_slide_runtime_http_error(err)
+
+    return {
+        "controller_session_id": controller_session_id,
+        "interactive_lesson_session": interactive_lesson_session,
+    }
+
+
+@v1.post(
+    "/class/{class_id}/thread/{thread_id}/lecture-slide/control/release",
+    dependencies=[Depends(Authz("can_participate", "thread:{thread_id}"))],
+    response_model=schemas.InteractiveLessonControlReleaseResponse,
+)
+async def release_lecture_slide_control(
+    class_id: str,
+    thread_id: str,
+    data: schemas.InteractiveLessonControlReleaseRequest,
+    request: StateRequest,
+):
+    thread = await get_lecture_slide_thread_or_404(
+        request.state["db"], class_id, thread_id
+    )
+    try:
+        interactive_lesson_session = await lecture_slide_runtime.release_control(
+            request.state["db"],
+            thread.id,
+            request.state["session"].user.id,
+            data.controller_session_id,
+            nowfn=get_now_fn(request),
+        )
+    except lecture_slide_runtime.LectureSlideRuntimeError as err:
+        _raise_lecture_slide_runtime_http_error(err)
+    return {"interactive_lesson_session": interactive_lesson_session}
+
+
+@v1.post(
+    "/class/{class_id}/thread/{thread_id}/lecture-slide/control/renew",
+    dependencies=[Depends(Authz("can_participate", "thread:{thread_id}"))],
+    response_model=schemas.InteractiveLessonControlRenewResponse,
+)
+async def renew_lecture_slide_control(
+    class_id: str,
+    thread_id: str,
+    data: schemas.InteractiveLessonControlRenewRequest,
+    request: StateRequest,
+):
+    thread = await get_lecture_slide_thread_or_404(
+        request.state["db"], class_id, thread_id
+    )
+    try:
+        lease_expires_at = await lecture_slide_runtime.renew_control(
+            request.state["db"],
+            thread.id,
+            request.state["session"].user.id,
+            data.controller_session_id,
+            nowfn=get_now_fn(request),
+        )
+    except lecture_slide_runtime.LectureSlideRuntimeError as err:
+        _raise_lecture_slide_runtime_http_error(err)
+    return {
+        "lease_expires_at": lease_expires_at,
+        "lease_duration_ms": lecture_slide_runtime.CONTROLLER_LEASE_DURATION_MS,
+    }
+
+
+@v1.post(
+    "/class/{class_id}/thread/{thread_id}/lecture-slide/interactions",
+    dependencies=[Depends(Authz("can_participate", "thread:{thread_id}"))],
+    response_model=schemas.InteractiveLessonInteractionResponse,
+)
+async def post_lecture_slide_interaction(
+    class_id: str,
+    thread_id: str,
+    data: schemas.InteractiveLessonInteractionRequest,
+    request: StateRequest,
+):
+    thread = await get_lecture_slide_thread_or_404(
+        request.state["db"], class_id, thread_id
+    )
+    try:
+        interactive_lesson_session = await lecture_slide_runtime.process_interaction(
+            request.state["db"],
+            thread.id,
+            request.state["session"].user.id,
+            data,
+            nowfn=get_now_fn(request),
+        )
+    except lecture_slide_runtime.LectureSlideRuntimeError as err:
+        _raise_lecture_slide_runtime_http_error(err)
+    return {"interactive_lesson_session": interactive_lesson_session}
 
 
 @v1.get(

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -1,6 +1,9 @@
+import importlib
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import asc, select
 
 import pingpong.lecture_slide_runtime as lecture_slide_runtime
@@ -9,6 +12,7 @@ import pingpong.schemas as schemas
 from pingpong.testutil import with_institution
 
 pytestmark = pytest.mark.asyncio
+server_module = importlib.import_module("pingpong.server")
 
 
 def _slide_deck(
@@ -143,6 +147,16 @@ async def _list_slide_interactions(
     return list(result)
 
 
+def _server_request(session, user_id: int = 123):
+    return SimpleNamespace(
+        state={
+            "db": session,
+            "session": SimpleNamespace(user=SimpleNamespace(id=user_id)),
+        },
+        app=SimpleNamespace(state={}),
+    )
+
+
 @with_institution(11, "Test Institution")
 async def test_initialize_thread_state_and_acquire_control_for_lecture_slides(
     db, institution
@@ -180,6 +194,51 @@ async def test_initialize_thread_state_and_acquire_control_for_lecture_slides(
     assert [marker.id for marker in slide_session.question_markers] == [
         question.id for question in questions
     ]
+
+
+@with_institution(11, "Test Institution")
+async def test_acquire_lecture_slide_control_endpoint_uses_generic_lesson_session(
+    db, institution
+):
+    async with db.async_session() as session:
+        class_, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution
+        )
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDE
+        await session.flush()
+
+        response = await server_module.acquire_lecture_slide_control(
+            str(class_.id),
+            str(thread.id),
+            _server_request(session),
+        )
+
+    assert response["controller_session_id"]
+    lesson_session = response["interactive_lesson_session"]
+    assert isinstance(lesson_session, schemas.InteractiveLessonSession)
+    assert lesson_session.controller.has_control is True
+    assert lesson_session.current_question is not None
+    assert lesson_session.current_question.id == questions[0].id
+
+
+@with_institution(11, "Test Institution")
+async def test_acquire_lecture_slide_control_endpoint_rejects_non_slide_thread(
+    db, institution
+):
+    async with db.async_session() as session:
+        class_, _, _, thread, _ = await _create_slide_runtime_fixture(
+            session, institution
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await server_module.acquire_lecture_slide_control(
+                str(class_.id),
+                str(thread.id),
+                _server_request(session),
+            )
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.detail == "Lecture slide thread not found."
 
 
 @with_institution(11, "Test Institution")

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -204,7 +204,7 @@ async def test_acquire_lecture_slide_control_endpoint_uses_generic_lesson_sessio
         class_, _, _, thread, questions = await _create_slide_runtime_fixture(
             session, institution
         )
-        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDE
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
         await session.flush()
 
         response = await server_module.acquire_lecture_slide_control(


### PR DESCRIPTION
- Added new interaction mode for lecture slides in schemas.
- Implemented endpoints for acquiring, releasing, and renewing control of lecture slides.
- Introduced error handling for lecture slide runtime errors.
- Updated tests to cover new lecture slide control functionality.