### PR TITLE
change(slides): lower service_tier and reasoning

### DIFF
--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -3030,8 +3030,7 @@ async def _parse_responses_output(
                 instructions=instructions,
                 input=input_messages,
                 text_format=response_model,
-                reasoning=Reasoning(effort="high", summary=None),
-                service_tier="priority",
+                reasoning=Reasoning(effort="medium", summary=None),
                 store=False,
             )
             if response.output_parsed is None:


### PR DESCRIPTION
## Lecture Slides (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Slides, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
>
> Lecture Slides mode is currently visible only to institutional admins when creating an assistant.

### Updates & Improvements
* To more effectively manage costs, return to the `default` service tier, down from `priority`.
* To more effectively manage latency, use `medium` reasoning effort instead of `high`.