### PR TITLE
feat(slide): use ffmpeg for audio processing

### DIFF
--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -2780,6 +2780,9 @@ async def _persist_composite_artifacts(
             for page in sorted(deck.pages, key=lambda item: item.position)
             if page.narration is not None and page.narration.stored_object is not None
         ]
+        duration_ms = sum(
+            stored_object.duration_ms or 0 for stored_object in stored_objects
+        )
     combined_audio = await _combine_audio_objects(stored_objects)
     content_type = LECTURE_SLIDE_AUDIO_CONTENT_TYPE
     audio_key, audio_length = await _store_audio(
@@ -2813,7 +2816,6 @@ async def _persist_composite_artifacts(
                     with contextlib.suppress(Exception):
                         await config.video_store.store.delete(caption_key)
                 return
-            duration_ms = audio_duration_ms(combined_audio, content_type)
             audio_stored_object = models.LectureSlideNarrationStoredObject(
                 key=audio_key,
                 content_type=content_type,
@@ -2844,28 +2846,84 @@ async def _combine_audio_objects(
 ) -> bytes:
     if not stored_objects:
         return b""
-    chunks: list[bytes] = []
     if not config.lecture_video_audio_store:
         raise RuntimeError("Lecture video audio store is not configured.")
-    for stored_object in stored_objects:
-        data = bytearray()
-        async for chunk in config.lecture_video_audio_store.store.get_file(
-            stored_object.key
-        ):
-            data.extend(chunk)
-        chunks.append(bytes(data))
-    try:
-        combined = AudioSegment.empty()
-        for audio_data in chunks:
-            combined += AudioSegment.from_file(io.BytesIO(audio_data))
-        output = io.BytesIO()
-        combined.export(output, format="ogg")
-        return output.getvalue()
-    except Exception:
-        logger.warning(
-            "Falling back to byte concatenation for slide audio.", exc_info=True
-        )
-        return b"".join(chunks)
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise RuntimeError("ffmpeg is required for lecture slide audio concatenation.")
+
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        input_paths: list[Path] = []
+        for index, stored_object in enumerate(stored_objects):
+            input_path = temp_dir / f"input-{index}.ogg"
+            with input_path.open("wb") as file:
+                async for chunk in config.lecture_video_audio_store.store.get_file(
+                    stored_object.key
+                ):
+                    file.write(chunk)
+            input_paths.append(input_path)
+
+        output_path = temp_dir / "combined.ogg"
+        try:
+            await asyncio.to_thread(
+                _run_ffmpeg_concat,
+                ffmpeg_path,
+                input_paths,
+                output_path,
+                stream_copy=True,
+            )
+        except RuntimeError:
+            logger.warning(
+                "ffmpeg stream-copy concat failed; retrying with Opus re-encode.",
+                exc_info=True,
+            )
+            await asyncio.to_thread(
+                _run_ffmpeg_concat,
+                ffmpeg_path,
+                input_paths,
+                output_path,
+                stream_copy=False,
+            )
+        return output_path.read_bytes()
+
+
+def _run_ffmpeg_concat(
+    ffmpeg_path: str,
+    input_paths: Sequence[Path],
+    output_path: Path,
+    *,
+    stream_copy: bool,
+) -> None:
+    concat_path = output_path.with_suffix(".txt")
+    concat_path.write_text(
+        "".join(f"file '{_escape_ffmpeg_concat_path(path)}'\n" for path in input_paths)
+    )
+    codec_args = ["-c", "copy"] if stream_copy else ["-c:a", "libopus"]
+    command = [
+        ffmpeg_path,
+        "-y",
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(concat_path),
+        *codec_args,
+        str(output_path),
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise RuntimeError(f"ffmpeg concat failed: {stderr or completed.returncode}")
+
+
+def _escape_ffmpeg_concat_path(path: Path) -> str:
+    return path.as_posix().replace("\\", "\\\\").replace("'", "'\\''")
 
 
 async def _parse_responses_output(

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -107,6 +107,7 @@ RUN_LEASE_DURATION = timedelta(minutes=10)
 RUN_LEASE_HEARTBEAT_INTERVAL = min(timedelta(minutes=1), RUN_LEASE_DURATION / 2)
 UNEXPECTED_WORKER_EXIT_ERROR_MESSAGE = "Lecture slide worker exited unexpectedly."
 LECTURE_SLIDE_AUDIO_CONTENT_TYPE = "audio/ogg"
+FFMPEG_CONCAT_TIMEOUT_SECONDS = 300
 MAX_RUN_CREATE_RETRIES = 3
 OPENAI_GENERATION_MAX_ATTEMPTS = 3
 OPENAI_GENERATION_RETRY_DELAY_SECONDS = 5.0
@@ -2780,9 +2781,7 @@ async def _persist_composite_artifacts(
             for page in sorted(deck.pages, key=lambda item: item.position)
             if page.narration is not None and page.narration.stored_object is not None
         ]
-        duration_ms = sum(
-            stored_object.duration_ms or 0 for stored_object in stored_objects
-        )
+        duration_ms = _total_stored_audio_duration_ms(stored_objects)
     combined_audio = await _combine_audio_objects(stored_objects)
     content_type = LECTURE_SLIDE_AUDIO_CONTENT_TYPE
     audio_key, audio_length = await _store_audio(
@@ -2844,6 +2843,7 @@ async def _persist_composite_artifacts(
 async def _combine_audio_objects(
     stored_objects: Sequence[models.LectureSlideNarrationStoredObject],
 ) -> bytes:
+    """Combine stored Ogg/Opus narration objects without decoding them in Python."""
     if not stored_objects:
         return b""
     if not config.lecture_video_audio_store:
@@ -2888,6 +2888,23 @@ async def _combine_audio_objects(
         return output_path.read_bytes()
 
 
+def _total_stored_audio_duration_ms(
+    stored_objects: Sequence[models.LectureSlideNarrationStoredObject],
+) -> int:
+    """Return the sum of required stored narration durations."""
+    missing_duration_keys = [
+        stored_object.key
+        for stored_object in stored_objects
+        if stored_object.duration_ms is None
+    ]
+    if missing_duration_keys:
+        raise RuntimeError(
+            "Lecture slide narration duration is missing for stored object(s): "
+            + ", ".join(missing_duration_keys)
+        )
+    return sum(cast(int, stored_object.duration_ms) for stored_object in stored_objects)
+
+
 def _run_ffmpeg_concat(
     ffmpeg_path: str,
     input_paths: Sequence[Path],
@@ -2895,11 +2912,16 @@ def _run_ffmpeg_concat(
     *,
     stream_copy: bool,
 ) -> None:
+    """Run ffmpeg concat, preferring stream-copy unless re-encode is requested."""
     concat_path = output_path.with_suffix(".txt")
     concat_path.write_text(
         "".join(f"file '{_escape_ffmpeg_concat_path(path)}'\n" for path in input_paths)
     )
-    codec_args = ["-c", "copy"] if stream_copy else ["-c:a", "libopus"]
+    codec_args = (
+        ["-c", "copy"]
+        if stream_copy
+        else ["-c:a", "libopus", "-b:a", "64k", "-application", "voip"]
+    )
     command = [
         ffmpeg_path,
         "-y",
@@ -2916,13 +2938,38 @@ def _run_ffmpeg_concat(
         *codec_args,
         str(output_path),
     ]
-    completed = subprocess.run(command, capture_output=True, text=True)
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=FFMPEG_CONCAT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = _subprocess_timeout_output(exc)
+        raise RuntimeError(
+            f"ffmpeg concat timed out after {FFMPEG_CONCAT_TIMEOUT_SECONDS} seconds"
+            f"{output}"
+        ) from exc
     if completed.returncode != 0:
         stderr = completed.stderr.strip()
         raise RuntimeError(f"ffmpeg concat failed: {stderr or completed.returncode}")
 
 
+def _subprocess_timeout_output(exc: subprocess.TimeoutExpired) -> str:
+    """Format captured subprocess output for timeout errors."""
+    output_parts: list[str] = []
+    if exc.stdout:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else exc.stdout
+        output_parts.append(f"stdout={stdout.strip()}")
+    if exc.stderr:
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else exc.stderr
+        output_parts.append(f"stderr={stderr.strip()}")
+    return f" ({'; '.join(output_parts)})" if output_parts else ""
+
+
 def _escape_ffmpeg_concat_path(path: Path) -> str:
+    """Escape a path for ffmpeg's single-quoted concat demuxer syntax."""
     return path.as_posix().replace("\\", "\\\\").replace("'", "'\\''")
 
 

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -854,6 +854,76 @@ async def _async_value(value):
     return value
 
 
+async def test_combine_audio_objects_uses_ffmpeg_stream_copy(monkeypatch):
+    downloaded_keys: list[str] = []
+    commands: list[list[str]] = []
+    concat_files: list[str] = []
+
+    class FakeAudioStore:
+        async def get_file(self, key):
+            downloaded_keys.append(key)
+            yield key.encode("utf-8")
+            yield b"-audio"
+
+    def fake_run(command, *, capture_output, text):
+        commands.append(command)
+        concat_files.append(Path(command[command.index("-i") + 1]).read_text())
+        Path(command[-1]).write_bytes(b"combined-audio")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=FakeAudioStore())
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing.shutil, "which", lambda _name: "ffmpeg"
+    )
+    monkeypatch.setattr(lecture_slide_processing.subprocess, "run", fake_run)
+
+    result = await lecture_slide_processing._combine_audio_objects(
+        [SimpleNamespace(key="first.ogg"), SimpleNamespace(key="second.ogg")]
+    )
+
+    assert result == b"combined-audio"
+    assert downloaded_keys == ["first.ogg", "second.ogg"]
+    assert len(commands) == 1
+    assert commands[0][commands[0].index("-c") + 1] == "copy"
+    assert "file '" in concat_files[0]
+    assert "input-0.ogg" in concat_files[0]
+    assert "input-1.ogg" in concat_files[0]
+
+
+async def test_combine_audio_objects_reencodes_when_stream_copy_fails(monkeypatch):
+    commands: list[list[str]] = []
+
+    class FakeAudioStore:
+        async def get_file(self, key):
+            yield key.encode("utf-8")
+
+    def fake_run(command, *, capture_output, text):
+        commands.append(command)
+        if len(commands) == 1:
+            return SimpleNamespace(returncode=1, stderr="copy failed")
+        Path(command[-1]).write_bytes(b"reencoded-audio")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=FakeAudioStore())
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing.shutil, "which", lambda _name: "ffmpeg"
+    )
+    monkeypatch.setattr(lecture_slide_processing.subprocess, "run", fake_run)
+
+    result = await lecture_slide_processing._combine_audio_objects(
+        [SimpleNamespace(key="first.ogg")]
+    )
+
+    assert result == b"reencoded-audio"
+    assert len(commands) == 2
+    assert commands[0][commands[0].index("-c") + 1] == "copy"
+    assert commands[1][commands[1].index("-c:a") + 1] == "libopus"
+
+
 async def test_transcribe_audio_words_enriches_punctuation_from_segments(tmp_path):
     class FakeTranscriptions:
         async def create(self, **_kwargs):
@@ -1411,6 +1481,9 @@ async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
         stored_content_types.append(content_type)
         return store_key, len(audio)
 
+    def fail_audio_duration(*_args):
+        pytest.fail("composite artifact duration should use page narration durations")
+
     monkeypatch.setattr(config, "video_store", SimpleNamespace(store=FakeVideoStore()))
     monkeypatch.setattr(
         lecture_slide_processing,
@@ -1418,7 +1491,9 @@ async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
         lambda _stored_objects: _async_value(b"combined-ogg"),
     )
     monkeypatch.setattr(lecture_slide_processing, "_store_audio", fake_store_audio)
-    monkeypatch.setattr(lecture_slide_processing, "audio_duration_ms", lambda *_: 200)
+    monkeypatch.setattr(
+        lecture_slide_processing, "audio_duration_ms", fail_audio_duration
+    )
 
     await lecture_slide_processing._persist_composite_artifacts(
         run_id,
@@ -1439,6 +1514,7 @@ async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
         assert deck is not None
         assert deck.continuous_narration_stored_object is not None
         assert deck.continuous_narration_stored_object.content_type == "audio/ogg"
+        assert deck.continuous_narration_stored_object.duration_ms == 200
 
 
 async def test_synthesize_knowledge_check_audio_deletes_uploaded_audio_when_db_lookup_raises(

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -865,9 +865,10 @@ async def test_combine_audio_objects_uses_ffmpeg_stream_copy(monkeypatch):
             yield key.encode("utf-8")
             yield b"-audio"
 
-    def fake_run(command, *, capture_output, text):
+    def fake_run(command, *, capture_output, text, timeout):
         commands.append(command)
         concat_files.append(Path(command[command.index("-i") + 1]).read_text())
+        assert timeout == lecture_slide_processing.FFMPEG_CONCAT_TIMEOUT_SECONDS
         Path(command[-1]).write_bytes(b"combined-audio")
         return SimpleNamespace(returncode=0, stderr="")
 
@@ -899,7 +900,7 @@ async def test_combine_audio_objects_reencodes_when_stream_copy_fails(monkeypatc
         async def get_file(self, key):
             yield key.encode("utf-8")
 
-    def fake_run(command, *, capture_output, text):
+    def fake_run(command, *, capture_output, text, timeout):
         commands.append(command)
         if len(commands) == 1:
             return SimpleNamespace(returncode=1, stderr="copy failed")
@@ -922,6 +923,70 @@ async def test_combine_audio_objects_reencodes_when_stream_copy_fails(monkeypatc
     assert len(commands) == 2
     assert commands[0][commands[0].index("-c") + 1] == "copy"
     assert commands[1][commands[1].index("-c:a") + 1] == "libopus"
+    assert commands[1][commands[1].index("-b:a") + 1] == "64k"
+    assert commands[1][commands[1].index("-application") + 1] == "voip"
+
+
+async def test_combine_audio_objects_requires_ffmpeg(monkeypatch):
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=SimpleNamespace())
+    )
+    monkeypatch.setattr(lecture_slide_processing.shutil, "which", lambda _name: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="ffmpeg is required for lecture slide audio concatenation",
+    ):
+        await lecture_slide_processing._combine_audio_objects(
+            [SimpleNamespace(key="first.ogg")]
+        )
+
+
+async def test_combine_audio_objects_reencodes_when_stream_copy_times_out(monkeypatch):
+    commands: list[list[str]] = []
+
+    class FakeAudioStore:
+        async def get_file(self, key):
+            yield key.encode("utf-8")
+
+    def fake_run(command, *, capture_output, text, timeout):
+        commands.append(command)
+        if len(commands) == 1:
+            raise lecture_slide_processing.subprocess.TimeoutExpired(
+                command, timeout, stderr=b"stalled"
+            )
+        Path(command[-1]).write_bytes(b"reencoded-audio")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=FakeAudioStore())
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing.shutil, "which", lambda _name: "ffmpeg"
+    )
+    monkeypatch.setattr(lecture_slide_processing.subprocess, "run", fake_run)
+
+    result = await lecture_slide_processing._combine_audio_objects(
+        [SimpleNamespace(key="first.ogg")]
+    )
+
+    assert result == b"reencoded-audio"
+    assert len(commands) == 2
+    assert commands[0][commands[0].index("-c") + 1] == "copy"
+    assert commands[1][commands[1].index("-c:a") + 1] == "libopus"
+
+
+async def test_total_stored_audio_duration_requires_every_duration():
+    with pytest.raises(
+        RuntimeError,
+        match="Lecture slide narration duration is missing",
+    ):
+        lecture_slide_processing._total_stored_audio_duration_ms(
+            [
+                SimpleNamespace(key="ready.ogg", duration_ms=100),
+                SimpleNamespace(key="missing.ogg", duration_ms=None),
+            ]
+        )
 
 
 async def test_transcribe_audio_words_enriches_punctuation_from_segments(tmp_path):


### PR DESCRIPTION
- Implemented audio concatenation using ffmpeg for improved performance and reliability in _combine_audio_objects.
- Added error handling to fall back on Opus re-encoding if stream-copy fails.
- Updated _persist_composite_artifacts to calculate audio duration from page narrations.
- Introduced unit tests to validate ffmpeg integration and error handling scenarios.