### PR TITLE
change(slides): do not include full knowledge check history

### DIFF
--- a/pingpong/lecture_slide_chat.py
+++ b/pingpong/lecture_slide_chat.py
@@ -250,31 +250,11 @@ def _format_slide_narrations(deck: models.LectureSlideDeck) -> str:
     return "\n".join(lines)
 
 
-def _format_all_knowledge_checks(deck: models.LectureSlideDeck) -> str:
-    lines = ["### Lecture Knowledge Checks"]
-    questions = sorted(deck.questions, key=lambda item: item.position)
-    if not questions:
-        lines.extend(["", "None."])
-        return "\n".join(lines)
-    for question in questions:
-        lines.extend(
-            [
-                "",
-                _format_knowledge_check_prompt(
-                    question,
-                    prefix=f"At {question.stop_offset_ms}ms:",
-                ),
-            ]
-        )
-    return "\n".join(lines)
-
-
 def _format_initial_lecture_developer_context(deck: models.LectureSlideDeck) -> str:
     return "\n\n".join(
         [
             "## Lecture Slide Lesson Context",
             _format_slide_narrations(deck),
-            _format_all_knowledge_checks(deck),
         ]
     )
 

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -885,10 +885,10 @@ async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
     assert lesson_context_message.role == schemas.MessageRole.DEVELOPER
     assert "## Lecture Slide Narrations" in lesson_context_text
     assert "This slide introduces the core idea." in lesson_context_text
-    assert "## Lecture Knowledge Checks" in lesson_context_text
-    assert "What is shown on this slide?" in lesson_context_text
-    assert "What comes next?" in lesson_context_text
-    assert "A clear example" in lesson_context_text
+    assert "## Lecture Knowledge Checks" not in lesson_context_text
+    assert "What is shown on this slide?" not in lesson_context_text
+    assert "What comes next?" not in lesson_context_text
+    assert "A clear example" not in lesson_context_text
     assert file_message.is_hidden is True
     assert file_message.role == schemas.MessageRole.USER
     assert file_message.content[0].type == schemas.MessagePartType.INPUT_FILE

--- a/pingpong/test_migrations_m12_upload_lecture_slide_sources_to_openai.py
+++ b/pingpong/test_migrations_m12_upload_lecture_slide_sources_to_openai.py
@@ -267,7 +267,6 @@ async def test_upload_lecture_slide_sources_to_openai_does_not_bump_without_uplo
         old_deck_id = deck.id
         thread_id = thread.id
         assistant_id = assistant.id
-        file_object_id = file.id
 
     async with db.async_session() as session:
         result = await migration.upload_lecture_slide_sources_to_openai(session)


### PR DESCRIPTION
## Lecture Slides (Preview)
### Updates & Improvements
* Lecture Slides chat now provides the model Knowledge Check context in developer messages only as learners reach each check, instead of loading the full list when chat first starts.

Closes #1804 