### PR TITLE
feat(slide): updates to slide processing and manifest generation

### DIFF
--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeVar, TypedDict, cast
 
 import openai
+from openai.types import Reasoning
 import uuid_utils as uuid
 from openai.types.audio import TranscriptionWord
 from openai.types.responses.response_input_param import ResponseInputParam
@@ -213,6 +214,19 @@ SLIDE LESSON MANIFEST ADAPTATION:
   stop_offset_ms, continue_offset_ms, summary_checkpoints, and moment_contexts.
 - Use slide_offset_ms as the offset within the visible slide where the question
   appears.
+- Keep each question's slide_offset_ms inside the selected slide's timing
+  range: 0 <= slide_offset_ms <= end_offset_ms - start_offset_ms for that slide.
+  The question's stop_offset_ms must also stay between that slide's
+  start_offset_ms and end_offset_ms. If a question falls on a slide boundary,
+  use the boundary timestamp exactly or assign it to the next slide instead of
+  placing it a few milliseconds outside the slide.
+- Derive slide_offset_ms from stop_offset_ms minus the selected slide's
+  start_offset_ms. Derive continue_slide_offset_ms the same way from
+  continue_offset_ms when you provide slide coordinates. Do not estimate slide
+  offsets independently.
+- Transcript word ids include the slide number, such as slide-17-word-3. Use
+  that slide number as a sanity check when choosing pause and resume points, but
+  do not emit word-id fields in the JSON.
 - Options use option_text, post_answer_text, continue_offset_ms, correct, and
   optional continue_slide_position / continue_slide_offset_ms when the resume
   point is naturally described in slide coordinates.
@@ -1239,7 +1253,6 @@ async def _extract_and_store_slide_assets(
                     )
                 )
             deck.slide_count = len(assets)
-            session.add(deck)
             await session.commit()
     finally:
         cleanup_extracted_slide_assets(assets)
@@ -2438,7 +2451,6 @@ async def _persist_slide_manifest(
         deck.context_version = 4
         deck.lecture_slide_chat_available = bool(transcript)
         deck.transcript_data = transcript_data_from_words(transcript)
-        session.add(deck)
         await session.commit()
 
 
@@ -2639,6 +2651,9 @@ async def _parse_responses_output(
                 instructions=instructions,
                 input=input_messages,
                 text_format=response_model,
+                reasoning=Reasoning(effort="high", summary=None),
+                service_tier="priority",
+                store=False,
             )
             if response.output_parsed is None:
                 raise RuntimeError("OpenAI Responses parse returned no parsed output.")

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -209,6 +209,71 @@ async def test_extract_slide_assets_from_pdf_cleans_empty_pdf_output_dir(
     assert not output_dir.exists()
 
 
+async def test_extract_and_store_slide_assets_replaces_existing_pages(
+    db, monkeypatch, tmp_path
+):
+    await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=0,
+            user_notes="Keep these notes.",
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.SLIDE_ASSET_EXTRACTION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([page, run])
+        await session.commit()
+        run_id = run.id
+
+    asset_dir = tmp_path / "assets"
+    asset_dir.mkdir()
+    image_path = asset_dir / "slide.png"
+    image_path.write_bytes(b"replacement image")
+
+    class FakeVideoStore:
+        async def put(self, _key, _body, _content_type):
+            return None
+
+    monkeypatch.setattr(config, "video_store", SimpleNamespace(store=FakeVideoStore()))
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "extract_slide_assets_from_pdf",
+        lambda _pdf_path: [
+            lecture_slide_processing.ExtractedSlideAsset(
+                position=0,
+                image_path=str(image_path),
+                width_px=640,
+                height_px=480,
+                extracted_text="Replacement text.",
+            )
+        ],
+    )
+
+    await lecture_slide_processing._extract_and_store_slide_assets(
+        run_id,
+        "lease",
+        1,
+        str(tmp_path / "slides.pdf"),
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.slide_count == 1
+        assert len(deck.pages) == 1
+        assert deck.pages[0].extracted_text == "Replacement text."
+        assert deck.pages[0].user_notes == "Keep these notes."
+
+
 async def test_list_rendered_pdf_page_images_sorts_zero_padded_names(tmp_path):
     for filename in ("page-10.png", "page-02.png", "page-01.png"):
         (tmp_path / filename).write_bytes(b"")
@@ -428,6 +493,9 @@ async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_tex
     assert "QUALITY EXAMPLES:" in instructions
     assert "FINAL VERIFICATION BEFORE OUTPUT:" in instructions
     assert "SLIDE LESSON MANIFEST ADAPTATION:" in instructions
+    assert "0 <= slide_offset_ms <= end_offset_ms - start_offset_ms" in instructions
+    assert "Derive slide_offset_ms from stop_offset_ms" in instructions
+    assert "Transcript word ids include the slide number" in instructions
     assert captured["text_format"] is lecture_slide_processing.GeneratedSlideManifest
     assert captured["deleted_file_id"] == "file-pdf"
     payload = json.dumps(captured["input"])
@@ -536,6 +604,112 @@ async def test_generate_slide_manifest_rejects_multiple_correct_options(
             "assistant-chat-model",
             fake_client,
         )
+
+
+async def test_persist_slide_manifest_replaces_existing_questions(db):
+    await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        old_question = models.LectureSlideQuestion(
+            lecture_slide_deck_id=1,
+            position=0,
+            slide_position=0,
+            slide_offset_ms=0,
+            stop_offset_ms=100,
+            question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+            question_text="Old question?",
+            intro_text="",
+            options=[
+                models.LectureSlideQuestionOption(
+                    position=0,
+                    option_text="Old option",
+                    post_answer_text="",
+                    continue_offset_ms=100,
+                )
+            ],
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.MANIFEST_GENERATION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([old_question, run])
+        await session.commit()
+        run_id = run.id
+
+    manifest = lecture_slide_processing.GeneratedSlideManifest(
+        questions=[
+            lecture_slide_processing.GeneratedSlideQuestion(
+                slide_position=0,
+                slide_offset_ms=250,
+                stop_offset_ms=250,
+                question_text="New question?",
+                options=[
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Correct",
+                        continue_offset_ms=500,
+                        correct=True,
+                    ),
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Incorrect",
+                        continue_offset_ms=500,
+                        correct=False,
+                    ),
+                ],
+            )
+        ],
+        summary_checkpoints=[
+            schemas.LectureVideoManifestSummaryCheckpointV4(
+                end_offset_ms=500,
+                summary="The slide introduces the new topic.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureVideoManifestMomentContextV4(
+                start_offset_ms=0,
+                center_offset_ms=250,
+                end_offset_ms=500,
+                before="The lesson starts.",
+                at="The question appears.",
+                after="The lesson continues.",
+            )
+        ],
+    )
+    transcript = [
+        schemas.LectureVideoManifestWordV3(
+            id="slide-0-word-0",
+            word="hello",
+            start_offset_ms=0,
+            end_offset_ms=100,
+        )
+    ]
+
+    await lecture_slide_processing._persist_slide_manifest(
+        run_id,
+        "lease",
+        1,
+        manifest,
+        transcript,
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.context_version == 4
+        assert deck.transcript_data is not None
+        assert len(deck.questions) == 1
+        assert deck.questions[0].question_text == "New question?"
+        assert [option.option_text for option in deck.questions[0].options] == [
+            "Correct",
+            "Incorrect",
+        ]
+        assert deck.questions[0].correct_option is not None
+        assert deck.questions[0].correct_option.option_text == "Correct"
 
 
 async def test_parse_responses_output_retries_transient_openai_failure(monkeypatch):

--- a/web/default.conf.template
+++ b/web/default.conf.template
@@ -25,7 +25,15 @@ server {
         try_files $uri $uri/ $uri.html /index.html;
     }
 
-    location ~* \.(?:css|js|jpg|svg|png|woff|woff2|ttf|mjs)$ {
+    location ~* \.mjs$ {
+        types {
+            application/javascript mjs;
+        }
+        expires 30d;
+        add_header Cache-Control "public";
+    }
+
+    location ~* \.(?:css|js|jpg|svg|png|woff|woff2|ttf)$ {
         expires 30d;
         add_header Cache-Control "public";
     }

--- a/web/default.conf.template
+++ b/web/default.conf.template
@@ -25,7 +25,7 @@ server {
         try_files $uri $uri/ $uri.html /index.html;
     }
 
-    location ~* \.(?:css|js|jpg|svg|png|woff|woff2|ttf)$ {
+    location ~* \.(?:css|js|jpg|svg|png|woff|woff2|ttf|mjs)$ {
         expires 30d;
         add_header Cache-Control "public";
     }


### PR DESCRIPTION
- Updated slide processing logic to ensure question offsets remain within slide timing ranges.
- Added reasoning and service tier parameters to OpenAI response handling.
- Implemented tests for replacing existing slide assets and persisting slide manifests, ensuring correct question updates.
- Enhanced documentation for slide lesson manifest adaptation with new offset derivation rules.