### PR TITLE
change(ui): remove assistant version badge

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -36,7 +36,6 @@
 		type ChatInputMessage
 	} from '$lib/components/ChatInput.svelte';
 	import ChatDropOverlay from '$lib/components/ChatDropOverlay.svelte';
-	import AssistantVersionBadge from '$lib/components/AssistantVersionBadge.svelte';
 	import {
 		RefreshOutline,
 		CodeOutline,
@@ -1921,9 +1920,6 @@
 						>
 							<span class="flex items-center gap-2">
 								{getName(message.data)}
-								{#if message.data.role !== 'user' && !assistantDeleted}
-									<AssistantVersionBadge version={$version} extraClasses="shrink-0" />
-								{/if}
 							</span>
 							<span
 								class="ml-1 text-xs font-normal text-gray-500 hover:underline"

--- a/web/pingpong/src/routes/threads/+page.svelte
+++ b/web/pingpong/src/routes/threads/+page.svelte
@@ -3,7 +3,6 @@
 	import * as api from '$lib/api';
 	import dayjs from '$lib/time';
 	import { Select, Button } from 'flowbite-svelte';
-	import AssistantVersionBadge from '$lib/components/AssistantVersionBadge.svelte';
 	import { page } from '$app/stores';
 	import { resolve } from '$app/paths';
 	import { getValue, updateSearch } from '$lib/urlstate';
@@ -132,7 +131,6 @@
 								<h4 class="eyebrow eyebrow-dark shrink truncate">
 									{Object.values(thread.assistant_names || { 1: 'Unknown Assistant' }).join(', ')}
 								</h4>
-								<AssistantVersionBadge version={thread.version} extraClasses="shrink-0" />
 							</div>
 							<div class="pt-2 pb-2 text-lg font-light">
 								{thread.name || 'New Conversation'}


### PR DESCRIPTION
## Thread Archive
### Updates & Improvements
* The assistant generation badge has been removed. Moderators can reference the assistant version in the Edit Assistant page.

## UI
### Updates & Improvements
* The assistant generation badge has been removed. A warning when using the older, Classic assistants may still appear for users.