### PR TITLE
feat(ui): open links in new tab on embed

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -102,6 +102,7 @@
 	export let data;
 
 	let userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	$: openAllLinksInNewTab = data.openAllLinksInNewTab;
 	$: routeClassId = parseInt($page.params.classId ?? '');
 	$: routeThreadId = parseInt($page.params.threadId ?? '');
 	$: expandedThreadData = api.expandResponse(data.threadData);
@@ -2529,6 +2530,7 @@
 										more information, please review <a
 											href={resolve('/privacy-policy')}
 											rel="noopener noreferrer"
+											target={openAllLinksInNewTab ? '_blank' : undefined}
 											class="underline">PingPong's privacy statement</a
 										>.&nbsp;
 									{/if}Assistants can make mistakes. Check important info.</Span
@@ -2551,6 +2553,7 @@
 												<a
 													href={resolve('/privacy-policy')}
 													rel="noopener noreferrer"
+													target={openAllLinksInNewTab ? '_blank' : undefined}
 													class="underline">PingPong's privacy statement</a
 												>.&nbsp;Assistants can make mistakes. Check important info.</Span
 											>
@@ -2570,6 +2573,7 @@
 												<a
 													href={resolve('/privacy-policy')}
 													rel="noopener noreferrer"
+													target={openAllLinksInNewTab ? '_blank' : undefined}
 													class="underline">PingPong's privacy statement</a
 												>.&nbsp;Assistants can make mistakes. Check important info.</Span
 											>
@@ -2586,6 +2590,7 @@
 										{#if isCurrentUser}For more information, please review <a
 												href={resolve('/privacy-policy')}
 												rel="noopener noreferrer"
+												target={openAllLinksInNewTab ? '_blank' : undefined}
 												class="underline">PingPong's privacy statement</a
 											>.&nbsp;
 										{/if}Assistants can make mistakes. Check important info.</Span

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -46,6 +46,7 @@
 	 * Application data.
 	 */
 	export let data;
+	$: openAllLinksInNewTab = data.openAllLinksInNewTab;
 	$: lectureVideoEnabled = data?.lectureVideoEnabled ?? true;
 	$: conversationId = $page.url.searchParams.get('conversation_id');
 
@@ -1018,8 +1019,11 @@
 									ontouchstart={showModeratorsModal}>Moderators</Button
 								> <span class="font-semibold">cannot</span> see this thread or your name. For more
 								information, please review
-								<a href={resolve('/privacy-policy')} rel="noopener noreferrer" class="underline"
-									>PingPong's privacy statement</a
+								<a
+									href={resolve('/privacy-policy')}
+									rel="noopener noreferrer"
+									target={openAllLinksInNewTab ? '_blank' : undefined}
+									class="underline">PingPong's privacy statement</a
 								>. Assistants can make mistakes. Check important info.</Span
 							>
 						</div>
@@ -1038,8 +1042,11 @@
 									<span class="font-semibold"
 										>your full name, and listen to a recording of your conversation</span
 									>. For more information, please review
-									<a href={resolve('/privacy-policy')} rel="noopener noreferrer" class="underline"
-										>PingPong's privacy statement</a
+									<a
+										href={resolve('/privacy-policy')}
+										rel="noopener noreferrer"
+										target={openAllLinksInNewTab ? '_blank' : undefined}
+										class="underline">PingPong's privacy statement</a
 									>. Assistants can make mistakes. Check important info.</Span
 								>
 							</div>
@@ -1055,8 +1062,11 @@
 										ontouchstart={showModeratorsModal}>Moderators</Button
 									> can see this thread and <span class="font-semibold">your full name</span>. For
 									more information, please review
-									<a href={resolve('/privacy-policy')} rel="noopener noreferrer" class="underline"
-										>PingPong's privacy statement</a
+									<a
+										href={resolve('/privacy-policy')}
+										rel="noopener noreferrer"
+										target={openAllLinksInNewTab ? '_blank' : undefined}
+										class="underline">PingPong's privacy statement</a
 									>. Assistants can make mistakes. Check important info.</Span
 								>
 							</div>
@@ -1072,8 +1082,11 @@
 									onclick={showModeratorsModal}
 									ontouchstart={showModeratorsModal}>Moderators</Button
 								> can see this thread but not your name. For more information, please review
-								<a href={resolve('/privacy-policy')} rel="noopener noreferrer" class="underline"
-									>PingPong's privacy statement</a
+								<a
+									href={resolve('/privacy-policy')}
+									rel="noopener noreferrer"
+									target={openAllLinksInNewTab ? '_blank' : undefined}
+									class="underline">PingPong's privacy statement</a
 								>. Assistants can make mistakes. Check important info.</Span
 							>
 						</div>

--- a/web/pingpong/src/routes/+layout.ts
+++ b/web/pingpong/src/routes/+layout.ts
@@ -84,10 +84,11 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
 	const hasAuthenticatedContext = authed || isLTIContext;
 	const needsOnboarding = !!meData.user && (!meData.user.first_name || !meData.user.last_name);
 	const needsAgreements = meData.agreement_id !== null;
+	const isEmbedded = typeof window !== 'undefined' && window.self !== window.top;
 	let doNotShowSidebar = false;
 	let forceShowSidebarButton = hasAuthenticatedContext;
 	let forceCollapsedLayout = hasAuthenticatedContext;
-	let openAllLinksInNewTab = false;
+	let openAllLinksInNewTab = isEmbedded;
 	let logoIsClickable = true;
 	let showSidebarItems = true;
 


### PR DESCRIPTION
## UI
### New Features
* When PingPong is embedded, external links, and some links that may lead users to pages they cannot navigate back from will open in a new window. This feature was previously available to some users when PingPong was launched in an LTI context.

### Updates & Improvements
* Added the "PingPong's privacy statement" link in the thread footnote to the list of links that will open in a new window when embedded or in an LTI context.