### PR TITLE
feat(slide): implement retry functionality for lecture slide processing

### DIFF
--- a/pingpong/interactive_lesson_runtime.py
+++ b/pingpong/interactive_lesson_runtime.py
@@ -524,9 +524,7 @@ async def initialize_thread_state(
 
     state_data = {
         "thread_id": thread.id,
-        "state": (
-            state_enum.PLAYING if first_question is not None else state_enum.COMPLETED
-        ),
+        "state": state_enum.PLAYING,
         "current_question_id": first_question.id
         if first_question is not None
         else None,

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -779,6 +779,19 @@ async def process_claimed_run(assignment: RunAssignment) -> None:
     await _process_claimed_slide_run(assignment.run_id, assignment.lease_token)
 
 
+async def _deck_has_slide_manifest(deck_id: int) -> bool:
+    async with config.db.driver.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id(session, deck_id)
+        if deck is None or deck.context_version != 4:
+            return False
+        question_count = await session.scalar(
+            select(func.count(models.LectureSlideQuestion.id)).where(
+                models.LectureSlideQuestion.lecture_slide_deck_id == deck_id
+            )
+        )
+        return bool(question_count)
+
+
 async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
     try:
         async with config.db.driver.async_session() as session:
@@ -903,10 +916,12 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                 )
                 if transcript is None:
                     return
+                has_manifest = await _deck_has_slide_manifest(deck_id)
                 start_stage = (
                     schemas.LectureSlideProcessingStage.COMPOSITE_ARTIFACTS
                     if original_start_stage
                     == schemas.LectureSlideProcessingStage.NARRATION_AUDIO
+                    and has_manifest
                     else schemas.LectureSlideProcessingStage.MANIFEST_GENERATION
                 )
 

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -1451,6 +1451,9 @@ async def _persist_narration_text(
                 raise ValueError(f"Missing narration for slide {page.position}.")
             page.title = generated.title
             page.narration_text = generated.narration_text
+            page.narration_id = None
+            page.start_offset_ms = None
+            page.end_offset_ms = None
             session.add(page)
         await session.commit()
 
@@ -1471,7 +1474,7 @@ async def _synthesize_slide_audio(
         pages = [
             (page.id, page.position, page.narration_text or "")
             for page in sorted(deck.pages, key=lambda item: item.position)
-            if text_needs_audio(page.narration_text or "")
+            if page.narration_id is None and text_needs_audio(page.narration_text or "")
         ]
     if not pages:
         return []
@@ -1586,11 +1589,12 @@ async def _transcribe_and_persist_slide_audio(
     openai_client: openai.AsyncClient | openai.AsyncAzureOpenAI,
     temp_dir: str,
 ) -> list[schemas.LectureVideoManifestWordV3] | None:
-    words: list[schemas.LectureVideoManifestWordV3] = []
-    current_offset_ms = 0
-    page_timings: dict[int, tuple[int, int]] = {}
+    artifacts_by_page_id = {artifact.page_id: artifact for artifact in slide_audio}
+    transcribed_words_by_page_id: dict[
+        int, list[schemas.LectureVideoManifestWordV3]
+    ] = {}
     for artifact in sorted(slide_audio, key=lambda item: item.page_position):
-        slide_path = os.path.join(temp_dir, f"slide-{artifact.page_position}.audio")
+        slide_path = os.path.join(temp_dir, f"slide-{artifact.page_position}.ogg")
         Path(slide_path).write_bytes(artifact.audio)
         slide_words = await _await_with_run_lease_heartbeat(
             run_id,
@@ -1599,20 +1603,7 @@ async def _transcribe_and_persist_slide_audio(
         )
         if slide_words is None:
             return None
-        for word_index, word in enumerate(slide_words):
-            words.append(
-                schemas.LectureVideoManifestWordV3(
-                    id=f"slide-{artifact.page_position}-word-{word_index}",
-                    word=word.word,
-                    start_offset_ms=word.start_offset_ms + current_offset_ms,
-                    end_offset_ms=word.end_offset_ms + current_offset_ms,
-                )
-            )
-        page_timings[artifact.page_id] = (
-            current_offset_ms,
-            current_offset_ms + artifact.duration_ms,
-        )
-        current_offset_ms += artifact.duration_ms
+        transcribed_words_by_page_id[artifact.page_id] = slide_words
 
     async with config.db.driver.async_session() as session:
         run = await models.LectureSlideProcessingRun.get_by_id(session, run_id)
@@ -1626,11 +1617,71 @@ async def _transcribe_and_persist_slide_audio(
             or run.lease_token != lease_token
         ):
             return None
-        for page in deck.pages:
-            start, end = page_timings.get(page.id, (None, None))
-            page.start_offset_ms = start
-            page.end_offset_ms = end
+        old_transcript = []
+        if deck.transcript_data is not None:
+            raw_words = deck.transcript_data.get("word_level_transcription")
+            if isinstance(raw_words, list):
+                old_transcript = [
+                    schemas.LectureVideoManifestWordV3.model_validate(word)
+                    for word in raw_words
+                ]
+
+        words: list[schemas.LectureVideoManifestWordV3] = []
+        current_offset_ms = 0
+        for page in sorted(deck.pages, key=lambda item: item.position):
+            page_artifact = artifacts_by_page_id.get(page.id)
+            if page_artifact is not None:
+                duration_ms = page_artifact.duration_ms
+            elif (
+                page.narration is not None and page.narration.stored_object is not None
+            ):
+                duration_ms = page.narration.stored_object.duration_ms or 0
+            else:
+                duration_ms = 0
+
+            old_start_offset_ms = page.start_offset_ms
+            old_end_offset_ms = page.end_offset_ms
+            start_offset_ms = current_offset_ms if duration_ms > 0 else None
+            end_offset_ms = current_offset_ms + duration_ms if duration_ms > 0 else None
+
+            if page_artifact is not None and start_offset_ms is not None:
+                for word_index, word in enumerate(
+                    transcribed_words_by_page_id.get(page.id, [])
+                ):
+                    words.append(
+                        schemas.LectureVideoManifestWordV3(
+                            id=f"slide-{page_artifact.page_position}-word-{word_index}",
+                            word=word.word,
+                            start_offset_ms=word.start_offset_ms + start_offset_ms,
+                            end_offset_ms=word.end_offset_ms + start_offset_ms,
+                        )
+                    )
+            elif (
+                old_start_offset_ms is not None
+                and old_end_offset_ms is not None
+                and start_offset_ms is not None
+            ):
+                offset_delta_ms = start_offset_ms - old_start_offset_ms
+                for word in _transcript_for_slide_window(
+                    old_transcript,
+                    start_offset_ms=old_start_offset_ms,
+                    end_offset_ms=old_end_offset_ms,
+                ):
+                    words.append(
+                        word.model_copy(
+                            update={
+                                "start_offset_ms": word.start_offset_ms
+                                + offset_delta_ms,
+                                "end_offset_ms": word.end_offset_ms + offset_delta_ms,
+                            }
+                        )
+                    )
+
+            page.start_offset_ms = start_offset_ms
+            page.end_offset_ms = end_offset_ms
             session.add(page)
+            current_offset_ms += duration_ms
+
         deck.total_duration_ms = current_offset_ms
         deck.transcript_data = transcript_data_from_words(words)
         session.add(deck)

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -29,6 +29,7 @@ LECTURE_SLIDE_DECK_ALREADY_ASSIGNED_DETAIL = (
 class LectureSlidePageUpdateResult:
     notes_changed: bool = False
     narration_changed: bool = False
+    narration_changed_positions: frozenset[int] = frozenset()
 
 
 def generate_source_store_key() -> str:
@@ -231,7 +232,20 @@ async def apply_lecture_slide_page_notes(
 ) -> LectureSlidePageUpdateResult:
     notes_changed = False
     narration_changed = False
-    for note in notes:
+    narration_changed_positions: set[int] = set()
+    notes_by_position = {note.position: note for note in notes}
+    pages_by_position = {
+        page.position: page
+        for page in (
+            await session.scalars(
+                select(models.LectureSlidePage).where(
+                    models.LectureSlidePage.lecture_slide_deck_id == deck.id,
+                    models.LectureSlidePage.position.in_(notes_by_position),
+                )
+            )
+        ).all()
+    }
+    for note in notes_by_position.values():
         if note.position >= deck.slide_count:
             raise HTTPException(
                 status_code=400,
@@ -239,9 +253,7 @@ async def apply_lecture_slide_page_notes(
             )
         user_notes = (note.user_notes or "").strip() or None
         narration_text = (note.narration_text or "").strip() or None
-        page = next(
-            (page for page in deck.pages if page.position == note.position), None
-        )
+        page = pages_by_position.get(note.position)
         if page is None:
             if user_notes is None and narration_text is None:
                 continue
@@ -251,10 +263,11 @@ async def apply_lecture_slide_page_notes(
                 user_notes=user_notes,
                 narration_text=narration_text,
             )
-            deck.pages.append(page)
             session.add(page)
             notes_changed = notes_changed or user_notes is not None
             narration_changed = narration_changed or narration_text is not None
+            if narration_text is not None:
+                narration_changed_positions.add(note.position)
             continue
         if page.user_notes != user_notes:
             page.user_notes = user_notes
@@ -262,13 +275,37 @@ async def apply_lecture_slide_page_notes(
             notes_changed = True
         if page.narration_text != narration_text:
             page.narration_text = narration_text
+            page.narration_id = None
+            page.start_offset_ms = None
+            page.end_offset_ms = None
             session.add(page)
             narration_changed = True
+            narration_changed_positions.add(note.position)
     if notes_changed or narration_changed:
         await session.flush()
     return LectureSlidePageUpdateResult(
         notes_changed=notes_changed,
         narration_changed=narration_changed,
+        narration_changed_positions=frozenset(narration_changed_positions),
+    )
+
+
+async def lecture_slide_deck_has_pages(session: AsyncSession, deck_id: int) -> bool:
+    page_id = await session.scalar(
+        select(models.LectureSlidePage.id)
+        .where(models.LectureSlidePage.lecture_slide_deck_id == deck_id)
+        .limit(1)
+    )
+    return page_id is not None
+
+
+async def clear_lecture_slide_page_narrations(
+    session: AsyncSession, deck_id: int
+) -> None:
+    await session.execute(
+        update(models.LectureSlidePage)
+        .where(models.LectureSlidePage.lecture_slide_deck_id == deck_id)
+        .values(narration_id=None, start_offset_ms=None, end_offset_ms=None)
     )
 
 

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -302,11 +302,141 @@ async def lecture_slide_deck_has_pages(session: AsyncSession, deck_id: int) -> b
 async def clear_lecture_slide_page_narrations(
     session: AsyncSession, deck_id: int
 ) -> None:
+    narration_ids = list(
+        (
+            await session.scalars(
+                select(models.LectureSlidePage.narration_id).where(
+                    models.LectureSlidePage.lecture_slide_deck_id == deck_id,
+                    models.LectureSlidePage.narration_id.is_not(None),
+                )
+            )
+        ).all()
+    )
     await session.execute(
         update(models.LectureSlidePage)
         .where(models.LectureSlidePage.lecture_slide_deck_id == deck_id)
         .values(narration_id=None, start_offset_ms=None, end_offset_ms=None)
     )
+    audio_keys = await _delete_lecture_slide_narrations_if_unused(
+        session, narration_ids
+    )
+    await _delete_lecture_slide_audio_keys_quietly(audio_keys)
+
+
+async def _delete_lecture_slide_narrations_if_unused(
+    session: AsyncSession, narration_ids: Iterable[int | None]
+) -> list[str]:
+    candidate_narration_ids = list(dict.fromkeys(id_ for id_ in narration_ids if id_))
+    if not candidate_narration_ids:
+        return []
+
+    referenced_narration_ids: set[int] = set()
+    for column in (
+        models.LectureSlidePage.narration_id,
+        models.LectureSlideQuestion.intro_narration_id,
+        models.LectureSlideQuestionOption.post_narration_id,
+    ):
+        referenced_narration_ids.update(
+            (
+                await session.scalars(
+                    select(column).where(column.in_(candidate_narration_ids))
+                )
+            ).all()
+        )
+
+    unused_narration_ids = [
+        id_ for id_ in candidate_narration_ids if id_ not in referenced_narration_ids
+    ]
+    if not unused_narration_ids:
+        return []
+
+    stored_object_rows = list(
+        (
+            await session.execute(
+                select(
+                    models.LectureSlideNarration.stored_object_id,
+                    models.LectureSlideNarrationStoredObject.key,
+                )
+                .join(
+                    models.LectureSlideNarrationStoredObject,
+                    models.LectureSlideNarrationStoredObject.id
+                    == models.LectureSlideNarration.stored_object_id,
+                )
+                .where(models.LectureSlideNarration.id.in_(unused_narration_ids))
+            )
+        ).all()
+    )
+
+    await session.execute(
+        delete(models.LectureSlideNarration).where(
+            models.LectureSlideNarration.id.in_(unused_narration_ids)
+        )
+    )
+    return await _delete_lecture_slide_narration_stored_objects_if_unused(
+        session,
+        [
+            (stored_object_id, key)
+            for stored_object_id, key in stored_object_rows
+            if stored_object_id is not None
+        ],
+    )
+
+
+async def _delete_lecture_slide_narration_stored_objects_if_unused(
+    session: AsyncSession, stored_object_rows: Iterable[tuple[int, str]]
+) -> list[str]:
+    stored_object_keys_by_id = {
+        stored_object_id: key for stored_object_id, key in stored_object_rows
+    }
+    if not stored_object_keys_by_id:
+        return []
+
+    stored_object_ids = list(stored_object_keys_by_id)
+    referenced_stored_object_ids = set(
+        (
+            await session.scalars(
+                select(models.LectureSlideNarration.stored_object_id).where(
+                    models.LectureSlideNarration.stored_object_id.in_(stored_object_ids)
+                )
+            )
+        ).all()
+    )
+    referenced_stored_object_ids.update(
+        (
+            await session.scalars(
+                select(
+                    models.LectureSlideDeck.continuous_narration_stored_object_id
+                ).where(
+                    models.LectureSlideDeck.continuous_narration_stored_object_id.in_(
+                        stored_object_ids
+                    )
+                )
+            )
+        ).all()
+    )
+
+    unused_stored_object_ids = [
+        id_ for id_ in stored_object_ids if id_ not in referenced_stored_object_ids
+    ]
+    if not unused_stored_object_ids:
+        return []
+
+    await session.execute(
+        delete(models.LectureSlideNarrationStoredObject).where(
+            models.LectureSlideNarrationStoredObject.id.in_(unused_stored_object_ids)
+        )
+    )
+    return [stored_object_keys_by_id[id_] for id_ in unused_stored_object_ids]
+
+
+async def _delete_lecture_slide_audio_keys_quietly(keys: Iterable[str]) -> None:
+    if not config.lecture_video_audio_store:
+        return
+    for key in keys:
+        try:
+            await config.lecture_video_audio_store.store.delete_file(key)
+        except Exception:
+            logger.exception("Failed to clean up lecture slide audio key=%s", key)
 
 
 async def clone_lecture_slide_deck_snapshot(
@@ -465,7 +595,82 @@ async def delete_lecture_slide_deck_if_unused(
         .where(models.LectureSlideProcessingRun.lecture_slide_deck_id == deck_id)
         .values(lecture_slide_deck_id=None)
     )
+    page_narration_ids = list(
+        (
+            await session.scalars(
+                select(models.LectureSlidePage.narration_id).where(
+                    models.LectureSlidePage.lecture_slide_deck_id == deck_id,
+                    models.LectureSlidePage.narration_id.is_not(None),
+                )
+            )
+        ).all()
+    )
+    question_narration_ids = list(
+        (
+            await session.scalars(
+                select(models.LectureSlideQuestion.intro_narration_id).where(
+                    models.LectureSlideQuestion.lecture_slide_deck_id == deck_id,
+                    models.LectureSlideQuestion.intro_narration_id.is_not(None),
+                )
+            )
+        ).all()
+    )
+    option_narration_ids = list(
+        (
+            await session.scalars(
+                select(models.LectureSlideQuestionOption.post_narration_id)
+                .join(
+                    models.LectureSlideQuestion,
+                    models.LectureSlideQuestion.id
+                    == models.LectureSlideQuestionOption.question_id,
+                )
+                .where(
+                    models.LectureSlideQuestion.lecture_slide_deck_id == deck_id,
+                    models.LectureSlideQuestionOption.post_narration_id.is_not(None),
+                )
+            )
+        ).all()
+    )
+    question_ids = list(
+        (
+            await session.scalars(
+                select(models.LectureSlideQuestion.id).where(
+                    models.LectureSlideQuestion.lecture_slide_deck_id == deck_id
+                )
+            )
+        ).all()
+    )
+    if question_ids:
+        await session.execute(
+            delete(
+                models.lecture_slide_question_single_select_correct_option_association
+            ).where(
+                models.lecture_slide_question_single_select_correct_option_association.c.question_id.in_(
+                    question_ids
+                )
+            )
+        )
+        await session.execute(
+            delete(models.LectureSlideQuestionOption).where(
+                models.LectureSlideQuestionOption.question_id.in_(question_ids)
+            )
+        )
+        await session.execute(
+            delete(models.LectureSlideQuestion).where(
+                models.LectureSlideQuestion.id.in_(question_ids)
+            )
+        )
+    await session.execute(
+        delete(models.LectureSlidePage).where(
+            models.LectureSlidePage.lecture_slide_deck_id == deck_id
+        )
+    )
     await session.execute(
         delete(models.LectureSlideDeck).where(models.LectureSlideDeck.id == deck_id)
     )
+    audio_keys = await _delete_lecture_slide_narrations_if_unused(
+        session,
+        [*page_narration_ids, *question_narration_ids, *option_narration_ids],
+    )
     await session.flush()
+    await _delete_lecture_slide_audio_keys_quietly(audio_keys)

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -760,6 +760,28 @@ class LectureSlidePageView(BaseModel):
     narration_text: str | None = None
 
 
+class LectureSlideQuestionOptionView(BaseModel):
+    id: int
+    option_text: str
+    post_answer_text: str | None = None
+    continue_slide_position: int | None = Field(None, ge=0)
+    continue_slide_offset_ms: int | None = Field(None, ge=0)
+    continue_offset_ms: int = Field(..., ge=0)
+    correct: bool = False
+
+
+class LectureSlideQuestionView(BaseModel):
+    id: int
+    position: int
+    slide_position: int = Field(..., ge=0)
+    slide_offset_ms: int = Field(..., ge=0)
+    stop_offset_ms: int = Field(..., ge=0)
+    type: LectureSlideQuestionType
+    question_text: str
+    intro_text: str
+    options: list[LectureSlideQuestionOptionView] = Field(default_factory=list)
+
+
 class LectureSlideDeckView(BaseModel):
     id: int
     display_name: str
@@ -1117,6 +1139,7 @@ class LectureSlideConfigResponse(BaseModel):
     generation_prompt: str | None = None
     narration_prompt: str | None = None
     pages: list["LectureSlidePageView"] = Field(default_factory=list)
+    questions: list["LectureSlideQuestionView"] = Field(default_factory=list)
     processing_status: LectureVideoProcessingRunSummary | None = None
 
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -356,14 +356,23 @@ def _lecture_video_matches_assistant(
     )
 
 
-def _lecture_video_dual_text_enabled(thread: models.Thread) -> bool:
-    return thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
+def _is_lecture_lesson_mode(interaction_mode: schemas.InteractionMode | None) -> bool:
+    return interaction_mode in {
+        schemas.InteractionMode.LECTURE_VIDEO,
+        schemas.InteractionMode.LECTURE_SLIDES,
+    }
 
 
-def _lecture_video_followups_enabled(thread: models.Thread) -> bool:
-    # Intentionally mirrors _lecture_video_dual_text_enabled; both are gated on
-    # LECTURE_VIDEO mode. Keep these conditions in sync if either changes.
-    return thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
+def _lecture_lesson_dual_text_enabled(thread: models.Thread) -> bool:
+    return _is_lecture_lesson_mode(thread.interaction_mode)
+
+
+def _lecture_lesson_followups_enabled(thread: models.Thread) -> bool:
+    return _is_lecture_lesson_mode(thread.interaction_mode)
+
+
+def _allows_first_message_without_prior_run(thread: models.Thread) -> bool:
+    return _is_lecture_lesson_mode(thread.interaction_mode)
 
 
 def _build_run_instructions(
@@ -373,18 +382,18 @@ def _build_run_instructions(
 ) -> str | None:
     """Return the effective instructions for a run or prompt inspection.
 
-    Lecture-video threads compute formatting fresh per run so that prompt
+    Lecture lesson threads compute formatting fresh per run so that prompt
     segment updates (say snippets, follow-ups, LaTeX/diagrams) take effect on
     existing threads. Other modes continue to use the thread's stored
     instructions verbatim.
     """
-    if thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO:
+    if _is_lecture_lesson_mode(thread.interaction_mode):
         base_instructions = thread.instructions
         if base_instructions is None:
             base_instructions = asst.instructions or ""
         return format_instructions(
             base_instructions,
-            use_latex=asst.use_latex,
+            use_latex=True,
             use_image_descriptions=asst.use_image_descriptions,
             disable_prompt_randomization=asst.disable_prompt_randomization,
             thread_id=str(thread.id),
@@ -424,7 +433,7 @@ async def _ensure_thread_instructions_migrated(
     if thread.instructions is not None:
         session.add(thread)
         return
-    elif thread.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO:
+    elif _is_lecture_lesson_mode(thread.interaction_mode):
         logger.info(
             "Thread %s does not have instructions set, migrating from assistant instructions",
             thread.id,
@@ -453,9 +462,9 @@ async def _ensure_thread_instructions_migrated(
 
 
 def _display_text_for_thread(thread: models.Thread, text: str) -> str:
-    if _lecture_video_followups_enabled(thread):
+    if _lecture_lesson_followups_enabled(thread):
         text = strip_followup_snippets(text)
-    if _lecture_video_dual_text_enabled(thread):
+    if _lecture_lesson_dual_text_enabled(thread):
         text = transform_say_text(text, "display")
     return text
 
@@ -463,7 +472,7 @@ def _display_text_for_thread(thread: models.Thread, text: str) -> str:
 def _followup_suggestions_for_thread(
     thread: models.Thread, text: str | None
 ) -> list[str]:
-    if not _lecture_video_followups_enabled(thread):
+    if not _lecture_lesson_followups_enabled(thread):
         return []
     return extract_followup_suggestions(text or "")
 
@@ -3309,7 +3318,7 @@ def _get_lecture_video_provider_prerequisite_message(
                 "Configure an ElevenLabs credential in Manage Group to enable Lecture "
                 "Video mode."
             )
-        return "Lecture Video mode is in active development."
+        return "Lecture Video mode is in active development"
 
     if (
         not class_context["has_gemini_credential"]
@@ -3326,7 +3335,7 @@ def _get_lecture_video_provider_prerequisite_message(
             "Configure an ElevenLabs credential in Manage Group to enable Lecture "
             "Video mode."
         )
-    return "Lecture Video mode is in active development."
+    return "Lecture Video mode is in active development"
 
 
 async def _ensure_lecture_video_manifest_generation_configured(
@@ -8521,8 +8530,8 @@ async def create_run(
                 or not asst.hide_web_search_actions,
                 show_mcp_server_call_details=is_supervisor
                 or not asst.hide_mcp_server_call_details,
-                lecture_video_dual_text_mode=_lecture_video_dual_text_enabled(thread),
-                lecture_video_followups_mode=_lecture_video_followups_enabled(thread),
+                lecture_video_dual_text_mode=_lecture_lesson_dual_text_enabled(thread),
+                lecture_video_followups_mode=_lecture_lesson_followups_enabled(thread),
             )
         except Exception as e:
             logger.exception("Error running thread")
@@ -8675,10 +8684,7 @@ async def send_message(
                 request.state["db"], thread.id
             )
 
-            if (
-                not last_run
-                and thread.interaction_mode != schemas.InteractionMode.LECTURE_VIDEO
-            ):
+            if not last_run and not _allows_first_message_without_prior_run(thread):
                 raise HTTPException(
                     status_code=500,
                     detail="We're having trouble fetching information about this conversation. If the issue persists, check <a class='underline' href='https://pingpong-hks.statuspage.io' target='_blank'>PingPong's status page</a> for updates.",
@@ -9140,8 +9146,8 @@ async def send_message(
                 tts_voice_id=tts_voice_id,
                 tts_api_key=tts_api_key,
                 tts_voice_settings=tts_voice_settings,
-                lecture_video_dual_text_mode=_lecture_video_dual_text_enabled(thread),
-                lecture_video_followups_mode=_lecture_video_followups_enabled(thread),
+                lecture_video_dual_text_mode=_lecture_lesson_dual_text_enabled(thread),
+                lecture_video_followups_mode=_lecture_lesson_followups_enabled(thread),
                 user_assistant_messages_only=(
                     lecture_chat_prep.user_assistant_messages_only
                     if lecture_chat_prep is not None
@@ -10802,6 +10808,9 @@ async def create_assistant(
     uses_voice = req.interaction_mode == schemas.InteractionMode.VOICE
     is_video = req.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
     is_slides = req.interaction_mode == schemas.InteractionMode.LECTURE_SLIDES
+    is_lesson_mode = is_video or is_slides
+    if is_lesson_mode:
+        req.use_latex = True
     lecture_video_object_id = None
     lecture_video_manifest = None
     lecture_video_voice_id = None
@@ -11225,13 +11234,13 @@ async def preview_assistant_instructions(
     return {
         "instructions_preview": format_instructions(
             req.instructions,
-            use_latex=req.use_latex,
+            use_latex=True
+            if _is_lecture_lesson_mode(req.interaction_mode)
+            else req.use_latex,
             disable_prompt_randomization=req.disable_prompt_randomization,
             user_id=request.state["session"].user.id,
             thread_id=f"preview_{uuid.uuid4()}",
-            lecture_video_mode=(
-                req.interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
-            ),
+            lecture_video_mode=_is_lecture_lesson_mode(req.interaction_mode),
         )
     }
 
@@ -11723,6 +11732,7 @@ async def update_assistant(
     uses_voice = interaction_mode == schemas.InteractionMode.VOICE
     is_video = interaction_mode == schemas.InteractionMode.LECTURE_VIDEO
     is_slides = interaction_mode == schemas.InteractionMode.LECTURE_SLIDES
+    is_lesson_mode = is_video or is_slides
     lecture_video = asst.lecture_video
     lecture_video_manifest = None
     lecture_video_voice_id = None
@@ -12451,7 +12461,11 @@ async def update_assistant(
     if update_tool_resources:
         openai_update["tool_resources"] = tool_resources
 
-    if "use_latex" in req.model_fields_set and req.use_latex is not None:
+    if is_lesson_mode:
+        if not asst.use_latex:
+            update_instructions = True
+            asst.use_latex = True
+    elif "use_latex" in req.model_fields_set and req.use_latex is not None:
         update_instructions = True
         asst.use_latex = req.use_latex
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -9730,6 +9730,65 @@ async def get_assistant_lecture_slide_source(
 
 
 @v1.get(
+    "/class/{class_id}/assistant/{assistant_id}/lecture-slides/thumbnail",
+    dependencies=[Depends(Authz("can_view", "assistant:{assistant_id}"))],
+    response_class=StreamingResponse,
+)
+async def get_assistant_lecture_slide_thumbnail(
+    class_id: str,
+    assistant_id: str,
+    request: StateRequest,
+):
+    if not config.video_store:
+        raise HTTPException(status_code=404, detail="No Video Store exists.")
+
+    assistant = await lecture_slide_service.get_lecture_slide_assistant_for_class(
+        request.state["db"], int(assistant_id), int(class_id)
+    )
+    if assistant.lecture_slide_deck_id is None:
+        raise HTTPException(status_code=404, detail="Lecture slide deck not found.")
+
+    image_stored_object_id = await request.state["db"].scalar(
+        select(models.LectureSlidePage.image_stored_object_id)
+        .where(
+            models.LectureSlidePage.lecture_slide_deck_id
+            == assistant.lecture_slide_deck_id,
+            models.LectureSlidePage.image_stored_object_id.is_not(None),
+        )
+        .order_by(models.LectureSlidePage.position)
+        .limit(1)
+    )
+    if image_stored_object_id is None:
+        raise HTTPException(status_code=404, detail="Lecture slide thumbnail not found.")
+
+    image = await request.state["db"].get(
+        models.LectureSlideImageStoredObject, image_stored_object_id
+    )
+    if image is None:
+        raise HTTPException(status_code=404, detail="Lecture slide thumbnail not found.")
+
+    try:
+        stream = await prefetch_stream(
+            config.video_store.store.stream_video_range(key=image.key),
+            store_error=VideoStoreError,
+            logger=logger,
+            store_error_log="VideoStoreError while streaming lecture slide thumbnail; aborting stream.",
+            unexpected_error_log="Unexpected error while streaming lecture slide thumbnail",
+        )
+    except VideoStoreError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unable to stream lecture slide thumbnail: {e.detail or str(e)}",
+        ) from e
+
+    return StreamingResponse(
+        stream,
+        media_type=image.content_type or "image/png",
+        headers={"Cache-Control": "private, max-age=86400"},
+    )
+
+
+@v1.get(
     "/class/{class_id}/assistant/{assistant_id}/lecture-video/poster",
     dependencies=[Depends(Authz("can_view", "assistant:{assistant_id}"))],
     response_class=StreamingResponse,
@@ -10119,6 +10178,37 @@ async def get_assistant_lecture_slide_config(
         )
         for page in sorted(deck.pages, key=lambda item: item.position)
     ]
+    questions = []
+    for question in sorted(deck.questions, key=lambda item: item.position):
+        correct_option_id = (
+            question.correct_option.id if question.correct_option is not None else None
+        )
+        questions.append(
+            schemas.LectureSlideQuestionView(
+                id=question.id,
+                position=question.position,
+                slide_position=question.slide_position,
+                slide_offset_ms=question.slide_offset_ms,
+                stop_offset_ms=question.stop_offset_ms,
+                type=question.question_type,
+                question_text=question.question_text,
+                intro_text=question.intro_text,
+                options=[
+                    schemas.LectureSlideQuestionOptionView(
+                        id=option.id,
+                        option_text=option.option_text,
+                        post_answer_text=option.post_answer_text,
+                        continue_slide_position=option.continue_slide_position,
+                        continue_slide_offset_ms=option.continue_slide_offset_ms,
+                        continue_offset_ms=option.continue_offset_ms,
+                        correct=option.id == correct_option_id,
+                    )
+                    for option in sorted(
+                        question.options, key=lambda item: item.position
+                    )
+                ],
+            )
+        )
     return schemas.LectureSlideConfigResponse(
         lecture_slide_deck=cast(
             schemas.LectureSlideSummary,
@@ -10128,6 +10218,7 @@ async def get_assistant_lecture_slide_config(
         generation_prompt=deck.generation_prompt,
         narration_prompt=deck.narration_prompt,
         pages=pages,
+        questions=questions,
         processing_status=processing_status,
     )
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -9759,13 +9759,17 @@ async def get_assistant_lecture_slide_thumbnail(
         .limit(1)
     )
     if image_stored_object_id is None:
-        raise HTTPException(status_code=404, detail="Lecture slide thumbnail not found.")
+        raise HTTPException(
+            status_code=404, detail="Lecture slide thumbnail not found."
+        )
 
     image = await request.state["db"].get(
         models.LectureSlideImageStoredObject, image_stored_object_id
     )
     if image is None:
-        raise HTTPException(status_code=404, detail="Lecture slide thumbnail not found.")
+        raise HTTPException(
+            status_code=404, detail="Lecture slide thumbnail not found."
+        )
 
     try:
         stream = await prefetch_stream(

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -10232,6 +10232,76 @@ async def retry_assistant_lecture_video_processing(
 
 
 @v1.post(
+    "/class/{class_id}/assistant/{assistant_id}/lecture-slides/retry",
+    dependencies=[Depends(Authz("can_edit", "assistant:{assistant_id}"))],
+    response_model=schemas.LectureSlideSummary,
+)
+async def retry_assistant_lecture_slide_processing(
+    class_id: str,
+    assistant_id: str,
+    request: StateRequest,
+):
+    assistant = await lecture_slide_service.get_lecture_slide_assistant_for_class(
+        request.state["db"], int(assistant_id), int(class_id)
+    )
+    if assistant.lecture_slide_deck_id is None:
+        raise HTTPException(404, "Lecture slide deck not found.")
+
+    deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+        request.state["db"], assistant.lecture_slide_deck_id
+    )
+    if deck is None or deck.class_id != int(class_id):
+        raise HTTPException(404, "Lecture slide deck not found.")
+    if deck.status != schemas.LectureSlideDeckStatus.FAILED:
+        raise HTTPException(
+            status_code=409,
+            detail="Lecture slide retry is only available after lecture slide processing fails.",
+        )
+
+    latest_failed_stage = await request.state["db"].scalar(
+        select(models.LectureSlideProcessingRun.stage)
+        .where(
+            models.LectureSlideProcessingRun.lecture_slide_deck_id_snapshot == deck.id,
+            models.LectureSlideProcessingRun.status
+            == schemas.LectureSlideProcessingRunStatus.FAILED,
+        )
+        .order_by(
+            models.LectureSlideProcessingRun.finished_at.desc().nulls_last(),
+            models.LectureSlideProcessingRun.id.desc(),
+        )
+        .limit(1)
+    )
+    if latest_failed_stage is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Lecture slide retry is only available after lecture slide processing fails.",
+        )
+
+    retry_stage = schemas.LectureSlideProcessingStage(latest_failed_stage)
+    if retry_stage == schemas.LectureSlideProcessingStage.NARRATION_TRANSCRIPTION:
+        retry_stage = schemas.LectureSlideProcessingStage.NARRATION_AUDIO
+
+    retry_run = await lecture_slide_processing.queue_lecture_slide_processing_run(
+        request.state["db"],
+        deck,
+        requested_by_assistant_id=assistant.id,
+        stage=retry_stage,
+    )
+    if retry_run is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Lecture slide retry is no longer available because the assistant or lecture slide configuration changed.",
+        )
+
+    refreshed_deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+        request.state["db"], deck.id
+    )
+    return await lecture_slide_service.lecture_slide_summary_from_model(
+        refreshed_deck or deck
+    )
+
+
+@v1.post(
     "/class/{class_id}/lecture-video/voice/validate",
     dependencies=[
         Depends(Authz("can_create_assistants", "class:{class_id}")),
@@ -13027,13 +13097,11 @@ async def update_assistant(
                 notes_changed = page_update_result.notes_changed
                 narration_text_changed = page_update_result.narration_changed
 
-            needs_full_processing = (
-                target_lecture_slide_deck.status
-                in {
-                    schemas.LectureSlideDeckStatus.UPLOADED,
-                    schemas.LectureSlideDeckStatus.FAILED,
-                }
-                or not target_lecture_slide_deck.pages
+            needs_full_processing = target_lecture_slide_deck.status in {
+                schemas.LectureSlideDeckStatus.UPLOADED,
+                schemas.LectureSlideDeckStatus.FAILED,
+            } or not await lecture_slide_service.lecture_slide_deck_has_pages(
+                request.state["db"], target_lecture_slide_deck.id
             )
             needs_narration_text = (
                 regenerate_narration_requested
@@ -13046,6 +13114,10 @@ async def update_assistant(
             needs_audio = regenerate_audio_requested or voice_changed
             if narration_text_changed:
                 needs_audio = True
+            if regenerate_audio_requested or voice_changed:
+                await lecture_slide_service.clear_lecture_slide_page_narrations(
+                    request.state["db"], target_lecture_slide_deck.id
+                )
 
             queued_run = None
             if needs_full_processing:

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -700,6 +701,77 @@ async def test_synthesize_slide_audio_skips_empty_pages_and_stores_ogg_metadata(
         assert stored_object.content_type == "audio/ogg"
 
 
+async def test_synthesize_slide_audio_skips_pages_with_existing_narration(
+    db, monkeypatch
+):
+    await _create_class_and_deck(db, slide_count=2)
+    async with db.async_session() as session:
+        stored_object = models.LectureSlideNarrationStoredObject(
+            key="slides/page-0.ogg",
+            content_type="audio/ogg",
+            content_length=5,
+            duration_ms=1000,
+        )
+        pages = [
+            models.LectureSlidePage(
+                lecture_slide_deck_id=1,
+                position=0,
+                narration_text="Existing narration.",
+                narration=models.LectureSlideNarration(
+                    stored_object=stored_object,
+                    status=schemas.LectureSlideNarrationStatus.READY,
+                ),
+            ),
+            models.LectureSlidePage(
+                lecture_slide_deck_id=1,
+                position=1,
+                narration_text="Changed narration.",
+            ),
+        ]
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_AUDIO,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([stored_object, *pages, run])
+        await session.commit()
+        changed_page_id = pages[1].id
+        run_id = run.id
+
+    requested_texts: list[str] = []
+
+    async def fake_get_elevenlabs_api_key(_class_id):
+        return "elevenlabs-key"
+
+    async def fake_synthesize_speech(_api_key, _voice_id, text):
+        requested_texts.append(text)
+        return "audio/mpeg", f"audio-{text}".encode("utf-8")
+
+    async def fake_store_audio(store_key, _content_type, audio):
+        return store_key, len(audio)
+
+    monkeypatch.setattr(
+        lecture_slide_processing, "_get_elevenlabs_api_key", fake_get_elevenlabs_api_key
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing, "synthesize_elevenlabs_speech", fake_synthesize_speech
+    )
+    monkeypatch.setattr(lecture_slide_processing, "_store_audio", fake_store_audio)
+    monkeypatch.setattr(lecture_slide_processing, "audio_duration_ms", lambda *_: 500)
+
+    artifacts = await lecture_slide_processing._synthesize_slide_audio(
+        run_id, "lease", 1
+    )
+
+    assert requested_texts == ["Changed narration."]
+    assert artifacts is not None
+    assert [artifact.page_id for artifact in artifacts] == [changed_page_id]
+
+
 async def test_synthesize_slide_audio_deletes_uploaded_audio_when_db_lookup_raises(
     db, monkeypatch
 ):
@@ -836,6 +908,174 @@ async def test_transcribe_and_persist_slide_audio_offsets_words(
         assert [page.end_offset_ms for page in deck.pages] == [1000, 3000]
         assert deck.transcript_data is not None
         assert len(deck.transcript_data["word_level_transcription"]) == 2
+
+
+async def test_transcribe_and_persist_slide_audio_reuses_unchanged_slide_words(
+    db, monkeypatch, tmp_path
+):
+    await _create_class_and_deck(db, slide_count=2)
+    async with db.async_session() as session:
+        unchanged_stored_object = models.LectureSlideNarrationStoredObject(
+            key="slides/page-1.ogg",
+            content_type="audio/ogg",
+            content_length=5,
+            duration_ms=1000,
+        )
+        pages = [
+            models.LectureSlidePage(
+                lecture_slide_deck_id=1,
+                position=0,
+                start_offset_ms=0,
+                end_offset_ms=1000,
+            ),
+            models.LectureSlidePage(
+                lecture_slide_deck_id=1,
+                position=1,
+                narration=models.LectureSlideNarration(
+                    stored_object=unchanged_stored_object,
+                    status=schemas.LectureSlideNarrationStatus.READY,
+                ),
+                start_offset_ms=1000,
+                end_offset_ms=2000,
+            ),
+        ]
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TRANSCRIPTION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        deck = await session.get(models.LectureSlideDeck, 1)
+        assert deck is not None
+        deck.total_duration_ms = 2000
+        deck.transcript_data = lecture_slide_processing.transcript_data_from_words(
+            [
+                schemas.LectureVideoManifestWordV3(
+                    id="slide-0-word-0",
+                    word="old",
+                    start_offset_ms=100,
+                    end_offset_ms=300,
+                ),
+                schemas.LectureVideoManifestWordV3(
+                    id="slide-1-word-0",
+                    word="unchanged",
+                    start_offset_ms=1100,
+                    end_offset_ms=1300,
+                ),
+            ]
+        )
+        session.add_all([unchanged_stored_object, *pages, run, deck])
+        await session.commit()
+        changed_page_id = pages[0].id
+        run_id = run.id
+
+    async def fake_transcribe_audio_words(_path, _client):
+        return [
+            schemas.LectureVideoManifestWordV3(
+                id="w",
+                word="new",
+                start_offset_ms=0,
+                end_offset_ms=500,
+            )
+        ]
+
+    monkeypatch.setattr(
+        lecture_slide_processing, "transcribe_audio_words", fake_transcribe_audio_words
+    )
+
+    words = await lecture_slide_processing._transcribe_and_persist_slide_audio(
+        run_id,
+        "lease",
+        1,
+        [
+            lecture_slide_processing.SlideAudioArtifact(
+                page_id=changed_page_id,
+                page_position=0,
+                content_type="audio/ogg",
+                audio=b"audio-1",
+                duration_ms=1500,
+                store_key="a1",
+                stored_object_id=1,
+            )
+        ],
+        SimpleNamespace(),
+        str(tmp_path),
+    )
+
+    assert [
+        (word.word, word.start_offset_ms, word.end_offset_ms) for word in words or []
+    ] == [
+        ("new", 0, 500),
+        ("unchanged", 1600, 1800),
+    ]
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.total_duration_ms == 2500
+        assert [page.start_offset_ms for page in deck.pages] == [0, 1500]
+        assert [page.end_offset_ms for page in deck.pages] == [1500, 2500]
+
+
+async def test_transcribe_and_persist_slide_audio_uses_supported_temp_extension(
+    db, monkeypatch, tmp_path
+):
+    await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        page = models.LectureSlidePage(lecture_slide_deck_id=1, position=0)
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TRANSCRIPTION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([page, run])
+        await session.commit()
+        page_id = page.id
+        run_id = run.id
+
+    seen_paths: list[str] = []
+
+    async def fake_transcribe_audio_words(path, _client):
+        seen_paths.append(path)
+        return [
+            schemas.LectureVideoManifestWordV3(
+                id="w", word="hello", start_offset_ms=0, end_offset_ms=100
+            )
+        ]
+
+    monkeypatch.setattr(
+        lecture_slide_processing, "transcribe_audio_words", fake_transcribe_audio_words
+    )
+
+    words = await lecture_slide_processing._transcribe_and_persist_slide_audio(
+        run_id,
+        "lease",
+        1,
+        [
+            lecture_slide_processing.SlideAudioArtifact(
+                page_id=page_id,
+                page_position=0,
+                content_type="audio/ogg",
+                audio=b"audio",
+                duration_ms=100,
+                store_key="a1",
+                stored_object_id=1,
+            )
+        ],
+        SimpleNamespace(),
+        str(tmp_path),
+    )
+
+    assert words is not None
+    assert [Path(path).suffix for path in seen_paths] == [".ogg"]
 
 
 async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -17,6 +17,12 @@ pytestmark = pytest.mark.asyncio
 server_module = importlib.import_module("pingpong.server")
 
 
+async def test_send_message_allows_first_run_for_lecture_slide_threads():
+    thread = SimpleNamespace(interaction_mode=schemas.InteractionMode.LECTURE_SLIDES)
+
+    assert server_module._allows_first_message_without_prior_run(thread)
+
+
 def _slide_deck(
     class_: models.Class,
     source: models.LectureSlideSourceStoredObject,
@@ -387,7 +393,7 @@ async def test_process_lecture_slide_question_answer_and_resume(db, institution)
 
 
 @with_institution(11, "Test Institution")
-async def test_initialize_thread_state_completes_when_lecture_slides_have_no_questions(
+async def test_initialize_thread_state_plays_when_lecture_slides_have_no_questions(
     db, institution
 ):
     async with db.async_session() as session:
@@ -398,7 +404,7 @@ async def test_initialize_thread_state_completes_when_lecture_slides_have_no_que
         state = await lecture_slide_runtime.initialize_thread_state(session, thread.id)
         interactions = await _list_slide_interactions(session, thread.id)
 
-    assert state.state == schemas.InteractiveLessonSessionState.COMPLETED
+    assert state.state == schemas.InteractiveLessonSessionState.PLAYING
     assert state.current_question_id is None
     assert state.last_known_offset_ms == 0
     assert state.version == 1

--- a/pingpong/test_lecture_slide_server.py
+++ b/pingpong/test_lecture_slide_server.py
@@ -1,7 +1,8 @@
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 import pingpong.schemas as schemas
 from pingpong import lecture_slide_service, models
+from pingpong.config import LocalAudioStoreSettings
 
 from .testutil import with_authz, with_institution, with_user
 
@@ -176,3 +177,282 @@ async def test_apply_lecture_slide_page_notes_handles_unloaded_pages(db, institu
     assert page is not None
     assert page.user_notes == "New notes"
     assert page.narration_text == "Narrate this."
+
+
+@with_institution(11, "Test Institution")
+async def test_clear_lecture_slide_page_narrations_deletes_unused_audio(
+    db, institution, config, monkeypatch, tmp_path
+):
+    narration_dir = tmp_path / "narrations"
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        LocalAudioStoreSettings(save_target=str(narration_dir)),
+    )
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=1,
+            voice_id="voice-test-id",
+        )
+        stored_object = models.LectureSlideNarrationStoredObject(
+            key="slide-1.ogg",
+            content_type="audio/ogg",
+            content_length=100,
+        )
+        session.add(stored_object)
+        await session.flush()
+        narration_dir.mkdir(parents=True, exist_ok=True)
+        (narration_dir / stored_object.key).write_bytes(b"slide-audio")
+        narration = models.LectureSlideNarration(
+            stored_object_id=stored_object.id,
+            status=schemas.LectureSlideNarrationStatus.READY,
+        )
+        session.add(narration)
+        await session.flush()
+        page = models.LectureSlidePage(
+            lecture_slide_deck_id=deck.id,
+            position=0,
+            narration_id=narration.id,
+            start_offset_ms=0,
+            end_offset_ms=100,
+        )
+        session.add(page)
+        await session.commit()
+
+        await lecture_slide_service.clear_lecture_slide_page_narrations(
+            session, deck.id
+        )
+        await session.commit()
+
+        page_after_clear = await session.get(models.LectureSlidePage, page.id)
+        page_after_clear_narration_id = (
+            page_after_clear.narration_id if page_after_clear else None
+        )
+        page_after_clear_start_offset_ms = (
+            page_after_clear.start_offset_ms if page_after_clear else None
+        )
+        page_after_clear_end_offset_ms = (
+            page_after_clear.end_offset_ms if page_after_clear else None
+        )
+        narration_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarration)
+        )
+        stored_object_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarrationStoredObject)
+        )
+
+    assert page_after_clear is not None
+    assert page_after_clear_narration_id is None
+    assert page_after_clear_start_offset_ms is None
+    assert page_after_clear_end_offset_ms is None
+    assert narration_count == 0
+    assert stored_object_count == 0
+    assert not (narration_dir / "slide-1.ogg").exists()
+
+
+@with_institution(11, "Test Institution")
+async def test_clear_lecture_slide_page_narrations_preserves_shared_audio(
+    db, institution, config, monkeypatch, tmp_path
+):
+    narration_dir = tmp_path / "narrations"
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        LocalAudioStoreSettings(save_target=str(narration_dir)),
+    )
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        first_deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=1,
+            voice_id="voice-test-id",
+        )
+        second_deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04-copy.pdf",
+            slide_count=1,
+            voice_id="voice-test-id",
+        )
+        stored_object = models.LectureSlideNarrationStoredObject(
+            key="shared-slide.ogg",
+            content_type="audio/ogg",
+            content_length=100,
+        )
+        session.add(stored_object)
+        await session.flush()
+        narration_dir.mkdir(parents=True, exist_ok=True)
+        (narration_dir / stored_object.key).write_bytes(b"shared-audio")
+        first_narration = models.LectureSlideNarration(
+            stored_object_id=stored_object.id,
+            status=schemas.LectureSlideNarrationStatus.READY,
+        )
+        second_narration = models.LectureSlideNarration(
+            stored_object_id=stored_object.id,
+            status=schemas.LectureSlideNarrationStatus.READY,
+        )
+        session.add_all([first_narration, second_narration])
+        await session.flush()
+        second_narration_id = second_narration.id
+        session.add_all(
+            [
+                models.LectureSlidePage(
+                    lecture_slide_deck_id=first_deck.id,
+                    position=0,
+                    narration_id=first_narration.id,
+                ),
+                models.LectureSlidePage(
+                    lecture_slide_deck_id=second_deck.id,
+                    position=0,
+                    narration_id=second_narration.id,
+                ),
+            ]
+        )
+        await session.commit()
+
+        await lecture_slide_service.clear_lecture_slide_page_narrations(
+            session, first_deck.id
+        )
+        await session.commit()
+
+        remaining_narration_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarration)
+        )
+        remaining_stored_object_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarrationStoredObject)
+        )
+        second_page = await session.scalar(
+            select(models.LectureSlidePage).where(
+                models.LectureSlidePage.lecture_slide_deck_id == second_deck.id
+            )
+        )
+        second_page_narration_id = second_page.narration_id if second_page else None
+
+    assert remaining_narration_count == 1
+    assert remaining_stored_object_count == 1
+    assert second_page is not None
+    assert second_page_narration_id == second_narration_id
+    assert (narration_dir / "shared-slide.ogg").exists()
+
+
+@with_institution(11, "Test Institution")
+async def test_delete_unused_lecture_slide_deck_deletes_page_narration_audio(
+    db, institution, config, monkeypatch, tmp_path
+):
+    narration_dir = tmp_path / "narrations"
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        LocalAudioStoreSettings(save_target=str(narration_dir)),
+    )
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=1,
+            voice_id="voice-test-id",
+        )
+        stored_object = models.LectureSlideNarrationStoredObject(
+            key="deleted-deck-slide.ogg",
+            content_type="audio/ogg",
+            content_length=100,
+        )
+        session.add(stored_object)
+        await session.flush()
+        narration_dir.mkdir(parents=True, exist_ok=True)
+        (narration_dir / stored_object.key).write_bytes(b"slide-audio")
+        narration = models.LectureSlideNarration(
+            stored_object_id=stored_object.id,
+            status=schemas.LectureSlideNarrationStatus.READY,
+        )
+        session.add(narration)
+        await session.flush()
+        session.add(
+            models.LectureSlidePage(
+                lecture_slide_deck_id=deck.id,
+                position=0,
+                narration_id=narration.id,
+            )
+        )
+        await session.commit()
+
+        await lecture_slide_service.delete_lecture_slide_deck_if_unused(
+            session, deck.id
+        )
+        await session.commit()
+
+        remaining_deck_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideDeck)
+        )
+        remaining_narration_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarration)
+        )
+        remaining_stored_object_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarrationStoredObject)
+        )
+
+    assert remaining_deck_count == 0
+    assert remaining_narration_count == 0
+    assert remaining_stored_object_count == 0
+    assert not (narration_dir / "deleted-deck-slide.ogg").exists()

--- a/pingpong/test_lecture_slide_server.py
+++ b/pingpong/test_lecture_slide_server.py
@@ -1,0 +1,178 @@
+from sqlalchemy import select
+
+import pingpong.schemas as schemas
+from pingpong import lecture_slide_service, models
+
+from .testutil import with_authz, with_institution, with_user
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "admin", "class:1"),
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+    ]
+)
+async def test_retry_lecture_slide_endpoint_queues_processing_after_failure(
+    api, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=18,
+            voice_id="voice-test-id",
+            status=schemas.LectureSlideDeckStatus.FAILED,
+            error_message="Unable to process the lecture slide deck right now. Please retry.",
+        )
+        assistant = models.Assistant(
+            id=1,
+            name="Physics Slides",
+            class_id=class_.id,
+            interaction_mode=schemas.InteractionMode.LECTURE_SLIDES,
+            version=3,
+            lecture_slide_deck_id=deck.id,
+            instructions="You are a lecture assistant.",
+            model="gpt-4o-mini",
+            tools="[]",
+            use_latex=False,
+            use_image_descriptions=False,
+            hide_prompt=False,
+        )
+        session.add(assistant)
+        await models.LectureSlideProcessingRun.create(
+            session,
+            lecture_slide_deck_id=deck.id,
+            lecture_slide_deck_id_snapshot=deck.id,
+            class_id=class_.id,
+            assistant_id_at_start=assistant.id,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TRANSCRIPTION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.FAILED,
+        )
+        await session.commit()
+        deck_id = deck.id
+
+    response = api.post(
+        "/api/v1/class/1/assistant/1/lecture-slides/retry",
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == schemas.LectureSlideDeckStatus.PROCESSING.value
+    assert response.json()["error_message"] is None
+
+    async with db.async_session() as session:
+        refreshed_deck = await models.LectureSlideDeck.get_by_id(session, deck_id)
+        runs = list(
+            (
+                await session.scalars(
+                    select(models.LectureSlideProcessingRun)
+                    .where(
+                        models.LectureSlideProcessingRun.lecture_slide_deck_id_snapshot
+                        == deck_id
+                    )
+                    .order_by(models.LectureSlideProcessingRun.attempt_number.asc())
+                )
+            ).all()
+        )
+
+    assert refreshed_deck is not None
+    assert refreshed_deck.status == schemas.LectureSlideDeckStatus.PROCESSING
+    assert refreshed_deck.error_message is None
+    assert len(runs) == 2
+    assert runs[0].status == schemas.LectureSlideProcessingRunStatus.FAILED
+    assert runs[1].status == schemas.LectureSlideProcessingRunStatus.QUEUED
+    assert runs[1].stage == schemas.LectureSlideProcessingStage.NARRATION_AUDIO
+    assert runs[1].attempt_number == 2
+
+
+@with_institution(11, "Test Institution")
+async def test_apply_lecture_slide_page_notes_handles_unloaded_pages(db, institution):
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=2,
+            voice_id="voice-test-id",
+        )
+        session.add(
+            models.LectureSlidePage(
+                lecture_slide_deck_id=deck.id,
+                position=0,
+                user_notes="Old notes",
+            )
+        )
+        await session.commit()
+        deck_id = deck.id
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id(session, deck_id)
+        assert deck is not None
+        assert "pages" not in deck.__dict__
+
+        result = await lecture_slide_service.apply_lecture_slide_page_notes(
+            session,
+            deck,
+            [
+                schemas.LectureSlidePageNotes(
+                    position=0,
+                    user_notes="New notes",
+                    narration_text="Narrate this.",
+                )
+            ],
+        )
+        await session.commit()
+
+    assert result.notes_changed is True
+    assert result.narration_changed is True
+
+    async with db.async_session() as session:
+        page = await session.scalar(
+            select(models.LectureSlidePage).where(
+                models.LectureSlidePage.lecture_slide_deck_id == deck_id,
+                models.LectureSlidePage.position == 0,
+            )
+        )
+
+    assert page is not None
+    assert page.user_notes == "New notes"
+    assert page.narration_text == "Narrate this."

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -1,7 +1,11 @@
 import pytest
 
 from pingpong import models, schemas
-from pingpong.server import _build_run_instructions
+from pingpong.server import (
+    _build_run_instructions,
+    _lecture_lesson_dual_text_enabled,
+    _lecture_lesson_followups_enabled,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -69,7 +73,7 @@ async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
 
-async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_contract(
+async def test_build_run_instructions_for_lecture_video_forces_latex_and_say_contract(
     db,
 ):
     thread, assistant = await create_thread_and_assistant(
@@ -85,9 +89,7 @@ async def test_build_run_instructions_for_lecture_video_without_latex_skips_say_
     assert instructions is not None
     assert "Stored lecture snapshot." in instructions
     assert "Updated assistant instructions." not in instructions
-    assert (
-        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
-    )
+    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
 
@@ -109,6 +111,33 @@ async def test_build_run_instructions_for_lecture_video_normalizes_missing_threa
     assert "Assistant fallback instructions." in instructions
     assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: Lecture Video Follow-ups---" in instructions
+
+
+async def test_build_run_instructions_for_lecture_slides_uses_lecture_formatting(
+    db,
+):
+    thread, assistant = await create_thread_and_assistant(
+        db,
+        interaction_mode=schemas.InteractionMode.LECTURE_SLIDES,
+        thread_instructions="Stored slide snapshot.",
+        assistant_instructions="Updated assistant instructions.",
+        use_latex=False,
+    )
+
+    instructions = _build_run_instructions(thread, assistant, user_id=1)
+
+    assert instructions is not None
+    assert "Stored slide snapshot." in instructions
+    assert "Updated assistant instructions." not in instructions
+    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+
+
+async def test_lecture_slides_enable_dual_text_and_followups():
+    thread = models.Thread(interaction_mode=schemas.InteractionMode.LECTURE_SLIDES)
+
+    assert _lecture_lesson_dual_text_enabled(thread)
+    assert _lecture_lesson_followups_enabled(thread)
 
 
 async def test_build_run_instructions_for_non_lecture_video_uses_stored_instructions(

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -862,7 +862,7 @@ def fake_class_models_response(model_id: str = "gpt-4o-mini") -> dict:
         "lecture_video": {
             "show_mode_in_assistant_editor": True,
             "can_select_mode_in_assistant_editor": True,
-            "message": "Lecture Video mode is in active development.",
+            "message": "Lecture Video mode is in active development",
         },
     }
 
@@ -3701,7 +3701,7 @@ async def test_lecture_video_answer_submitted_rejects_option_from_another_questi
 
 
 @with_institution(11, "Test Institution")
-async def test_initialize_thread_state_completes_when_lecture_video_has_no_questions(
+async def test_initialize_thread_state_plays_when_lecture_video_has_no_questions(
     db, institution
 ):
     async with db.async_session() as session:
@@ -3761,7 +3761,7 @@ async def test_initialize_thread_state_completes_when_lecture_video_has_no_quest
             session, thread.id
         )
 
-    assert state.state == schemas.LectureVideoSessionState.COMPLETED
+    assert state.state == schemas.LectureVideoSessionState.PLAYING
     assert state.current_question_id is None
     assert state.last_known_offset_ms == 0
     assert state.version == 1

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1901,6 +1901,36 @@ async def test_preview_assistant_instructions_includes_lecture_video_say_contrac
 @with_user(123)
 @with_institution(1, "Test Institution")
 @with_authz(grants=[("user:123", "can_create_assistants", "class:1")])
+async def test_preview_assistant_instructions_for_lecture_slides_forces_latex_formatting(
+    api, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_ = models.Class(id=1, name="Test Class", institution_id=institution.id)
+        session.add(class_)
+        await session.commit()
+
+    response = api.post(
+        "/api/v1/class/1/assistant_instructions",
+        json={
+            "instructions": "Be helpful",
+            "use_latex": False,
+            "interaction_mode": "lecture_slides",
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert response.status_code == 200
+    instructions_preview = response.json()["instructions_preview"]
+    assert (
+        "---Formatting: Lecture Video Dual Speech/Display Blocks---"
+        in instructions_preview
+    )
+    assert "---Formatting: Mermaid---" in instructions_preview
+
+
+@with_user(123)
+@with_institution(1, "Test Institution")
+@with_authz(grants=[("user:123", "can_create_assistants", "class:1")])
 async def test_preview_assistant_instructions_excludes_latex_formatting(
     api, db, institution, valid_user_token
 ):

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -2215,6 +2215,15 @@ export const retryAssistantLectureVideo = async (
 	return await POST<never, LectureVideoSummary>(f, url);
 };
 
+export const retryAssistantLectureSlides = async (
+	f: Fetcher,
+	classId: number,
+	assistantId: number
+) => {
+	const url = `class/${classId}/assistant/${assistantId}/lecture-slides/retry`;
+	return await POST<never, LectureSlideSummary>(f, url);
+};
+
 /**
  * Load the lecture-video editor policy for a class.
  */

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1876,12 +1876,37 @@ export type LectureSlidePageNotes = {
 	narration_text?: string | null;
 };
 
+export type LectureSlideQuestionType = 'single_select';
+
+export type LectureSlideQuestionOption = {
+	id: number;
+	option_text: string;
+	post_answer_text?: string | null;
+	continue_slide_position?: number | null;
+	continue_slide_offset_ms?: number | null;
+	continue_offset_ms: number;
+	correct: boolean;
+};
+
+export type LectureSlideQuestion = {
+	id: number;
+	position: number;
+	slide_position: number;
+	slide_offset_ms: number;
+	stop_offset_ms: number;
+	type: LectureSlideQuestionType;
+	question_text: string;
+	intro_text: string;
+	options: LectureSlideQuestionOption[];
+};
+
 export type LectureSlideConfigResponse = {
 	lecture_slide_deck: LectureSlideSummary;
 	voice_id: string;
 	generation_prompt?: string | null;
 	narration_prompt?: string | null;
 	pages: LectureSlidePage[];
+	questions: LectureSlideQuestion[];
 	processing_status?: LectureVideoProcessingRunSummary | null;
 };
 

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -156,19 +156,21 @@
 		: otherAssistants;
 	let assistant = {} as Assistant;
 	$: assistantMeta = getAssistantMetadata(assistant);
-	let lectureVideoPosterFailed = false;
-	let lectureVideoPosterLoaded = false;
-	let lectureVideoPosterAssistantId: number | undefined;
-	$: lectureVideoPosterUrl =
+	let lessonThumbnailFailed = false;
+	let lessonThumbnailLoaded = false;
+	let lessonThumbnailAssistantId: number | undefined;
+	$: lessonThumbnailUrl =
 		assistant.interaction_mode === 'lecture_video' && data?.class?.id && assistant.id
 			? `/api/v1/class/${data.class.id}/assistant/${assistant.id}/lecture-video/poster`
-			: '';
+			: assistant.interaction_mode === 'lecture_slides' && data?.class?.id && assistant.id
+				? `/api/v1/class/${data.class.id}/assistant/${assistant.id}/lecture-slides/thumbnail`
+				: '';
 	$: {
-		// Reset failure state when the selected assistant changes so we re-attempt the new poster.
-		if (lectureVideoPosterAssistantId !== assistant.id) {
-			lectureVideoPosterAssistantId = assistant.id;
-			lectureVideoPosterFailed = false;
-			lectureVideoPosterLoaded = false;
+		// Reset failure state when the selected assistant changes so we re-attempt the new thumbnail.
+		if (lessonThumbnailAssistantId !== assistant.id) {
+			lessonThumbnailAssistantId = assistant.id;
+			lessonThumbnailFailed = false;
+			lessonThumbnailLoaded = false;
 		}
 	}
 	// Whether billing is set up for the class (which controls everything).
@@ -879,20 +881,24 @@
 					{/if}
 				{:else if assistant.interaction_mode === 'lecture_video' || assistant.interaction_mode === 'lecture_slides'}
 					<div class="h-[5%] max-h-8"></div>
-					{#if assistant.interaction_mode === 'lecture_video' && lectureVideoPosterUrl && !lectureVideoPosterFailed}
+					{#if lessonThumbnailUrl && !lessonThumbnailFailed}
 						<div class="relative aspect-video w-full max-w-md overflow-hidden rounded-lg shadow-lg">
-							{#if !lectureVideoPosterLoaded}
+							{#if !lessonThumbnailLoaded}
 								<div class="flex h-full w-full items-center justify-center bg-blue-light-50">
-									<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />
+									{#if assistant.interaction_mode === 'lecture_slides'}
+										<BookOpenOutline size="xl" class="text-blue-dark-40" />
+									{:else}
+										<ClapperboardPlayOutline size="xl" class="text-blue-dark-40" />
+									{/if}
 								</div>
 							{/if}
 							<img
-								src={lectureVideoPosterUrl}
+								src={lessonThumbnailUrl}
 								alt=""
 								class="absolute inset-0 h-full w-full object-cover transition-opacity"
-								class:opacity-0={!lectureVideoPosterLoaded}
-								onload={() => (lectureVideoPosterLoaded = true)}
-								onerror={() => (lectureVideoPosterFailed = true)}
+								class:opacity-0={!lessonThumbnailLoaded}
+								onload={() => (lessonThumbnailLoaded = true)}
+								onerror={() => (lessonThumbnailFailed = true)}
 							/>
 						</div>
 					{:else}

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -46,6 +46,7 @@
 	const ERROR_CONTROLLER_LEASE_EXPIRED = 'controller_lease_expired';
 	const CONTROL_RECOVERY_GRACE_MS = 1_000;
 	const ACTIVE_PAGE_RECOVERY_DEBOUNCE_MS = 150;
+	const COMPLETED_SEEK_TOLERANCE_MS = 2_000;
 	type InitErrorAction = 'refresh' | null;
 	type InitErrorState = {
 		detail: string;
@@ -268,6 +269,11 @@
 	let playbackInteractionAllowed = $derived(allowsPlaybackInteraction(sessionState));
 	let hasQuestionPrompt = $derived(hasVisibleQuestionPrompt(sessionState));
 	let isCompleted = $derived(isCompletedSession(sessionState));
+	let completedPlaybackReachedEnd = $derived(
+		durationMsOverride == null ||
+			durationMsOverride <= 0 ||
+			furthestOffsetMs >= durationMsOverride - COMPLETED_SEEK_TOLERANCE_MS
+	);
 	let visibleCurrentQuestion = $derived(hasQuestionPrompt ? currentQuestion : null);
 	let questionReviewPlaybackAllowed = $derived(
 		hasQuestionPrompt && questionPlaybackLocked && currentQuestion != null && !playerDisabled
@@ -2116,7 +2122,7 @@
 							{activeQuestionIds}
 							{questionPresentationVersion}
 							{furthestOffsetMs}
-							allowFullSeek={isCompleted && canParticipate}
+							allowFullSeek={isCompleted && canParticipate && completedPlaybackReachedEnd}
 							maxSeekOffsetMs={questionReviewSeekLimitMs}
 							manualPlaybackPrompt={playbackRequiresManualStart}
 							bind:videoElement

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -1080,6 +1080,11 @@
 				(page.narration_text || '').trim().length > 0
 		) ||
 			(selectedLectureSlidePage.narration_text || '').trim().length > 0);
+	$: selectedLectureSlideQuestions = selectedLectureSlidePage
+		? (data.lectureSlideConfig?.questions || []).filter(
+				(question) => question.slide_position === selectedLectureSlidePage?.position
+			)
+		: [];
 	const goToAdjacentLectureSlide = (delta: number) => {
 		if (selectedLectureSlideIndex < 0) {
 			return;
@@ -3427,49 +3432,122 @@
 					</div>
 				</div>
 				{#if selectedLectureSlidePage}
-					<div class="min-h-0 flex-1 overflow-y-auto pr-1">
-						<div class="mb-4">
-							<Label for="slide_author_notes">Author Notes</Label>
-							<Helper class="pb-1"
-								>Instructor notes used when generating narration for this slide.</Helper
-							>
-							<Textarea
-								id="slide_author_notes"
-								rows={8}
-								value={selectedLectureSlidePage.user_notes || ''}
-								disabled={preventEdits}
-								oninput={(event) =>
-									updateLectureSlidePageDraft(
-										selectedLectureSlidePage.position,
-										'user_notes',
-										(event.target as HTMLTextAreaElement).value
-									)}
-							/>
-						</div>
-						<div class="mb-4">
-							<Label for="slide_narration_text">Narration</Label>
-							<Helper class="pb-1"
-								>Edit the spoken narration for this slide. Saving manual narration edits regenerates
-								audio.</Helper
-							>
-							{#if !selectedLectureSlideHasNarration}
-								<Alert color="blue" defaultClass="mb-3 p-3 text-sm">
-									Narration will become editable after it has been generated.
-								</Alert>
+					<div class="min-h-0 flex-1 overflow-hidden pr-1">
+						<Accordion class="w-full text-left" flush>
+							<AccordionItem paddingFlush="py-2" open>
+								<span slot="header" class="mr-3 w-full">
+									<div class="flex w-full flex-row items-center justify-between gap-2">
+										<div>Slide Content</div>
+										<div class="text-sm font-light text-gray-500">Notes and narration</div>
+									</div>
+								</span>
+								<div class="my-3 max-h-[calc(78vh-14rem)] overflow-y-auto pr-1">
+									<div>
+										<Label for="slide_author_notes">Author Notes</Label>
+										<Helper class="pb-1"
+											>Instructor notes used when generating narration for this slide.</Helper
+										>
+										<Textarea
+											id="slide_author_notes"
+											rows={8}
+											value={selectedLectureSlidePage.user_notes || ''}
+											disabled={preventEdits}
+											oninput={(event) =>
+												updateLectureSlidePageDraft(
+													selectedLectureSlidePage.position,
+													'user_notes',
+													(event.target as HTMLTextAreaElement).value
+												)}
+										/>
+									</div>
+									<div class="mt-4 mb-3">
+										<Label for="slide_narration_text">Narration</Label>
+										<Helper class="pb-1"
+											>Edit the spoken narration for this slide. Saving manual narration edits
+											regenerates audio.</Helper
+										>
+										{#if !selectedLectureSlideHasNarration}
+											<Alert color="blue" defaultClass="mb-3 p-3 text-sm">
+												Narration will become editable after it has been generated.
+											</Alert>
+										{/if}
+										<Textarea
+											id="slide_narration_text"
+											rows={12}
+											value={selectedLectureSlidePage.narration_text || ''}
+											disabled={preventEdits || !selectedLectureSlideHasNarration}
+											oninput={(event) =>
+												updateLectureSlidePageDraft(
+													selectedLectureSlidePage.position,
+													'narration_text',
+													(event.target as HTMLTextAreaElement).value
+												)}
+										/>
+									</div>
+								</div>
+							</AccordionItem>
+							{#if selectedLectureSlideQuestions.length > 0}
+								<AccordionItem paddingFlush="py-2">
+									<span slot="header" class="mr-3 w-full">
+										<div class="flex w-full flex-row items-center justify-between gap-2">
+											<div>Knowledge Checks</div>
+											<div class="text-sm font-light text-gray-500">
+												{selectedLectureSlideQuestions.length}
+												{selectedLectureSlideQuestions.length === 1 ? 'question' : 'questions'}
+											</div>
+										</div>
+									</span>
+									<div
+										class="my-3 flex max-h-[calc(78vh-14rem)] flex-col gap-3 overflow-y-auto pr-1"
+									>
+										{#each selectedLectureSlideQuestions as question, questionIndex (question.id)}
+											<div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+												<div class="mb-2 text-xs font-semibold text-gray-500 uppercase">
+													Question {questionIndex + 1}
+												</div>
+												<div class="text-sm font-semibold text-gray-900">
+													{question.question_text}
+												</div>
+												{#if question.intro_text}
+													<div class="mt-1 text-xs text-gray-600">{question.intro_text}</div>
+												{/if}
+												<div class="mt-3 flex flex-col gap-2">
+													{#each question.options as option (option.id)}
+														<div class="rounded-md border border-gray-200 bg-white p-2">
+															<div class="flex items-start justify-between gap-2">
+																<div class="text-sm text-gray-900">{option.option_text}</div>
+																{#if option.correct}
+																	<Badge
+																		class="flex shrink-0 flex-row items-center gap-1 rounded-md border border-green-300 bg-green-50 px-2 py-0.5 text-xs text-green-800 normal-case"
+																	>
+																		<CheckCircleOutline class="h-3.5 w-3.5" />
+																		<div>Correct</div>
+																	</Badge>
+																{/if}
+															</div>
+															{#if option.post_answer_text}
+																<div class="mt-1 text-xs text-gray-600">
+																	{option.post_answer_text}
+																</div>
+															{/if}
+														</div>
+													{/each}
+												</div>
+											</div>
+										{/each}
+									</div>
+								</AccordionItem>
+							{:else}
+								<div class="border-t border-gray-200 py-2 opacity-60">
+									<div
+										class="flex w-full cursor-not-allowed flex-row items-center justify-between gap-2 py-3 text-sm font-medium text-gray-500"
+									>
+										<div>Knowledge Checks</div>
+										<div class="font-light">No questions generated</div>
+									</div>
+								</div>
 							{/if}
-							<Textarea
-								id="slide_narration_text"
-								rows={12}
-								value={selectedLectureSlidePage.narration_text || ''}
-								disabled={preventEdits || !selectedLectureSlideHasNarration}
-								oninput={(event) =>
-									updateLectureSlidePageDraft(
-										selectedLectureSlidePage.position,
-										'narration_text',
-										(event.target as HTMLTextAreaElement).value
-									)}
-							/>
-						</div>
+						</Accordion>
 					</div>
 				{:else}
 					<div class="flex min-h-[320px] items-center justify-center text-sm text-gray-600">

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -17,7 +17,8 @@
 		RadioButton,
 		InputAddon,
 		Tooltip,
-		Spinner
+		Spinner,
+		Alert
 	} from 'flowbite-svelte';
 	import type {
 		Tool,
@@ -3445,27 +3446,30 @@
 									)}
 							/>
 						</div>
-						{#if selectedLectureSlideHasNarration}
-							<div class="mb-4">
-								<Label for="slide_narration_text">Narration</Label>
-								<Helper class="pb-1"
-									>Edit the spoken narration for this slide. Saving manual narration edits
-									regenerates audio.</Helper
-								>
-								<Textarea
-									id="slide_narration_text"
-									rows={12}
-									value={selectedLectureSlidePage.narration_text || ''}
-									disabled={preventEdits}
-									oninput={(event) =>
-										updateLectureSlidePageDraft(
-											selectedLectureSlidePage.position,
-											'narration_text',
-											(event.target as HTMLTextAreaElement).value
-										)}
-								/>
-							</div>
-						{/if}
+						<div class="mb-4">
+							<Label for="slide_narration_text">Narration</Label>
+							<Helper class="pb-1"
+								>Edit the spoken narration for this slide. Saving manual narration edits regenerates
+								audio.</Helper
+							>
+							{#if !selectedLectureSlideHasNarration}
+								<Alert color="blue" defaultClass="mb-3 p-3 text-sm">
+									Narration will become editable after it has been generated.
+								</Alert>
+							{/if}
+							<Textarea
+								id="slide_narration_text"
+								rows={12}
+								value={selectedLectureSlidePage.narration_text || ''}
+								disabled={preventEdits || !selectedLectureSlideHasNarration}
+								oninput={(event) =>
+									updateLectureSlidePageDraft(
+										selectedLectureSlidePage.position,
+										'narration_text',
+										(event.target as HTMLTextAreaElement).value
+									)}
+							/>
+						</div>
 					</div>
 				{:else}
 					<div class="flex min-h-[320px] items-center justify-center text-sm text-gray-600">
@@ -3539,11 +3543,6 @@
 							{#if interactionMode === 'lecture_video'}<ClapperboardPlaySolid
 									class="h-5 w-5"
 								/>{:else}<ClapperboardPlayOutline class="h-5 w-5" />{/if}Lecture Video mode
-							<div
-								class="flex flex-row items-center rounded-full border border-gray-300 px-3 py-1 text-xs font-normal text-gray-600"
-							>
-								Research Preview
-							</div>
 						</div></RadioButton
 					>
 					<RadioButton
@@ -3559,11 +3558,6 @@
 							{#if interactionMode === 'lecture_slides'}<BookOpenSolid
 									class="h-5 w-5"
 								/>{:else}<BookOpenOutline class="h-5 w-5" />{/if}Lecture Slides mode
-							<div
-								class="flex flex-row items-center rounded-full border border-gray-300 px-3 py-1 text-xs font-normal text-gray-600"
-							>
-								Research Preview
-							</div>
 						</div></RadioButton
 					>
 				{/if}

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -2730,6 +2730,35 @@
 		}
 	};
 
+	const retryLectureSlideProcessing = async () => {
+		if (data.isCreating || !data.assistantId || !currentLectureSlideDeck) {
+			return;
+		}
+
+		let response;
+		try {
+			response = await api.retryAssistantLectureSlides(fetch, data.class.id, data.assistantId);
+		} catch (error) {
+			sadToast(
+				`Could not retry lecture slide processing:\n${
+					error instanceof Error ? error.message : error?.toString() || 'Unknown error'
+				}`
+			);
+			return;
+		}
+		const expanded = api.expandResponse(response);
+		if (expanded.error || !expanded.data) {
+			sadToast(
+				`Could not retry lecture slide processing:\n${expanded.error?.detail || 'Unknown error'}`
+			);
+			return;
+		}
+
+		syncLectureSlideSummary(expanded.data);
+		void refreshAssistantLectureSlideStatus();
+		happyToast('Lecture slide processing retried');
+	};
+
 	const syncLectureVideoSummary = (summary: api.LectureVideoSummary) => {
 		currentLectureVideo = { ...(currentLectureVideo || summary), ...summary };
 		if (selectedLectureVideo?.id === summary.id) {
@@ -3840,6 +3869,11 @@
 								</div>
 							</div>
 							<div class="flex items-center gap-2">
+								{#if !data.isCreating && data.assistantId && currentLectureSlideDeck && selectedLectureSlideDeck?.id === currentLectureSlideDeck.id && currentLectureSlideDeck.status === 'failed'}
+									<Button color="light" size="xs" onclick={retryLectureSlideProcessing}>
+										Retry
+									</Button>
+								{/if}
 								<Button
 									type="button"
 									color="light"


### PR DESCRIPTION
- Added a new endpoint to retry processing of failed lecture slides.
- Enhanced the backend logic to handle retries based on the last processing stage.
- Updated the frontend to include a retry button for failed lecture slide processing.
- Improved error handling for retry attempts and ensured proper state management for lecture slides.
- Added tests to verify the new retry functionality and its integration with existing systems.