### PR TITLE
feat(slides): update default lecture prompt

### DIFF
--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -4821,7 +4821,7 @@ def format_instructions(
         if lecture_video_mode:
             instructions += (
                 "\n\n"
-                "---Formatting: Lecture Video Dual Speech/Display Blocks---\n"
+                "---Formatting: Lecture Dual Speech/Display Blocks---\n"
                 "Before producing the final answer, check whether any part of it "
                 "contains math, symbols, formulas, special characters, "
                 "notation, or any text that should be spoken differently from "
@@ -5013,7 +5013,7 @@ def format_instructions(
     if lecture_video_mode:
         instructions += (
             "\n\n"
-            "---Formatting: Lecture Video Follow-ups---\n"
+            "---Formatting: Lecture Follow-ups---\n"
             "At the very end of your final answer, you may emit follow-up "
             "responses that the student can select to continue the chat. Three "
             "is the maximum, not a target. Return 0, 1, 2, or 3 responses "

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -44,6 +44,7 @@ from pingpong.config import config
 from pingpong.errors import capture_exception_to_sentry, sentry
 from pingpong.elevenlabs import synthesize_elevenlabs_speech
 from pingpong.lecture_video_manifest_generation import (
+    DEFAULT_LECTURE_INSTRUCTIONS,
     DEFAULT_GENERATION_PROMPT_CONTENT,
     _augment_manifest_words_with_segment_text,
     _generation_transcript_source_text,
@@ -85,6 +86,85 @@ class SlideQuestionPauseOffsets(TypedDict):
 
 OptionalSlideQuestionPauseOffsets = SlideQuestionPauseOffsets | None
 
+
+LECTURE_SLIDES_CONTENT_SECTION = """### Context Provided
+At the start of a lecture slide chat, the learner's first question may be preceded by developer message **hidden from the learner** and titled **"## Lecture Slide Lesson Context"**. Carefully use it as the source for the generated slide narration.
+
+The structure within the "Lecture Slide Lesson Context" matches this format:
+
+-----BEGIN LECTURE SLIDE LESSON CONTEXT-----
+
+## Lecture Slide Lesson Context
+
+### Lecture Slide Narrations
+
+### Slide 1
+The generated narration for slide 1.
+
+### Slide 2
+
+The generated narration for slide 2.
+
+...
+
+-----END LECTURE SLIDE LESSON CONTEXT-----
+
+# Source PDF Slide Deck
+If available, the source PDF slide deck is attached in a user message **hidden from the learner** after the hidden developer message titled "## Lecture Slide Lesson Context" as the visual source of truth for the lecture conversation. Use it to ground answers about slide visuals, text, diagrams, equations, and layout.
+
+Each turn, the learner's question is preceded by a developer message **hidden from the learner** and titled **"## Lecture Context"**. Carefully read the entire message before answering, as it presents the latest state and history of the learning session.
+
+The structure within the "Lecture Context" matches this format:
+
+-----BEGIN LECTURE CONTEXT-----
+
+## Lecture Slide Lesson Context
+
+### Lecture Slide Narrations
+
+## Lecture Context
+- **Status:** Indicates the learner’s present activity. One of:
+    - *Viewing the lecture slides*
+    - *Answering Knowledge Check #{n}*
+    - *Just answered Knowledge Check #{n}*
+    - *Finished the lecture slides*
+- **Current offset:** How far into the video the learner is currently, in milliseconds.
+- **Furthest watched offset:** How far into the video the learner has watched so far, in milliseconds. The learner may have paused or rewound the video.
+
+### Current Knowledge Check
+If the learner is currently working on a Knowledge Check, this section lists:
+- The question text.
+- Each option, marked as (correct), (incorrect), or (unknown).
+- Feedback displayed after each choice.
+
+### Upcoming Knowledge Check
+If a Knowledge Check is approaching, this section provides:
+- When it will occur (offset).
+- The exact question and its options (with correct/incorrect/unknown labels and feedback), but **do not use, reveal, or discuss the content or answer until the student has seen it.**
+  You may reference generally that a related question is coming.
+
+### Knowledge Checks Answered
+Chronological list of previous Knowledge Check interactions, each showing:
+- When it occurred, which question was asked, and what option the student selected.
+- How each option was marked and what feedback was given.
+- Use this to reinforce prior correct answers or gently revisit mistakes.
+
+-----END LECTURE CONTEXT-----
+
+The learner's own question immediately follows this developer message.
+"""
+
+
+DEFAULT_LECTURE_SLIDE_INSTRUCTIONS = DEFAULT_LECTURE_INSTRUCTIONS.safe_substitute(
+    {
+        "lecture_type": "slides",
+        "activity_lesson": "narrating the slides",
+        "context_provided_text": LECTURE_SLIDES_CONTENT_SECTION,
+        "context_array_scope": "'Current Knowledge Check', or past 'Knowledge Checks Answered'",
+        "content_array_scope_2": "'Upcoming Knowledge Check'",
+        "notes_text": "Under no circumstances should you provide or explain information from 'Upcoming Knowledge Check' until it has actually appeared in a past Knowledge Check.",
+    }
+)
 
 DEFAULT_NARRATION_PROMPT = """You are the instructor giving a lecture from this PDF slide deck.
 

--- a/pingpong/lecture_video_manifest_generation.py
+++ b/pingpong/lecture_video_manifest_generation.py
@@ -15,6 +15,7 @@ import openai
 from google.genai.client import AsyncClient
 from google.genai import types
 from pydantic import BaseModel, ConfigDict, Field
+from string import Template
 
 import pingpong.schemas as schemas
 from pingpong import gemini as gemini_helpers
@@ -37,67 +38,24 @@ def _log_missing_ffprobe_once() -> None:
     )
 
 
-DEFAULT_LECTURE_VIDEO_INSTRUCTIONS = """You are a friendly, clear tutor helping a learner during an interactive video lesson in a chat interface. You are speaking in the voice of the person in the video, so use pronouns "I/me".
+DEFAULT_LECTURE_INSTRUCTIONS: Template = Template("""You are a friendly, clear tutor helping a learner during an interactive $lecture_type lesson in a chat interface. You are speaking in the voice of the person $activity_lesson, so use pronouns "I/me".
 While the user can only type text, your responses will be **spoken aloud**, so they must sound natural, simple, and easy to follow.
 
 ---
 
-### Context Provided
-Each turn, the learner's question is preceded by a hidden developer message titled **"## Lecture Context"**. Carefully read the entire message before answering, as it presents the latest state and history of the learning session.
-The structure within the "Lecture context" matches this format:
-
------BEGIN LECTURE CONTEXT-----
-
-## Lecture Context
-- **Status:** Indicates the learner’s present activity. One of:
-    - *Watching the lecture video*
-    - *Answering Knowledge Check #{n}*
-    - *Just answered Knowledge Check #{n}*
-    - *Finished watching the lecture video*
-- **Current offset:** How far into the video the learner is currently, in milliseconds.
-- **Furthest watched offset:** How far into the video the learner has watched so far, in milliseconds. The learner may have paused or rewound the video.
-
-### Lecture Summary So Far
-A natural-language summary of the concepts, explanations, and main points already introduced in the lesson.
-
-### Current Moment Context
-- **Before this moment:** What the lecture and visuals covered just prior to the current point.
-- **At this moment:** What is occurring in the video at the present offset—focus carefully on this segment when answering.
-- **After this moment:** What will occur next—but you must avoid using or revealing this information unless acknowledging that it is coming (without explaining its substance).
-
-### Current Knowledge Check
-If the learner is currently working on a Knowledge Check, this section lists:
-- The question text.
-- Each option, marked as (correct), (incorrect), or (unknown).
-- Feedback displayed after each choice.
-
-### Upcoming Knowledge Check
-If a Knowledge Check is approaching, this section provides:
-- When it will occur (offset).
-- The exact question and its options (with correct/incorrect/unknown labels and feedback), but **do not use, reveal, or discuss the content or answer until the student has seen it.**
-  You may reference generally that a related question is coming.
-
-### Knowledge Checks Answered
-Chronological list of previous Knowledge Check interactions, each showing:
-- When it occurred, which question was asked, and what option the student selected.
-- How each option was marked and what feedback was given.
-- Use this to reinforce prior correct answers or gently revisit mistakes.
-
------END LECTURE CONTEXT-----
-
-The learner's own question immediately follows this developer message.
+$context_provided_text
 
 ---
 
-### Instructions
+# Instructions
 
 **Critical Content Control Rule**
-- **Never provide information, details, explanations, or content that have not yet appeared in the 'What the learner has encountered so far', 'Before this moment', 'At this moment', 'Current Knowledge Check', or past 'Knowledge Checks Answered'.**
-    - Do not reveal or elaborate on any material shown in 'After this moment' or 'Upcoming Knowledge Check' before those moments or questions actually occur.
+- **Never provide information, details, explanations, or content that have not yet appeared in the $context_array_scope.**
+    - Do not reveal or elaborate on any material shown in $content_array_scope_2 before those moments or questions actually occur.
     - You may briefly state that future concepts are coming (e.g., "We'll cover that in a moment"), but do not provide their substance ahead of time.
     - This applies to all responses, including direct student questions, requests for summaries, or answers to knowledge check content.
 - *Always draw only on content from the present and past portions of the context; anticipate but do not preempt upcoming information.*
-- If the available present-and-past context is sparse or insufficient, **do not fill gaps by drawing from 'After this moment' or 'Upcoming Knowledge Check'.** Instead, say only what is supported by the available material and, if needed, briefly encourage the learner to continue.
+- If the available present-and-past context is sparse or insufficient, **do not fill gaps by drawing from $content_array_scope_2.** Instead, say only what is supported by the available material and, if needed, briefly encourage the learner to continue.
 
 **1. Be clear and easy to follow**
 * Use plain language matched to the lecture level.
@@ -157,7 +115,7 @@ Respond with **only the answer**, as if speaking to the learner directly—clear
 Respond with a short, conversational spoken explanation. Avoid jargon unless defined. Do not repeat the question or instructions, and do not reference the context structure—speak only to the learner, in character.
 
 # Notes
-- Under no circumstances should you provide or explain information from 'After this moment' or 'Upcoming Knowledge Check' until it has actually become part of the "What the learner has encountered so far" or appeared in a past Knowledge Check.
+- $notes_text
 - When summarizing "so far," reference only what has been encountered, not what is still to come.
 - If there is insufficient past content, say so, and encourage watching further.
 - Make all explanations accessible at the learner’s level and easy to follow when spoken.
@@ -167,7 +125,64 @@ Respond with a short, conversational spoken explanation. Avoid jargon unless def
 
 ---
 
-**Remember: Always base your answer strictly on what has already happened in the lesson, as detailed above, and deliver your reply in a friendly, natural-sounding way suited for spoken delivery.**"""
+**Remember: Always base your answer strictly on what has already happened in the lesson, as detailed above, and deliver your reply in a friendly, natural-sounding way suited for spoken delivery.**""")
+
+LECTURE_VIDEO_CONTENT_SECTION = """### Context Provided
+Each turn, the learner's question is preceded by a hidden developer message titled **"## Lecture Context"**. Carefully read the entire message before answering, as it presents the latest state and history of the learning session.
+The structure within the "Lecture context" matches this format:
+
+-----BEGIN LECTURE CONTEXT-----
+
+## Lecture Context
+- **Status:** Indicates the learner’s present activity. One of:
+    - *Watching the lecture video*
+    - *Answering Knowledge Check #{n}*
+    - *Just answered Knowledge Check #{n}*
+    - *Finished watching the lecture video*
+- **Current offset:** How far into the video the learner is currently, in milliseconds.
+- **Furthest watched offset:** How far into the video the learner has watched so far, in milliseconds. The learner may have paused or rewound the video.
+
+### Lecture Summary So Far
+A natural-language summary of the concepts, explanations, and main points already introduced in the lesson.
+
+### Current Moment Context
+- **Before this moment:** What the lecture and visuals covered just prior to the current point.
+- **At this moment:** What is occurring in the video at the present offset—focus carefully on this segment when answering.
+- **After this moment:** What will occur next—but you must avoid using or revealing this information unless acknowledging that it is coming (without explaining its substance).
+
+### Current Knowledge Check
+If the learner is currently working on a Knowledge Check, this section lists:
+- The question text.
+- Each option, marked as (correct), (incorrect), or (unknown).
+- Feedback displayed after each choice.
+
+### Upcoming Knowledge Check
+If a Knowledge Check is approaching, this section provides:
+- When it will occur (offset).
+- The exact question and its options (with correct/incorrect/unknown labels and feedback), but **do not use, reveal, or discuss the content or answer until the student has seen it.**
+  You may reference generally that a related question is coming.
+
+### Knowledge Checks Answered
+Chronological list of previous Knowledge Check interactions, each showing:
+- When it occurred, which question was asked, and what option the student selected.
+- How each option was marked and what feedback was given.
+- Use this to reinforce prior correct answers or gently revisit mistakes.
+
+-----END LECTURE CONTEXT-----
+
+The learner's own question immediately follows this developer message.
+"""
+
+DEFAULT_LECTURE_VIDEO_INSTRUCTIONS: str = DEFAULT_LECTURE_INSTRUCTIONS.safe_substitute(
+    {
+        "lecture_type": "video",
+        "activity_lesson": "in the video",
+        "context_provided_text": LECTURE_VIDEO_CONTENT_SECTION,
+        "context_array_scope": "'What the learner has encountered so far', 'Before this moment', 'At this moment', 'Current Knowledge Check', or past 'Knowledge Checks Answered'",
+        "content_array_scope_2": "'After this moment' or 'Upcoming Knowledge Check'",
+        "notes_text": "Under no circumstances should you provide or explain information from 'After this moment' or 'Upcoming Knowledge Check' until it has actually become part of the \"What the learner has encountered so far\" or appeared in a past Knowledge Check.",
+    }
+)
 
 DEFAULT_GENERATION_PROMPT_CONTENT = """You will generate an interactive video lesson for the given lecture video and transcript.
 

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1147,6 +1147,7 @@ class LectureVideoDefaults(BaseModel):
     instructions: str
     generation_prompt: str
     can_generate_manifest: bool = False
+    lecture_slides_instructions: str
     lecture_slide_generation_prompt: str
     lecture_slide_narration_prompt: str
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -3961,6 +3961,7 @@ async def list_class_models(
             instructions=lecture_video_manifest_generation.DEFAULT_LECTURE_VIDEO_INSTRUCTIONS,
             generation_prompt=lecture_video_manifest_generation.DEFAULT_GENERATION_PROMPT_CONTENT,
             can_generate_manifest=lecture_video_context["has_gemini_credential"],
+            lecture_slides_instructions=lecture_slide_processing.DEFAULT_LECTURE_SLIDE_INSTRUCTIONS,
             lecture_slide_generation_prompt=lecture_slide_processing.DEFAULT_GENERATION_PROMPT_CONTENT,
             lecture_slide_narration_prompt=lecture_slide_processing.DEFAULT_NARRATION_PROMPT,
         )

--- a/pingpong/test_lecture_video_run_instructions.py
+++ b/pingpong/test_lecture_video_run_instructions.py
@@ -68,9 +68,9 @@ async def test_build_run_instructions_for_lecture_video_with_latex_includes_say_
     assert instructions is not None
     assert "Stored lecture snapshot." in instructions
     assert "Updated assistant instructions." not in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
 
 
 async def test_build_run_instructions_for_lecture_video_forces_latex_and_say_contract(
@@ -89,9 +89,9 @@ async def test_build_run_instructions_for_lecture_video_forces_latex_and_say_con
     assert instructions is not None
     assert "Stored lecture snapshot." in instructions
     assert "Updated assistant instructions." not in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
 
 
 async def test_build_run_instructions_for_lecture_video_normalizes_missing_thread_snapshot(
@@ -109,8 +109,8 @@ async def test_build_run_instructions_for_lecture_video_normalizes_missing_threa
 
     assert instructions is not None
     assert "Assistant fallback instructions." in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
 
 
 async def test_build_run_instructions_for_lecture_slides_uses_lecture_formatting(
@@ -129,8 +129,8 @@ async def test_build_run_instructions_for_lecture_slides_uses_lecture_formatting
     assert instructions is not None
     assert "Stored slide snapshot." in instructions
     assert "Updated assistant instructions." not in instructions
-    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
 
 
 async def test_lecture_slides_enable_dual_text_and_followups():

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -1238,7 +1238,7 @@ async def test_get_thread_returns_lecture_video_session(
     data = response.json()
     assert data["instructions"] is not None
     assert data["instructions"].startswith("You are a lecture assistant.")
-    assert "---Formatting: Lecture Video Follow-ups---" in data["instructions"]
+    assert "---Formatting: Lecture Follow-ups---" in data["instructions"]
     session_data = data["lecture_video_session"]
     assert session_data["state"] == "playing"
     assert session_data["last_known_offset_ms"] == 0

--- a/pingpong/test_say_transform.py
+++ b/pingpong/test_say_transform.py
@@ -40,7 +40,7 @@ def test_format_instructions_adds_block_contract_for_lecture_video_latex_only():
         lecture_video_mode=True,
     )
 
-    assert "---Formatting: Lecture Video Dual Speech/Display Blocks---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions
     assert "---Formatting: LaTeX---" not in instructions
     assert "MUST emit that part as a private-use block" in instructions
     assert "JSON object with at least one of `speech` or `content`" in instructions
@@ -84,7 +84,7 @@ def test_format_instructions_adds_block_contract_for_lecture_video_latex_only():
     ) in instructions
     assert "A block may not contain another block" in instructions
     assert "Do not place blocks inside markdown links" in instructions
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
     assert f"{SAY_MARKER_START}followups{SAY_MARKER_SEPARATOR}" in instructions
     assert '"responses"' in instructions
 
@@ -97,10 +97,8 @@ def test_format_instructions_does_not_add_block_contract_for_normal_latex_chat()
     )
 
     assert "---Formatting: LaTeX---" in instructions
-    assert (
-        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
-    )
-    assert "---Formatting: Lecture Video Follow-ups---" not in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" not in instructions
+    assert "---Formatting: Lecture Follow-ups---" not in instructions
 
 
 def test_format_instructions_does_not_add_block_contract_without_latex():
@@ -111,10 +109,8 @@ def test_format_instructions_does_not_add_block_contract_without_latex():
     )
 
     assert "---Formatting: LaTeX---" not in instructions
-    assert (
-        "---Formatting: Lecture Video Dual Speech/Display Blocks---" not in instructions
-    )
-    assert "---Formatting: Lecture Video Follow-ups---" in instructions
+    assert "---Formatting: Lecture Dual Speech/Display Blocks---" not in instructions
+    assert "---Formatting: Lecture Follow-ups---" in instructions
 
 
 def test_transform_returns_body_for_display():

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -1893,8 +1893,7 @@ async def test_preview_assistant_instructions_includes_lecture_video_say_contrac
     assert response.status_code == 200
     instructions_preview = response.json()["instructions_preview"]
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Blocks---"
-        in instructions_preview
+        "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions_preview
     )
 
 
@@ -1922,8 +1921,7 @@ async def test_preview_assistant_instructions_for_lecture_slides_forces_latex_fo
     assert response.status_code == 200
     instructions_preview = response.json()["instructions_preview"]
     assert (
-        "---Formatting: Lecture Video Dual Speech/Display Blocks---"
-        in instructions_preview
+        "---Formatting: Lecture Dual Speech/Display Blocks---" in instructions_preview
     )
     assert "---Formatting: Mermaid---" in instructions_preview
 

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -2621,6 +2621,7 @@ export type AssistantModels = {
 		instructions: string;
 		generation_prompt: string;
 		can_generate_manifest: boolean;
+		lecture_slides_instructions: string;
 		lecture_slide_generation_prompt: string;
 		lecture_slide_narration_prompt: string;
 	} | null;

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -89,6 +89,7 @@
 		data.lectureVideoDefaults?.lecture_slide_generation_prompt || '';
 	$: lectureSlideDefaultNarrationPrompt =
 		data.lectureVideoDefaults?.lecture_slide_narration_prompt || '';
+	$: lectureSlideDefaultInstructions = data.lectureVideoDefaults?.lecture_slides_instructions || '';
 	const SUPPORTED_LECTURE_VIDEO_QUESTION_TYPES = new Set<api.LectureVideoQuestionType>([
 		'single_select'
 	]);
@@ -1899,7 +1900,9 @@
 			instructions = assistant.instructions;
 			hasSetInstructions = true;
 		} else if ((mode === 'lecture_video' || mode === 'lecture_slides') && data.isCreating) {
-			instructions = lectureVideoDefaultInstructions;
+			instructions = isLectureVideoMode
+				? lectureVideoDefaultInstructions
+				: lectureSlideDefaultInstructions;
 			hasSetInstructions = true;
 		} else {
 			await tick();
@@ -2189,7 +2192,9 @@
 			data.isCreating &&
 			isLectureMode &&
 			normalizeNewlines(params.instructions || '') ===
-				normalizeNewlines(lectureVideoDefaultInstructions)
+				normalizeNewlines(
+					isLectureVideoMode ? lectureVideoDefaultInstructions : lectureSlideDefaultInstructions
+				)
 		) {
 			fields = fields.filter((field) => field !== 'instructions');
 		}
@@ -4587,8 +4592,14 @@
 						{#if isLectureMode}
 							{@const haveInstructionsChanged =
 								normalizeNewlines(instructions) !==
-									normalizeNewlines(lectureVideoDefaultInstructions) &&
-								!!lectureVideoDefaultInstructions}
+									normalizeNewlines(
+										isLectureVideoMode
+											? lectureVideoDefaultInstructions
+											: lectureSlideDefaultInstructions
+									) &&
+								!!(isLectureVideoMode
+									? lectureVideoDefaultInstructions
+									: lectureSlideDefaultInstructions)}
 							<div class="col-span-2 mb-1">
 								<div class="flex flex-row items-end justify-between">
 									<div>
@@ -4617,7 +4628,9 @@
 												uploadingFSPrivate ||
 												uploadingCIPrivate}
 											onclick={() => {
-												instructions = lectureVideoDefaultInstructions;
+												instructions = isLectureVideoMode
+													? lectureVideoDefaultInstructions
+													: lectureSlideDefaultInstructions;
 											}}>Switch to latest default</button
 										>
 										<Button

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.ts
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.ts
@@ -39,6 +39,7 @@ async function ensureModels(
 		instructions: string;
 		generation_prompt: string;
 		can_generate_manifest: boolean;
+		lecture_slides_instructions: string;
 		lecture_slide_generation_prompt: string;
 		lecture_slide_narration_prompt: string;
 	} | null;


### PR DESCRIPTION
## Lecture Slides (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Slides, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
>
> Lecture Slides mode is currently visible only to institutional admins when creating an assistant.

### Updates & Improvements
* Lecture Video and Lecture Slides now use a shared lecture prompt template with separate context sections for each lesson type.
* New Lecture Slide assistants now start with a slide-specific chat prompt that grounds learner answers in slide narrations, the source PDF deck, current slide state, and knowledge-check history.
* The Edit Assistant page now compares and resets Lecture Slide chat instructions against the Lecture Slides default prompt instead of the Lecture Video default prompt.

Resolves #1807, resolves #1806 