### PR TITLE
feat(slides): revamp slide editor and question generation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test Python
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
       wd: ./

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import pingpong.models as models
 import pingpong.schemas as schemas
+from pingpong import lecture_slide_service
 from pingpong import lecture_video_processing
 from pingpong.ai import get_openai_client_by_class_id
 from pingpong.class_credential_validation import (
@@ -314,18 +315,18 @@ Use surrounding context to avoid boundary artifacts, but keep generated offsets 
         {question.slide_position for question in manual_questions or []}
     )
     partial_question_positions = sorted(
-        {
+        [
             question.slide_position
             for question in question_requests or []
             if question.mode == schemas.LectureSlideQuestionDraftMode.PARTIAL
-        }
+        ]
     )
     marker_question_positions = sorted(
-        {
+        [
             question.slide_position
             for question in question_requests or []
             if question.mode == schemas.LectureSlideQuestionDraftMode.MARKER
-        }
+        ]
     )
     manual_question_guidance = ""
     if manual_question_positions:
@@ -344,9 +345,11 @@ INSTRUCTOR QUESTION REQUESTS:
 The instructor requested model-completed questions after these zero-based slide positions.
 - Partial question drafts to complete: {partial_question_positions}
 - Marker-only required questions to create: {marker_question_positions}
-You must include exactly one question after each of those slide positions in your output unless that slide is outside the generation window.
+You must include exactly one distinct question for each requested entry unless that slide is outside the generation window.
+These requested entries are required minimums, not an exclusive list of allowed question locations.
+You may generate additional questions at other useful slide breakpoints that were not selected by the instructor.
 Use any provided partial prompt, narration, options, feedback, or correct-answer hints as constraints, and fill missing details.
-Do not create more than one question after the same requested slide position.
+Do not generate additional unrequested questions after instructor-selected slide positions.
 """
 
     return f"""You are an expert educational content designer creating an interactive slide lesson from a PDF deck.
@@ -2778,6 +2781,25 @@ def _merge_slide_chunk_manifests(
     )
 
 
+def _generated_slide_question_to_input(
+    question: GeneratedSlideQuestion,
+) -> schemas.LectureSlideQuestionInput:
+    return schemas.LectureSlideQuestionInput(
+        mode=schemas.LectureSlideQuestionDraftMode.COMPLETE,
+        slide_position=question.slide_position,
+        question_text=question.question_text,
+        intro_text=question.intro_text,
+        options=[
+            schemas.LectureSlideQuestionOptionInput(
+                option_text=option.option_text,
+                post_answer_text=option.post_answer_text,
+                correct=option.correct,
+            )
+            for option in question.options
+        ],
+    )
+
+
 async def _persist_slide_manifest(
     run_id: int,
     lease_token: str,
@@ -2810,33 +2832,6 @@ async def _persist_slide_manifest(
             ],
         ]
 
-        await session.execute(
-            delete(
-                models.lecture_slide_question_single_select_correct_option_association
-            ).where(
-                models.lecture_slide_question_single_select_correct_option_association.c.question_id.in_(
-                    select(models.LectureSlideQuestion.id).where(
-                        models.LectureSlideQuestion.lecture_slide_deck_id == deck.id
-                    )
-                )
-            )
-        )
-        await session.execute(
-            delete(models.LectureSlideQuestionOption).where(
-                models.LectureSlideQuestionOption.question_id.in_(
-                    select(models.LectureSlideQuestion.id).where(
-                        models.LectureSlideQuestion.lecture_slide_deck_id == deck.id
-                    )
-                )
-            )
-        )
-        await session.execute(
-            delete(models.LectureSlideQuestion).where(
-                models.LectureSlideQuestion.lecture_slide_deck_id == deck.id
-            )
-        )
-        await session.flush()
-
         page_ranges: list[SlidePageRange] = [
             {
                 "slide_position": page.position,
@@ -2863,60 +2858,14 @@ async def _persist_slide_manifest(
                 continue
             question_pause_offsets_by_position.append((question, pause_offsets))
 
-        for question_position, (question, pause_offsets) in enumerate(
-            question_pause_offsets_by_position
-        ):
-            question_row = models.LectureSlideQuestion(
-                lecture_slide_deck_id=deck.id,
-                position=question_position,
-                slide_position=question.slide_position,
-                slide_offset_ms=pause_offsets["slide_offset_ms"],
-                stop_offset_ms=pause_offsets["stop_offset_ms"],
-                question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
-                question_text=question.question_text,
-                intro_text=question.intro_text,
-            )
-            session.add(question_row)
-            await session.flush()
-            if text_needs_audio(question.intro_text):
-                intro_narration = models.LectureSlideNarration(
-                    status=schemas.LectureSlideNarrationStatus.PENDING,
-                )
-                session.add(intro_narration)
-                await session.flush()
-                question_row.intro_narration_id = intro_narration.id
-
-            option_rows: list[
-                tuple[GeneratedSlideChoice, models.LectureSlideQuestionOption]
-            ] = []
-            for option_position, option in enumerate(question.options):
-                option_row = models.LectureSlideQuestionOption(
-                    question_id=question_row.id,
-                    position=option_position,
-                    option_text=option.option_text,
-                    post_answer_text=option.post_answer_text,
-                    continue_slide_position=question.slide_position,
-                    continue_slide_offset_ms=pause_offsets["slide_offset_ms"],
-                    continue_offset_ms=pause_offsets["stop_offset_ms"],
-                )
-                session.add(option_row)
-                option_rows.append((option, option_row))
-            await session.flush()
-            for option, option_row in option_rows:
-                if option.correct:
-                    await session.execute(
-                        models.lecture_slide_question_single_select_correct_option_association.insert().values(
-                            question_id=question_row.id,
-                            option_id=option_row.id,
-                        )
-                    )
-                if text_needs_audio(option.post_answer_text):
-                    post_narration = models.LectureSlideNarration(
-                        status=schemas.LectureSlideNarrationStatus.PENDING,
-                    )
-                    session.add(post_narration)
-                    await session.flush()
-                    option_row.post_narration_id = post_narration.id
+        await lecture_slide_service.apply_lecture_slide_question_drafts(
+            session,
+            deck,
+            [
+                _generated_slide_question_to_input(question)
+                for question, _pause_offsets in question_pause_offsets_by_position
+            ],
+        )
 
         context_data = dict(deck.context_data or {})
         context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -275,6 +275,8 @@ def _build_slide_manifest_generation_instructions(
     content_section: str,
     *,
     total_duration_ms: int | None,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
     generation_start_ms: int | None = None,
     generation_end_ms: int | None = None,
     context_start_ms: int | None = None,
@@ -308,11 +310,51 @@ This is one chunk from a longer slide lesson.{context_range_text}
 Generate questions only for {generation_window_interval_text}.
 Use surrounding context to avoid boundary artifacts, but keep generated offsets inside the requested generation window.
 """
+    manual_question_positions = sorted(
+        {question.slide_position for question in manual_questions or []}
+    )
+    partial_question_positions = sorted(
+        {
+            question.slide_position
+            for question in question_requests or []
+            if question.mode == schemas.LectureSlideQuestionDraftMode.PARTIAL
+        }
+    )
+    marker_question_positions = sorted(
+        {
+            question.slide_position
+            for question in question_requests or []
+            if question.mode == schemas.LectureSlideQuestionDraftMode.MARKER
+        }
+    )
+    manual_question_guidance = ""
+    if manual_question_positions:
+        manual_question_guidance = f"""
+
+COMPLETE INSTRUCTOR-AUTHORED QUESTIONS:
+The request includes instructor-authored questions after these zero-based slide positions: {manual_question_positions}.
+These questions will be inserted separately. Do not repeat, rephrase, replace, or generate additional questions after those slide positions.
+You may generate questions at other useful slide breakpoints.
+"""
+    question_request_guidance = ""
+    if partial_question_positions or marker_question_positions:
+        question_request_guidance = f"""
+
+INSTRUCTOR QUESTION REQUESTS:
+The instructor requested model-completed questions after these zero-based slide positions.
+- Partial question drafts to complete: {partial_question_positions}
+- Marker-only required questions to create: {marker_question_positions}
+You must include exactly one question after each of those slide positions in your output unless that slide is outside the generation window.
+Use any provided partial prompt, narration, options, feedback, or correct-answer hints as constraints, and fill missing details.
+Do not create more than one question after the same requested slide position.
+"""
 
     return f"""You are an expert educational content designer creating an interactive slide lesson from a PDF deck.
 
 You will be given the PDF, slide timing source data, and word-level narration transcript source data.{duration_text}
 {generation_window_text}
+{manual_question_guidance}
+{question_request_guidance}
 
 Use the PDF, slide timing source data, and transcript together. The PDF is the visual source of truth; the transcript is the spoken narration timeline.
 
@@ -357,6 +399,86 @@ def _slide_generation_final_task_text() -> str:
         "Based on the PDF, slide timing source data, and word-level transcript "
         "source data above, generate the interactive slide lesson manifest now. "
         "Follow the instructions and return only the schema-valid JSON object."
+    )
+
+
+def _manual_slide_questions_from_context(
+    context_data: Mapping[str, Any] | None,
+) -> list[GeneratedSlideQuestion]:
+    question_inputs = _manual_slide_question_inputs_from_context(context_data)
+    return [
+        GeneratedSlideQuestion(
+            slide_position=question.slide_position,
+            question_text=question.question_text,
+            intro_text=question.intro_text,
+            options=[
+                GeneratedSlideChoice(
+                    option_text=option.option_text,
+                    post_answer_text=option.post_answer_text,
+                    correct=option.correct,
+                )
+                for option in question.options
+            ],
+        )
+        for question in question_inputs
+        if question.mode == schemas.LectureSlideQuestionDraftMode.COMPLETE
+    ]
+
+
+def _manual_slide_question_inputs_from_context(
+    context_data: Mapping[str, Any] | None,
+) -> list[schemas.LectureSlideQuestionInput]:
+    if not context_data:
+        return []
+    raw_questions = context_data.get(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY)
+    if not isinstance(raw_questions, list):
+        return []
+    questions: list[schemas.LectureSlideQuestionInput] = []
+    for raw_question in raw_questions:
+        questions.append(schemas.LectureSlideQuestionInput.model_validate(raw_question))
+    return questions
+
+
+def _manual_slide_questions_source_text(
+    complete_questions: list[GeneratedSlideQuestion],
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
+) -> str | None:
+    partial_questions = [
+        question
+        for question in question_requests or []
+        if question.mode == schemas.LectureSlideQuestionDraftMode.PARTIAL
+    ]
+    marker_questions = [
+        question
+        for question in question_requests or []
+        if question.mode == schemas.LectureSlideQuestionDraftMode.MARKER
+    ]
+    if not complete_questions and not partial_questions and not marker_questions:
+        return None
+    payload: dict[str, object] = {}
+    if complete_questions:
+        payload["complete_questions_to_preserve"] = [
+            question.model_dump() for question in complete_questions
+        ]
+    if partial_questions:
+        payload["partial_questions_to_complete"] = [
+            question.model_dump(mode="json") for question in partial_questions
+        ]
+    if marker_questions:
+        payload["required_question_markers"] = [
+            {
+                "slide_position": question.slide_position,
+            }
+            for question in marker_questions
+        ]
+    return (
+        "INSTRUCTOR QUESTION SOURCE DATA:\n"
+        "This data was added by the instructor before generation. Preserve complete "
+        "questions exactly. For partial questions, keep the instructor-provided "
+        "details and fill in missing prompt, narration, answer choices, feedback, "
+        "and correct answer as needed. For required_question_markers, create one "
+        "useful question after each listed slide_position.\n\n"
+        f"{json.dumps(payload, indent=2)}"
     )
 
 
@@ -1949,6 +2071,8 @@ def _slide_manifest_request_token_estimate(
     page_ranges: list[SlidePageRange],
     transcript: list[schemas.LectureVideoManifestWordV3],
     total_duration_ms: int | None,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
     chunk: SlideManifestGenerationChunk | None = None,
 ) -> int:
     generation_start_ms = chunk.generation_start_ms if chunk is not None else None
@@ -1960,6 +2084,8 @@ def _slide_manifest_request_token_estimate(
             _build_slide_manifest_generation_instructions(
                 generation_prompt,
                 total_duration_ms=total_duration_ms,
+                manual_questions=manual_questions,
+                question_requests=question_requests,
                 generation_start_ms=generation_start_ms,
                 generation_end_ms=generation_end_ms,
                 context_start_ms=context_start_ms,
@@ -1967,6 +2093,10 @@ def _slide_manifest_request_token_estimate(
             ),
             _slide_timing_source_text(page_ranges),
             _generation_transcript_source_text(transcript, compact=False),
+            _manual_slide_questions_source_text(
+                manual_questions or [], question_requests
+            )
+            or "",
             _slide_generation_final_task_text(),
         ]
     )
@@ -1991,12 +2121,16 @@ def _slide_manifest_chunk_source_token_budget(
     *,
     generation_prompt: str,
     total_duration_ms: int,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
 ) -> int:
     fixed_request_tokens = _slide_manifest_request_token_estimate(
         generation_prompt=generation_prompt,
         page_ranges=[],
         transcript=[],
         total_duration_ms=total_duration_ms,
+        manual_questions=manual_questions,
+        question_requests=question_requests,
     )
     return max(0, SLIDE_MANIFEST_INPUT_TOKEN_BUDGET - fixed_request_tokens)
 
@@ -2053,12 +2187,16 @@ def _plan_slide_manifest_generation_chunks(
     generation_prompt: str,
     page_ranges: list[SlidePageRange],
     transcript: list[schemas.LectureVideoManifestWordV3],
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
 ) -> list[SlideManifestGenerationChunk]:
     full_request_tokens = _slide_manifest_request_token_estimate(
         generation_prompt=generation_prompt,
         page_ranges=page_ranges,
         transcript=transcript,
         total_duration_ms=total_duration_ms,
+        manual_questions=manual_questions,
+        question_requests=question_requests,
     )
     if full_request_tokens <= SLIDE_MANIFEST_INPUT_TOKEN_BUDGET:
         return [
@@ -2089,6 +2227,8 @@ def _plan_slide_manifest_generation_chunks(
     source_budget = _slide_manifest_chunk_source_token_budget(
         generation_prompt=generation_prompt,
         total_duration_ms=total_duration_ms,
+        manual_questions=manual_questions,
+        question_requests=question_requests,
     )
     chunk_source_budget = max(
         SLIDE_MANIFEST_MIN_CHUNK_SOURCE_TOKENS,
@@ -2329,6 +2469,10 @@ async def _generate_slide_manifest(
             return None
         prompt = deck.generation_prompt or DEFAULT_GENERATION_PROMPT_CONTENT
         total_duration_ms = deck.total_duration_ms
+        question_requests = _manual_slide_question_inputs_from_context(
+            deck.context_data
+        )
+        manual_questions = _manual_slide_questions_from_context(deck.context_data)
         page_ranges: list[SlidePageRange] = [
             {
                 "slide_position": page.position,
@@ -2362,6 +2506,8 @@ async def _generate_slide_manifest(
                 page_ranges=page_ranges,
                 transcript=transcript,
                 total_duration_ms=total_duration_ms,
+                manual_questions=manual_questions,
+                question_requests=question_requests,
             ),
         )
     finally:
@@ -2377,6 +2523,8 @@ async def _generate_slide_manifest_with_optional_chunks(
     page_ranges: list[SlidePageRange],
     transcript: list[schemas.LectureVideoManifestWordV3],
     total_duration_ms: int | None,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
 ) -> GeneratedSlideManifest:
     if total_duration_ms is None:
         return await _generate_slide_manifest_for_window(
@@ -2387,12 +2535,16 @@ async def _generate_slide_manifest_with_optional_chunks(
             page_ranges=page_ranges,
             transcript=transcript,
             total_duration_ms=None,
+            manual_questions=manual_questions,
+            question_requests=question_requests,
         )
     chunks = _plan_slide_manifest_generation_chunks(
         total_duration_ms,
         generation_prompt=generation_prompt,
         page_ranges=page_ranges,
         transcript=transcript,
+        manual_questions=manual_questions,
+        question_requests=question_requests,
     )
     if len(chunks) == 1:
         try:
@@ -2404,6 +2556,8 @@ async def _generate_slide_manifest_with_optional_chunks(
                 page_ranges=page_ranges,
                 transcript=transcript,
                 total_duration_ms=total_duration_ms,
+                manual_questions=manual_questions,
+                question_requests=question_requests,
             )
         except Exception as exc:
             if (
@@ -2437,6 +2591,8 @@ async def _generate_slide_manifest_with_optional_chunks(
                 transcript=transcript,
                 total_duration_ms=total_duration_ms,
                 chunk=chunk,
+                manual_questions=manual_questions,
+                question_requests=question_requests,
             )
         )
     return _merge_slide_chunk_manifests(chunk_manifests)
@@ -2452,6 +2608,8 @@ async def _generate_slide_manifest_chunks(
     transcript: list[schemas.LectureVideoManifestWordV3],
     total_duration_ms: int,
     chunk: SlideManifestGenerationChunk,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
 ) -> list[GeneratedSlideManifest]:
     try:
         manifest = await _generate_slide_manifest_for_window(
@@ -2463,6 +2621,8 @@ async def _generate_slide_manifest_chunks(
             transcript=transcript,
             total_duration_ms=total_duration_ms,
             chunk=chunk,
+            manual_questions=manual_questions,
+            question_requests=question_requests,
         )
         return [manifest]
     except Exception as exc:
@@ -2495,6 +2655,8 @@ async def _generate_slide_manifest_chunks(
                     transcript=transcript,
                     total_duration_ms=total_duration_ms,
                     chunk=child_chunk,
+                    manual_questions=manual_questions,
+                    question_requests=question_requests,
                 )
             )
         return manifests
@@ -2509,6 +2671,8 @@ async def _generate_slide_manifest_for_window(
     page_ranges: list[SlidePageRange],
     transcript: list[schemas.LectureVideoManifestWordV3],
     total_duration_ms: int | None,
+    manual_questions: list[GeneratedSlideQuestion] | None = None,
+    question_requests: list[schemas.LectureSlideQuestionInput] | None = None,
     chunk: SlideManifestGenerationChunk | None = None,
 ) -> GeneratedSlideManifest:
     chunk_transcript = transcript
@@ -2539,6 +2703,8 @@ async def _generate_slide_manifest_for_window(
         instructions=_build_slide_manifest_generation_instructions(
             generation_prompt,
             total_duration_ms=total_duration_ms,
+            manual_questions=manual_questions,
+            question_requests=question_requests,
             generation_start_ms=generation_start_ms,
             generation_end_ms=generation_end_ms,
             context_start_ms=context_start_ms,
@@ -2561,6 +2727,21 @@ async def _generate_slide_manifest_for_window(
                             compact=False,
                         ),
                     },
+                    *(
+                        [
+                            {
+                                "type": "input_text",
+                                "text": manual_question_source_text,
+                            }
+                        ]
+                        if (
+                            manual_question_source_text
+                            := _manual_slide_questions_source_text(
+                                manual_questions or [], question_requests
+                            )
+                        )
+                        else []
+                    ),
                     {
                         "type": "input_text",
                         "text": _slide_generation_final_task_text(),
@@ -2616,6 +2797,18 @@ async def _persist_slide_manifest(
             or run.lease_token != lease_token
         ):
             return
+        manual_questions = _manual_slide_questions_from_context(deck.context_data)
+        manual_question_positions = {
+            question.slide_position for question in manual_questions
+        }
+        manifest_questions = [
+            *manual_questions,
+            *[
+                question
+                for question in manifest.questions
+                if question.slide_position not in manual_question_positions
+            ],
+        ]
 
         await session.execute(
             delete(
@@ -2658,7 +2851,10 @@ async def _persist_slide_manifest(
         question_pause_offsets_by_position: list[
             tuple[GeneratedSlideQuestion, SlideQuestionPauseOffsets]
         ] = []
-        for question in manifest.questions:
+        for question in sorted(
+            manifest_questions,
+            key=lambda item: item.slide_position,
+        ):
             pause_offsets = _slide_question_pause_offsets(
                 question,
                 page_range_by_position=page_range_by_position,
@@ -2722,7 +2918,9 @@ async def _persist_slide_manifest(
                     await session.flush()
                     option_row.post_narration_id = post_narration.id
 
-        deck.context_data = {}
+        context_data = dict(deck.context_data or {})
+        context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
+        deck.context_data = context_data
         deck.context_version = 4
         deck.lecture_slide_chat_available = bool(transcript)
         deck.transcript_data = transcript_data_from_words(transcript)
@@ -2744,12 +2942,22 @@ async def _synthesize_knowledge_check_audio(
         class_id = deck.class_id
         narration_items: list[tuple[int, str]] = []
         for question in deck.questions:
-            if question.intro_narration and text_needs_audio(question.intro_text):
+            if (
+                question.intro_narration
+                and text_needs_audio(question.intro_text)
+                and question.intro_narration.status
+                != schemas.LectureSlideNarrationStatus.READY
+            ):
                 narration_items.append(
                     (question.intro_narration.id, question.intro_text)
                 )
             for option in question.options:
-                if option.post_narration and text_needs_audio(option.post_answer_text):
+                if (
+                    option.post_narration
+                    and text_needs_audio(option.post_answer_text)
+                    and option.post_narration.status
+                    != schemas.LectureSlideNarrationStatus.READY
+                ):
                     narration_items.append(
                         (option.post_narration.id, option.post_answer_text)
                     )

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -10,6 +10,7 @@ from pypdf import PdfReader
 from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 import pingpong.models as models
 import pingpong.schemas as schemas
@@ -31,6 +32,13 @@ class LectureSlidePageUpdateResult:
     notes_changed: bool = False
     narration_changed: bool = False
     narration_changed_positions: frozenset[int] = frozenset()
+
+
+@dataclass(frozen=True)
+class LectureSlideQuestionUpdateResult:
+    questions_changed: bool = False
+    audio_changed: bool = False
+    requires_question_generation: bool = False
 
 
 def generate_source_store_key() -> str:
@@ -357,6 +365,417 @@ async def apply_lecture_slide_page_notes(
     )
 
 
+def _text_needs_audio(text: str | None) -> bool:
+    return bool((text or "").strip())
+
+
+def _question_input_payload(
+    question: schemas.LectureSlideQuestionInput,
+) -> dict[str, object]:
+    return {
+        "mode": question.mode.value,
+        "slide_position": question.slide_position,
+        "question_text": question.question_text.strip(),
+        "intro_text": question.intro_text.strip(),
+        "options": [
+            {
+                "option_text": option.option_text.strip(),
+                "post_answer_text": option.post_answer_text.strip(),
+                "correct": option.correct,
+            }
+            for option in question.options
+        ],
+    }
+
+
+def lecture_slide_question_context_payload(
+    questions: Iterable[schemas.LectureSlideQuestionInput],
+) -> list[dict[str, object]]:
+    return [_question_input_payload(question) for question in questions]
+
+
+def _is_complete_question_input(question: schemas.LectureSlideQuestionInput) -> bool:
+    return question.mode == schemas.LectureSlideQuestionDraftMode.COMPLETE
+
+
+def _question_model_payload(
+    question: models.LectureSlideQuestion,
+) -> dict[str, object]:
+    correct_option_id = question.correct_option.id if question.correct_option else None
+    return {
+        "slide_position": question.slide_position,
+        "question_text": question.question_text,
+        "intro_text": question.intro_text,
+        "options": [
+            {
+                "option_text": option.option_text,
+                "post_answer_text": option.post_answer_text,
+                "correct": option.id == correct_option_id,
+            }
+            for option in sorted(question.options, key=lambda item: item.position)
+        ],
+    }
+
+
+def lecture_slide_question_model_context_payload(
+    questions: Iterable[models.LectureSlideQuestion],
+) -> list[dict[str, object]]:
+    return [
+        _question_model_payload(question)
+        for question in sorted(questions, key=lambda item: item.position)
+    ]
+
+
+async def _reset_narration_for_text(
+    session: AsyncSession,
+    narration: models.LectureSlideNarration | None,
+    text: str,
+) -> tuple[
+    models.LectureSlideNarration | None,
+    bool,
+    list[int],
+    list[tuple[int, str]],
+]:
+    if not _text_needs_audio(text):
+        return None, narration is not None, [narration.id] if narration else [], []
+    if narration is None:
+        narration = models.LectureSlideNarration(
+            status=schemas.LectureSlideNarrationStatus.PENDING,
+        )
+        session.add(narration)
+        await session.flush()
+        return narration, True, [], []
+    stored_object_row = (
+        [(narration.stored_object_id, narration.stored_object.key)]
+        if narration.stored_object_id is not None
+        and narration.stored_object is not None
+        else []
+    )
+    narration.stored_object_id = None
+    narration.status = schemas.LectureSlideNarrationStatus.PENDING
+    narration.error_message = None
+    session.add(narration)
+    return narration, True, [], stored_object_row
+
+
+async def _apply_question_option_drafts(
+    session: AsyncSession,
+    question: models.LectureSlideQuestion,
+    options: list[schemas.LectureSlideQuestionOptionInput],
+    *,
+    question_changed: bool,
+) -> tuple[bool, bool, list[int], list[tuple[int, str]]]:
+    changed = question_changed
+    audio_changed = False
+    old_narration_ids: list[int] = []
+    old_stored_object_rows: list[tuple[int, str]] = []
+    existing_options = {
+        option.position: option
+        for option in sorted(question.options, key=lambda item: item.position)
+    }
+    option_rows: list[tuple[models.LectureSlideQuestionOption, bool]] = []
+    for option_position, option in enumerate(options):
+        option_text = option.option_text.strip()
+        post_answer_text = option.post_answer_text.strip()
+        option_row = existing_options.pop(option_position, None)
+        if option_row is None:
+            option_row = models.LectureSlideQuestionOption(
+                question_id=question.id,
+                position=option_position,
+                option_text=option_text,
+                post_answer_text=post_answer_text,
+                continue_slide_position=question.slide_position,
+                continue_slide_offset_ms=question.slide_offset_ms,
+                continue_offset_ms=question.stop_offset_ms,
+            )
+            session.add(option_row)
+            await session.flush()
+            changed = True
+            if _text_needs_audio(post_answer_text):
+                post_narration = models.LectureSlideNarration(
+                    status=schemas.LectureSlideNarrationStatus.PENDING,
+                )
+                session.add(post_narration)
+                await session.flush()
+                option_row.post_narration_id = post_narration.id
+                audio_changed = True
+        else:
+            if option_row.position != option_position:
+                option_row.position = option_position
+                changed = True
+            if option_row.option_text != option_text:
+                option_row.option_text = option_text
+                changed = True
+            if option_row.post_answer_text != post_answer_text:
+                (
+                    narration,
+                    narration_changed,
+                    deleted_narration_ids,
+                    deleted_stored_object_rows,
+                ) = await _reset_narration_for_text(
+                    session, option_row.post_narration, post_answer_text
+                )
+                option_row.post_answer_text = post_answer_text
+                option_row.post_narration_id = narration.id if narration else None
+                old_narration_ids.extend(deleted_narration_ids)
+                old_stored_object_rows.extend(deleted_stored_object_rows)
+                changed = True
+                audio_changed = audio_changed or narration_changed
+            if option_row.continue_slide_position != question.slide_position:
+                option_row.continue_slide_position = question.slide_position
+                changed = True
+            if option_row.continue_slide_offset_ms != question.slide_offset_ms:
+                option_row.continue_slide_offset_ms = question.slide_offset_ms
+                changed = True
+            if option_row.continue_offset_ms != question.stop_offset_ms:
+                option_row.continue_offset_ms = question.stop_offset_ms
+                changed = True
+            session.add(option_row)
+        option_rows.append((option_row, option.correct))
+
+    for removed_option in existing_options.values():
+        if removed_option.post_narration_id is not None:
+            old_narration_ids.append(removed_option.post_narration_id)
+        await session.delete(removed_option)
+        changed = True
+        audio_changed = True
+
+    await session.flush()
+    existing_correct_option_id = (
+        question.correct_option.id if question.correct_option is not None else None
+    )
+    next_correct_option_id = next(
+        (option_row.id for option_row, is_correct in option_rows if is_correct),
+        None,
+    )
+    if existing_correct_option_id != next_correct_option_id:
+        changed = True
+    await session.execute(
+        delete(
+            models.lecture_slide_question_single_select_correct_option_association
+        ).where(
+            models.lecture_slide_question_single_select_correct_option_association.c.question_id
+            == question.id
+        )
+    )
+    for option_row, is_correct in option_rows:
+        if is_correct:
+            await session.execute(
+                models.lecture_slide_question_single_select_correct_option_association.insert().values(
+                    question_id=question.id,
+                    option_id=option_row.id,
+                )
+            )
+    return changed, audio_changed, old_narration_ids, old_stored_object_rows
+
+
+async def apply_lecture_slide_question_drafts(
+    session: AsyncSession,
+    deck: models.LectureSlideDeck,
+    questions: Iterable[schemas.LectureSlideQuestionInput],
+) -> LectureSlideQuestionUpdateResult:
+    question_inputs = list(questions)
+    complete_question_inputs = [
+        question
+        for question in question_inputs
+        if _is_complete_question_input(question)
+    ]
+    requires_question_generation = len(complete_question_inputs) != len(question_inputs)
+    for question in question_inputs:
+        if question.slide_position >= deck.slide_count:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Question slide position {question.slide_position} is outside this deck.",
+            )
+
+    manual_question_payload = lecture_slide_question_context_payload(question_inputs)
+    pages_by_position = {
+        page.position: page
+        for page in (
+            await session.scalars(
+                select(models.LectureSlidePage).where(
+                    models.LectureSlidePage.lecture_slide_deck_id == deck.id,
+                    models.LectureSlidePage.position.in_(
+                        [question.slide_position for question in question_inputs]
+                    )
+                    if question_inputs
+                    else True,
+                )
+            )
+        ).all()
+    }
+    questions_are_timed = all(
+        (page := pages_by_position.get(question.slide_position)) is not None
+        and page.start_offset_ms is not None
+        and page.end_offset_ms is not None
+        for question in question_inputs
+    )
+    if not questions_are_timed:
+        context_data = dict(deck.context_data or {})
+        previous_payload = context_data.get(
+            schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY
+        )
+        if manual_question_payload:
+            context_data[schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY] = (
+                manual_question_payload
+            )
+        else:
+            context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
+        deck.context_data = context_data
+        session.add(deck)
+        await session.flush()
+        return LectureSlideQuestionUpdateResult(
+            questions_changed=previous_payload != manual_question_payload,
+            audio_changed=False,
+            requires_question_generation=requires_question_generation,
+        )
+
+    old_narration_ids: list[int] = []
+    old_stored_object_rows: list[tuple[int, str]] = []
+    changed = False
+    audio_changed = False
+    existing_questions = {
+        question.position: question
+        for question in (
+            await session.scalars(
+                select(models.LectureSlideQuestion)
+                .where(models.LectureSlideQuestion.lecture_slide_deck_id == deck.id)
+                .options(selectinload(models.LectureSlideQuestion.options))
+                .options(selectinload(models.LectureSlideQuestion.correct_option))
+                .options(
+                    selectinload(
+                        models.LectureSlideQuestion.intro_narration
+                    ).selectinload(models.LectureSlideNarration.stored_object)
+                )
+                .options(
+                    selectinload(models.LectureSlideQuestion.options)
+                    .selectinload(models.LectureSlideQuestionOption.post_narration)
+                    .selectinload(models.LectureSlideNarration.stored_object)
+                )
+                .order_by(models.LectureSlideQuestion.position)
+            )
+        ).all()
+    }
+
+    for question_position, question_input in enumerate(complete_question_inputs):
+        page = pages_by_position[question_input.slide_position]
+        slide_offset_ms = (page.end_offset_ms or 0) - (page.start_offset_ms or 0)
+        stop_offset_ms = page.end_offset_ms or 0
+        question_text = question_input.question_text.strip()
+        intro_text = question_input.intro_text.strip()
+        question = existing_questions.pop(question_position, None)
+        question_changed = False
+        if question is None:
+            question = models.LectureSlideQuestion(
+                lecture_slide_deck_id=deck.id,
+                position=question_position,
+                slide_position=question_input.slide_position,
+                slide_offset_ms=slide_offset_ms,
+                stop_offset_ms=stop_offset_ms,
+                question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+                question_text=question_text,
+                intro_text=intro_text,
+            )
+            session.add(question)
+            await session.flush()
+            changed = True
+            question_changed = True
+            if _text_needs_audio(intro_text):
+                intro_narration = models.LectureSlideNarration(
+                    status=schemas.LectureSlideNarrationStatus.PENDING,
+                )
+                session.add(intro_narration)
+                await session.flush()
+                question.intro_narration_id = intro_narration.id
+                audio_changed = True
+        else:
+            if question.position != question_position:
+                question.position = question_position
+                question_changed = True
+            if question.slide_position != question_input.slide_position:
+                question.slide_position = question_input.slide_position
+                question_changed = True
+            if question.slide_offset_ms != slide_offset_ms:
+                question.slide_offset_ms = slide_offset_ms
+                question_changed = True
+            if question.stop_offset_ms != stop_offset_ms:
+                question.stop_offset_ms = stop_offset_ms
+                question_changed = True
+            if question.question_text != question_text:
+                question.question_text = question_text
+                question_changed = True
+            if question.intro_text != intro_text:
+                (
+                    narration,
+                    narration_changed,
+                    deleted_narration_ids,
+                    deleted_stored_object_rows,
+                ) = await _reset_narration_for_text(
+                    session, question.intro_narration, intro_text
+                )
+                question.intro_text = intro_text
+                question.intro_narration_id = narration.id if narration else None
+                old_narration_ids.extend(deleted_narration_ids)
+                old_stored_object_rows.extend(deleted_stored_object_rows)
+                question_changed = True
+                audio_changed = audio_changed or narration_changed
+            changed = changed or question_changed
+            session.add(question)
+
+        (
+            options_changed,
+            options_audio_changed,
+            deleted_narration_ids,
+            deleted_stored_object_rows,
+        ) = await _apply_question_option_drafts(
+            session,
+            question,
+            question_input.options,
+            question_changed=question_changed,
+        )
+        changed = changed or options_changed
+        audio_changed = audio_changed or options_audio_changed
+        old_narration_ids.extend(deleted_narration_ids)
+        old_stored_object_rows.extend(deleted_stored_object_rows)
+
+    for removed_question in existing_questions.values():
+        if removed_question.intro_narration_id is not None:
+            old_narration_ids.append(removed_question.intro_narration_id)
+        for option in removed_question.options:
+            if option.post_narration_id is not None:
+                old_narration_ids.append(option.post_narration_id)
+        await session.delete(removed_question)
+        changed = True
+        audio_changed = True
+
+    context_data = dict(deck.context_data or {})
+    if requires_question_generation:
+        context_data[schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY] = (
+            manual_question_payload
+        )
+    else:
+        context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
+    if context_data != (deck.context_data or {}):
+        deck.context_data = context_data
+        session.add(deck)
+        changed = True
+
+    await session.flush()
+    audio_keys = await _delete_lecture_slide_narrations_if_unused(
+        session, old_narration_ids
+    )
+    stored_object_keys = await _delete_lecture_slide_narration_stored_objects_if_unused(
+        session,
+        old_stored_object_rows,
+    )
+    await _delete_lecture_slide_audio_keys_quietly([*audio_keys, *stored_object_keys])
+    return LectureSlideQuestionUpdateResult(
+        questions_changed=changed,
+        audio_changed=audio_changed,
+        requires_question_generation=requires_question_generation,
+    )
+
+
 async def lecture_slide_deck_has_pages(session: AsyncSession, deck_id: int) -> bool:
     page_id = await session.scalar(
         select(models.LectureSlidePage.id)
@@ -386,6 +805,80 @@ async def clear_lecture_slide_page_narrations(
     )
     audio_keys = await _delete_lecture_slide_narrations_if_unused(
         session, narration_ids
+    )
+    await _delete_lecture_slide_audio_keys_quietly(audio_keys)
+
+
+async def reset_lecture_slide_question_narrations(
+    session: AsyncSession, deck_id: int
+) -> None:
+    narration_ids = list(
+        dict.fromkeys(
+            [
+                *(
+                    await session.scalars(
+                        select(models.LectureSlideQuestion.intro_narration_id).where(
+                            models.LectureSlideQuestion.lecture_slide_deck_id
+                            == deck_id,
+                            models.LectureSlideQuestion.intro_narration_id.is_not(None),
+                        )
+                    )
+                ).all(),
+                *(
+                    await session.scalars(
+                        select(models.LectureSlideQuestionOption.post_narration_id)
+                        .join(
+                            models.LectureSlideQuestion,
+                            models.LectureSlideQuestion.id
+                            == models.LectureSlideQuestionOption.question_id,
+                        )
+                        .where(
+                            models.LectureSlideQuestion.lecture_slide_deck_id
+                            == deck_id,
+                            models.LectureSlideQuestionOption.post_narration_id.is_not(
+                                None
+                            ),
+                        )
+                    )
+                ).all(),
+            ]
+        )
+    )
+    if not narration_ids:
+        return
+
+    stored_object_rows = list(
+        (
+            await session.execute(
+                select(
+                    models.LectureSlideNarration.stored_object_id,
+                    models.LectureSlideNarrationStoredObject.key,
+                )
+                .join(
+                    models.LectureSlideNarrationStoredObject,
+                    models.LectureSlideNarrationStoredObject.id
+                    == models.LectureSlideNarration.stored_object_id,
+                )
+                .where(models.LectureSlideNarration.id.in_(narration_ids))
+            )
+        ).all()
+    )
+    await session.execute(
+        update(models.LectureSlideNarration)
+        .where(models.LectureSlideNarration.id.in_(narration_ids))
+        .values(
+            stored_object_id=None,
+            status=schemas.LectureSlideNarrationStatus.PENDING,
+            error_message=None,
+        )
+    )
+    audio_keys = await _delete_lecture_slide_narration_stored_objects_if_unused(
+        session,
+        [
+            (stored_object_id, key)
+            for stored_object_id, key in stored_object_rows
+            if stored_object_id is not None
+        ],
     )
     await _delete_lecture_slide_audio_keys_quietly(audio_keys)
 

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -308,6 +308,7 @@ async def apply_lecture_slide_page_notes(
     notes_changed = False
     narration_changed = False
     narration_changed_positions: set[int] = set()
+    old_narration_ids: list[int] = []
     notes_by_position = {note.position: note for note in notes}
     pages_by_position = {
         page.position: page
@@ -349,6 +350,8 @@ async def apply_lecture_slide_page_notes(
             session.add(page)
             notes_changed = True
         if page.narration_text != narration_text:
+            if page.narration_id is not None:
+                old_narration_ids.append(page.narration_id)
             page.narration_text = narration_text
             page.narration_id = None
             page.start_offset_ms = None
@@ -358,6 +361,10 @@ async def apply_lecture_slide_page_notes(
             narration_changed_positions.add(note.position)
     if notes_changed or narration_changed:
         await session.flush()
+    audio_keys = await _delete_lecture_slide_narrations_if_unused(
+        session, old_narration_ids
+    )
+    await _delete_lecture_slide_audio_keys_quietly(audio_keys)
     return LectureSlidePageUpdateResult(
         notes_changed=notes_changed,
         narration_changed=narration_changed,
@@ -373,12 +380,14 @@ def _question_input_payload(
     question: schemas.LectureSlideQuestionInput,
 ) -> dict[str, object]:
     return {
+        "id": question.id,
         "mode": question.mode.value,
         "slide_position": question.slide_position,
         "question_text": question.question_text.strip(),
         "intro_text": question.intro_text.strip(),
         "options": [
             {
+                "id": option.id,
                 "option_text": option.option_text.strip(),
                 "post_answer_text": option.post_answer_text.strip(),
                 "correct": option.correct,
@@ -403,11 +412,14 @@ def _question_model_payload(
 ) -> dict[str, object]:
     correct_option_id = question.correct_option.id if question.correct_option else None
     return {
+        "id": question.id,
+        "mode": schemas.LectureSlideQuestionDraftMode.COMPLETE.value,
         "slide_position": question.slide_position,
         "question_text": question.question_text,
         "intro_text": question.intro_text,
         "options": [
             {
+                "id": option.id,
                 "option_text": option.option_text,
                 "post_answer_text": option.post_answer_text,
                 "correct": option.id == correct_option_id,
@@ -424,6 +436,22 @@ def lecture_slide_question_model_context_payload(
         _question_model_payload(question)
         for question in sorted(questions, key=lambda item: item.position)
     ]
+
+
+async def lecture_slide_deck_question_context_payload(
+    session: AsyncSession,
+    deck_id: int,
+) -> list[dict[str, object]]:
+    questions = (
+        await session.scalars(
+            select(models.LectureSlideQuestion)
+            .where(models.LectureSlideQuestion.lecture_slide_deck_id == deck_id)
+            .options(selectinload(models.LectureSlideQuestion.options))
+            .options(selectinload(models.LectureSlideQuestion.correct_option))
+            .order_by(models.LectureSlideQuestion.position)
+        )
+    ).all()
+    return lecture_slide_question_model_context_payload(questions)
 
 
 async def _reset_narration_for_text(
@@ -469,15 +497,44 @@ async def _apply_question_option_drafts(
     audio_changed = False
     old_narration_ids: list[int] = []
     old_stored_object_rows: list[tuple[int, str]] = []
-    existing_options = {
-        option.position: option
-        for option in sorted(question.options, key=lambda item: item.position)
+    existing_option_rows = list(
+        (
+            await session.scalars(
+                select(models.LectureSlideQuestionOption)
+                .where(models.LectureSlideQuestionOption.question_id == question.id)
+                .options(
+                    selectinload(
+                        models.LectureSlideQuestionOption.post_narration
+                    ).selectinload(models.LectureSlideNarration.stored_object)
+                )
+                .order_by(models.LectureSlideQuestionOption.position)
+            )
+        ).all()
+    )
+    remaining_options = {option.id: option for option in existing_option_rows}
+    existing_options_by_position = {
+        option.position: option for option in existing_option_rows
     }
+    for temp_position, existing_option in enumerate(existing_option_rows, start=1):
+        existing_option.position = -temp_position
+        session.add(existing_option)
+    if existing_option_rows:
+        await session.flush()
+    option_input_ids = {option.id for option in options if option.id is not None}
     option_rows: list[tuple[models.LectureSlideQuestionOption, bool]] = []
     for option_position, option in enumerate(options):
         option_text = option.option_text.strip()
         post_answer_text = option.post_answer_text.strip()
-        option_row = existing_options.pop(option_position, None)
+        option_row = (
+            remaining_options.pop(option.id, None) if option.id is not None else None
+        )
+        if option_row is None:
+            fallback_option = existing_options_by_position.get(option_position)
+            if (
+                fallback_option is not None
+                and fallback_option.id not in option_input_ids
+            ):
+                option_row = remaining_options.pop(fallback_option.id, None)
         if option_row is None:
             option_row = models.LectureSlideQuestionOption(
                 question_id=question.id,
@@ -533,7 +590,7 @@ async def _apply_question_option_drafts(
             session.add(option_row)
         option_rows.append((option_row, option.correct))
 
-    for removed_option in existing_options.values():
+    for removed_option in remaining_options.values():
         if removed_option.post_narration_id is not None:
             old_narration_ids.append(removed_option.post_narration_id)
         await session.delete(removed_option)
@@ -541,8 +598,13 @@ async def _apply_question_option_drafts(
         audio_changed = True
 
     await session.flush()
-    existing_correct_option_id = (
-        question.correct_option.id if question.correct_option is not None else None
+    existing_correct_option_id = await session.scalar(
+        select(
+            models.lecture_slide_question_single_select_correct_option_association.c.option_id
+        ).where(
+            models.lecture_slide_question_single_select_correct_option_association.c.question_id
+            == question.id
+        )
     )
     next_correct_option_id = next(
         (option_row.id for option_row, is_correct in option_rows if is_correct),
@@ -576,39 +638,44 @@ async def apply_lecture_slide_question_drafts(
 ) -> LectureSlideQuestionUpdateResult:
     question_inputs = list(questions)
     complete_question_inputs = [
-        question
-        for question in question_inputs
-        if _is_complete_question_input(question)
+        question_input
+        for question_input in question_inputs
+        if _is_complete_question_input(question_input)
     ]
     requires_question_generation = len(complete_question_inputs) != len(question_inputs)
-    for question in question_inputs:
-        if question.slide_position >= deck.slide_count:
+    for question_input in question_inputs:
+        if question_input.slide_position >= deck.slide_count:
             raise HTTPException(
                 status_code=400,
-                detail=f"Question slide position {question.slide_position} is outside this deck.",
+                detail=f"Question slide position {question_input.slide_position} is outside this deck.",
             )
 
     manual_question_payload = lecture_slide_question_context_payload(question_inputs)
-    pages_by_position = {
-        page.position: page
-        for page in (
-            await session.scalars(
-                select(models.LectureSlidePage).where(
-                    models.LectureSlidePage.lecture_slide_deck_id == deck.id,
-                    models.LectureSlidePage.position.in_(
-                        [question.slide_position for question in question_inputs]
+    pages_by_position = (
+        {
+            page.position: page
+            for page in (
+                await session.scalars(
+                    select(models.LectureSlidePage).where(
+                        models.LectureSlidePage.lecture_slide_deck_id == deck.id,
+                        models.LectureSlidePage.position.in_(
+                            [
+                                question_input.slide_position
+                                for question_input in question_inputs
+                            ]
+                        ),
                     )
-                    if question_inputs
-                    else True,
                 )
-            )
-        ).all()
-    }
+            ).all()
+        }
+        if question_inputs
+        else {}
+    )
     questions_are_timed = all(
-        (page := pages_by_position.get(question.slide_position)) is not None
+        (page := pages_by_position.get(question_input.slide_position)) is not None
         and page.start_offset_ms is not None
         and page.end_offset_ms is not None
-        for question in question_inputs
+        for question_input in question_inputs
     )
     if not questions_are_timed:
         context_data = dict(deck.context_data or {})
@@ -627,16 +694,15 @@ async def apply_lecture_slide_question_drafts(
         return LectureSlideQuestionUpdateResult(
             questions_changed=previous_payload != manual_question_payload,
             audio_changed=False,
-            requires_question_generation=requires_question_generation,
+            requires_question_generation=True,
         )
 
     old_narration_ids: list[int] = []
     old_stored_object_rows: list[tuple[int, str]] = []
     changed = False
     audio_changed = False
-    existing_questions = {
-        question.position: question
-        for question in (
+    existing_question_rows = list(
+        (
             await session.scalars(
                 select(models.LectureSlideQuestion)
                 .where(models.LectureSlideQuestion.lecture_slide_deck_id == deck.id)
@@ -655,6 +721,18 @@ async def apply_lecture_slide_question_drafts(
                 .order_by(models.LectureSlideQuestion.position)
             )
         ).all()
+    )
+    remaining_questions = {question.id: question for question in existing_question_rows}
+    existing_questions_by_position = {
+        question.position: question for question in existing_question_rows
+    }
+    for temp_position, existing_question in enumerate(existing_question_rows, start=1):
+        existing_question.position = -temp_position
+        session.add(existing_question)
+    if existing_question_rows:
+        await session.flush()
+    question_input_ids = {
+        question.id for question in complete_question_inputs if question.id is not None
     }
 
     for question_position, question_input in enumerate(complete_question_inputs):
@@ -663,7 +741,18 @@ async def apply_lecture_slide_question_drafts(
         stop_offset_ms = page.end_offset_ms or 0
         question_text = question_input.question_text.strip()
         intro_text = question_input.intro_text.strip()
-        question = existing_questions.pop(question_position, None)
+        question = (
+            remaining_questions.pop(question_input.id, None)
+            if question_input.id is not None
+            else None
+        )
+        if question is None:
+            fallback_question = existing_questions_by_position.get(question_position)
+            if (
+                fallback_question is not None
+                and fallback_question.id not in question_input_ids
+            ):
+                question = remaining_questions.pop(fallback_question.id, None)
         question_changed = False
         if question is None:
             question = models.LectureSlideQuestion(
@@ -738,7 +827,7 @@ async def apply_lecture_slide_question_drafts(
         old_narration_ids.extend(deleted_narration_ids)
         old_stored_object_rows.extend(deleted_stored_object_rows)
 
-    for removed_question in existing_questions.values():
+    for removed_question in remaining_questions.values():
         if removed_question.intro_narration_id is not None:
             old_narration_ids.append(removed_question.intro_narration_id)
         for option in removed_question.options:

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -5435,6 +5435,7 @@ class Assistant(Base):
         params.pop("lecture_video_manifest", None)
         params.pop("lecture_slide_deck_id", None)
         params.pop("lecture_slide_page_notes", None)
+        params.pop("lecture_slide_questions", None)
         params.pop("narration_prompt", None)
         params.pop("voice_id", None)
         if data.interaction_mode != schemas.InteractionMode.VOICE:

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -482,6 +482,12 @@ class LectureSlideQuestionType(StrEnum):
     SINGLE_SELECT = "single_select"
 
 
+class LectureSlideQuestionDraftMode(StrEnum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    MARKER = "marker"
+
+
 class LectureVideoNarrationStatus(StrEnum):
     PENDING = "pending"
     PROCESSING = "processing"
@@ -1107,6 +1113,46 @@ class LectureSlidePageNotes(BaseModel):
     narration_text: str | None = Field(None, max_length=20000)
 
 
+LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY = "manual_questions"
+
+
+class LectureSlideQuestionOptionInput(BaseModel):
+    id: int | None = None
+    option_text: str = Field("", max_length=2000)
+    post_answer_text: str = Field("", max_length=5000)
+    correct: bool
+
+
+class LectureSlideQuestionInput(BaseModel):
+    id: int | None = None
+    mode: LectureSlideQuestionDraftMode = LectureSlideQuestionDraftMode.COMPLETE
+    slide_position: int = Field(..., ge=0)
+    question_text: str = Field("", max_length=5000)
+    intro_text: str = Field("", max_length=5000)
+    options: list[LectureSlideQuestionOptionInput] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_options(self):
+        if self.mode == LectureSlideQuestionDraftMode.MARKER:
+            return self
+        if self.mode == LectureSlideQuestionDraftMode.PARTIAL:
+            return self
+        if not self.question_text.strip():
+            raise ValueError("Complete lecture slide questions need question text.")
+        if len(self.options) < 2:
+            raise ValueError(
+                "Complete lecture slide questions need at least two answer options."
+            )
+        if any(not option.option_text.strip() for option in self.options):
+            raise ValueError("Complete lecture slide question options need text.")
+        correct_count = sum(1 for option in self.options if option.correct)
+        if correct_count != 1:
+            raise ValueError(
+                "Single-select lecture slide questions must have exactly one correct option."
+            )
+        return self
+
+
 class LectureVideoAssistantEditorPolicy(BaseModel):
     show_mode_in_assistant_editor: bool = False
     can_select_mode_in_assistant_editor: bool = False
@@ -1447,7 +1493,7 @@ def lecture_video_validator_create_assistant(self):
             raise ValueError(
                 "Specifying a voice_id is required for lecture video assistants."
             )
-        if self.lecture_slide_deck_id is not None:
+        if self.lecture_slide_deck_id is not None or self.lecture_slide_questions:
             raise ValueError(
                 "Lecture slide data cannot be set for assistants in Lecture Video mode."
             )
@@ -1476,6 +1522,7 @@ def lecture_video_validator_create_assistant(self):
         or self.lecture_video_manifest is not None
         or self.lecture_slide_deck_id is not None
         or self.lecture_slide_page_notes
+        or self.lecture_slide_questions
         or self.voice_id is not None
         or self.generation_prompt is not None
         or self.narration_prompt is not None
@@ -1525,6 +1572,7 @@ def lecture_video_validator_update_assistant(self):
     lecture_slide_page_notes_present = (
         "lecture_slide_page_notes" in self.model_fields_set
     )
+    lecture_slide_questions_present = "lecture_slide_questions" in self.model_fields_set
     regenerate_narration_requested_present = (
         "regenerate_narration_requested" in self.model_fields_set
     )
@@ -1546,6 +1594,7 @@ def lecture_video_validator_update_assistant(self):
         lecture_slide_deck_id_present
         or narration_prompt_present
         or lecture_slide_page_notes_present
+        or lecture_slide_questions_present
         or regenerate_narration_requested_present
         or regenerate_questions_requested_present
     )
@@ -1725,6 +1774,9 @@ class CreateAssistant(BaseModel):
     lecture_video_manifest: LectureVideoManifest | None = None
     lecture_slide_deck_id: int | None = None
     lecture_slide_page_notes: list[LectureSlidePageNotes] = Field(default_factory=list)
+    lecture_slide_questions: list[LectureSlideQuestionInput] = Field(
+        default_factory=list
+    )
     voice_id: str | None = None
     generation_prompt: str | None = Field(None, max_length=20000)
     narration_prompt: str | None = Field(None, max_length=20000)
@@ -1811,6 +1863,7 @@ class UpdateAssistant(BaseModel):
     lecture_video_manifest: LectureVideoManifest | None = None
     lecture_slide_deck_id: int | None = None
     lecture_slide_page_notes: list[LectureSlidePageNotes] | None = None
+    lecture_slide_questions: list[LectureSlideQuestionInput] | None = None
     voice_id: str | None = None
     generation_prompt: str | None = Field(None, max_length=20000)
     narration_prompt: str | None = Field(None, max_length=20000)

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1186,6 +1186,7 @@ class LectureSlideConfigResponse(BaseModel):
     narration_prompt: str | None = None
     pages: list["LectureSlidePageView"] = Field(default_factory=list)
     questions: list["LectureSlideQuestionView"] = Field(default_factory=list)
+    question_drafts: list["LectureSlideQuestionInput"] = Field(default_factory=list)
     processing_status: LectureVideoProcessingRunSummary | None = None
 
 

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -10219,6 +10219,35 @@ async def get_assistant_lecture_slide_config(
                 ],
             )
         )
+    raw_question_drafts = (deck.context_data or {}).get(
+        schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY
+    )
+    question_drafts = (
+        [
+            schemas.LectureSlideQuestionInput.model_validate(question)
+            for question in raw_question_drafts
+        ]
+        if isinstance(raw_question_drafts, list)
+        else [
+            schemas.LectureSlideQuestionInput(
+                id=question.id,
+                mode=schemas.LectureSlideQuestionDraftMode.COMPLETE,
+                slide_position=question.slide_position,
+                question_text=question.question_text,
+                intro_text=question.intro_text,
+                options=[
+                    schemas.LectureSlideQuestionOptionInput(
+                        id=option.id,
+                        option_text=option.option_text,
+                        post_answer_text=option.post_answer_text,
+                        correct=option.correct,
+                    )
+                    for option in question.options
+                ],
+            )
+            for question in questions
+        ]
+    )
     return schemas.LectureSlideConfigResponse(
         lecture_slide_deck=cast(
             schemas.LectureSlideSummary,
@@ -10229,6 +10258,7 @@ async def get_assistant_lecture_slide_config(
         narration_prompt=deck.narration_prompt,
         pages=pages,
         questions=questions,
+        question_drafts=question_drafts,
         processing_status=processing_status,
     )
 
@@ -13263,15 +13293,31 @@ async def update_assistant(
                 await lecture_slide_service.reset_lecture_slide_question_narrations(
                     request.state["db"], target_lecture_slide_deck.id
                 )
-            if needs_questions and questions_present:
-                context_data = dict(target_lecture_slide_deck.context_data or {})
-                context_data[schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY] = (
-                    lecture_slide_service.lecture_slide_question_context_payload(
-                        req.lecture_slide_questions or []
+            if needs_questions:
+                if questions_present:
+                    manual_question_payload = (
+                        lecture_slide_service.lecture_slide_question_context_payload(
+                            req.lecture_slide_questions or []
+                        )
                     )
-                )
-                target_lecture_slide_deck.context_data = context_data
-                request.state["db"].add(target_lecture_slide_deck)
+                elif regenerate_questions_requested:
+                    manual_question_payload = []
+                else:
+                    manual_question_payload = await lecture_slide_service.lecture_slide_deck_question_context_payload(
+                        request.state["db"], target_lecture_slide_deck.id
+                    )
+                context_data = dict(target_lecture_slide_deck.context_data or {})
+                if manual_question_payload:
+                    context_data[schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY] = (
+                        manual_question_payload
+                    )
+                else:
+                    context_data.pop(
+                        schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None
+                    )
+                if context_data != (target_lecture_slide_deck.context_data or {}):
+                    target_lecture_slide_deck.context_data = context_data
+                    request.state["db"].add(target_lecture_slide_deck)
 
             queued_run = None
             if needs_full_processing:

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -10932,6 +10932,7 @@ async def create_assistant(
     lecture_slide_generation_prompt = None
     lecture_slide_narration_prompt = None
     lecture_slide_page_notes = req.lecture_slide_page_notes
+    lecture_slide_questions = req.lecture_slide_questions
 
     if is_video:
         if req.lecture_video_id is None:
@@ -10997,6 +10998,7 @@ async def create_assistant(
         or req.lecture_video_manifest is not None
         or req.lecture_slide_deck_id is not None
         or req.lecture_slide_page_notes
+        or req.lecture_slide_questions
         or req.voice_id is not None
         or req.generation_prompt is not None
         or req.narration_prompt is not None
@@ -11139,6 +11141,7 @@ async def create_assistant(
         del req.lecture_video_manifest
         del req.lecture_slide_deck_id
         del req.lecture_slide_page_notes
+        del req.lecture_slide_questions
         del req.voice_id
         del req.generation_prompt
         del req.narration_prompt
@@ -11223,6 +11226,9 @@ async def create_assistant(
             lecture_slide_deck.narration_prompt = lecture_slide_narration_prompt
             await lecture_slide_service.apply_lecture_slide_page_notes(
                 request.state["db"], lecture_slide_deck, lecture_slide_page_notes
+            )
+            await lecture_slide_service.apply_lecture_slide_question_drafts(
+                request.state["db"], lecture_slide_deck, lecture_slide_questions
             )
             await lecture_slide_processing.queue_lecture_slide_processing_run(
                 request.state["db"],
@@ -11872,6 +11878,7 @@ async def update_assistant(
     lecture_slide_specific_fields_present = (
         "lecture_slide_deck_id" in req.model_fields_set
         or "lecture_slide_page_notes" in req.model_fields_set
+        or "lecture_slide_questions" in req.model_fields_set
         or "narration_prompt" in req.model_fields_set
         or "regenerate_narration_requested" in req.model_fields_set
         or "regenerate_questions_requested" in req.model_fields_set
@@ -13144,6 +13151,7 @@ async def update_assistant(
             prompt_present = "generation_prompt" in req.model_fields_set
             narration_prompt_present = "narration_prompt" in req.model_fields_set
             notes_present = "lecture_slide_page_notes" in req.model_fields_set
+            questions_present = "lecture_slide_questions" in req.model_fields_set
             requested_voice_id = lecture_slide_voice_id.strip()
             voice_changed = (
                 lecture_slide_deck.voice_id or ""
@@ -13167,6 +13175,7 @@ async def update_assistant(
                 or generation_prompt_changed
                 or narration_prompt_changed
                 or notes_present
+                or questions_present
                 or regenerate_narration_requested
                 or regenerate_questions_requested
                 or regenerate_audio_requested
@@ -13201,6 +13210,8 @@ async def update_assistant(
                 )
             notes_changed = False
             narration_text_changed = False
+            question_audio_changed = False
+            question_generation_requested_by_draft = False
             if notes_present:
                 page_update_result = (
                     await lecture_slide_service.apply_lecture_slide_page_notes(
@@ -13211,6 +13222,18 @@ async def update_assistant(
                 )
                 notes_changed = page_update_result.notes_changed
                 narration_text_changed = page_update_result.narration_changed
+            if questions_present:
+                question_update_result = (
+                    await lecture_slide_service.apply_lecture_slide_question_drafts(
+                        request.state["db"],
+                        target_lecture_slide_deck,
+                        req.lecture_slide_questions or [],
+                    )
+                )
+                question_audio_changed = question_update_result.audio_changed
+                question_generation_requested_by_draft = (
+                    question_update_result.requires_question_generation
+                )
 
             needs_full_processing = target_lecture_slide_deck.status in {
                 schemas.LectureSlideDeckStatus.UPLOADED,
@@ -13224,15 +13247,31 @@ async def update_assistant(
                 or (notes_changed and not narration_text_changed)
             )
             needs_questions = (
-                regenerate_questions_requested or generation_prompt_changed
+                regenerate_questions_requested
+                or generation_prompt_changed
+                or question_generation_requested_by_draft
             )
-            needs_audio = regenerate_audio_requested or voice_changed
+            needs_audio = (
+                regenerate_audio_requested or voice_changed or question_audio_changed
+            )
             if narration_text_changed:
                 needs_audio = True
             if regenerate_audio_requested or voice_changed:
                 await lecture_slide_service.clear_lecture_slide_page_narrations(
                     request.state["db"], target_lecture_slide_deck.id
                 )
+                await lecture_slide_service.reset_lecture_slide_question_narrations(
+                    request.state["db"], target_lecture_slide_deck.id
+                )
+            if needs_questions and questions_present:
+                context_data = dict(target_lecture_slide_deck.context_data or {})
+                context_data[schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY] = (
+                    lecture_slide_service.lecture_slide_question_context_payload(
+                        req.lecture_slide_questions or []
+                    )
+                )
+                target_lecture_slide_deck.context_data = context_data
+                request.state["db"].add(target_lecture_slide_deck)
 
             queued_run = None
             if needs_full_processing:

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -4,7 +4,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from pingpong import lecture_slide_processing, models, schemas
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from pingpong import lecture_slide_processing, lecture_slide_service, models, schemas
 from pingpong.config import config
 from pingpong.now import utcnow
 
@@ -574,7 +577,7 @@ async def test_generate_slide_manifest_rejects_multiple_correct_options(
 
 
 async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatch):
-    await _create_class_and_deck(db)
+    await _create_class_and_deck(db, slide_count=2)
     async with db.async_session() as session:
         first_page = models.LectureSlidePage(
             lecture_slide_deck_id=1,
@@ -709,7 +712,7 @@ async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatc
 
 
 async def test_persist_slide_manifest_includes_manual_questions_from_context(db):
-    await _create_class_and_deck(db)
+    await _create_class_and_deck(db, slide_count=2)
     manual_question = {
         "slide_position": 0,
         "question_text": "Instructor question?",
@@ -815,6 +818,338 @@ async def test_persist_slide_manifest_includes_manual_questions_from_context(db)
         assert deck.questions[0].options[0].post_narration is not None
         assert deck.questions[0].correct_option is not None
         assert deck.questions[0].correct_option.option_text == "Instructor correct"
+
+
+async def test_persist_slide_manifest_preserves_unchanged_manual_question_rows(db):
+    await _create_class_and_deck(db)
+    manual_question = {
+        "slide_position": 0,
+        "question_text": "Instructor question?",
+        "intro_text": "Answer this instructor question.",
+        "options": [
+            {
+                "option_text": "Instructor correct",
+                "post_answer_text": "Correct.",
+                "correct": True,
+            },
+            {
+                "option_text": "Instructor incorrect",
+                "post_answer_text": "Try again.",
+                "correct": False,
+            },
+        ],
+    }
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        deck.context_data = {
+            schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY: [manual_question]
+        }
+        intro_narration = models.LectureSlideNarration(
+            status=schemas.LectureSlideNarrationStatus.READY
+        )
+        question = models.LectureSlideQuestion(
+            lecture_slide_deck_id=1,
+            position=0,
+            slide_position=0,
+            slide_offset_ms=500,
+            stop_offset_ms=500,
+            question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+            question_text="Instructor question?",
+            intro_text="Answer this instructor question.",
+            intro_narration=intro_narration,
+            options=[
+                models.LectureSlideQuestionOption(
+                    position=0,
+                    option_text="Instructor correct",
+                    post_answer_text="Correct.",
+                    continue_slide_position=0,
+                    continue_slide_offset_ms=500,
+                    continue_offset_ms=500,
+                ),
+                models.LectureSlideQuestionOption(
+                    position=1,
+                    option_text="Instructor incorrect",
+                    post_answer_text="Try again.",
+                    continue_slide_position=0,
+                    continue_slide_offset_ms=500,
+                    continue_offset_ms=500,
+                ),
+            ],
+        )
+        first_page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=0,
+            start_offset_ms=0,
+            end_offset_ms=500,
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.MANIFEST_GENERATION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([deck, first_page, question, run])
+        await session.flush()
+        await session.execute(
+            models.lecture_slide_question_single_select_correct_option_association.insert().values(
+                question_id=question.id,
+                option_id=question.options[0].id,
+            )
+        )
+        question_id = question.id
+        intro_narration_id = intro_narration.id
+        run_id = run.id
+        await session.commit()
+
+    await lecture_slide_processing._persist_slide_manifest(
+        run_id,
+        "lease",
+        1,
+        lecture_slide_processing.GeneratedSlideManifest(questions=[]),
+        [],
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.context_data == {}
+        assert len(deck.questions) == 1
+        assert deck.questions[0].id == question_id
+        assert deck.questions[0].intro_narration_id == intro_narration_id
+        assert deck.questions[0].intro_narration is not None
+        assert deck.questions[0].intro_narration.status == (
+            schemas.LectureSlideNarrationStatus.READY
+        )
+
+
+async def test_apply_question_drafts_requires_generation_when_pages_are_untimed(db):
+    await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        page = models.LectureSlidePage(lecture_slide_deck_id=1, position=0)
+        old_question = models.LectureSlideQuestion(
+            lecture_slide_deck_id=1,
+            position=0,
+            slide_position=0,
+            slide_offset_ms=0,
+            stop_offset_ms=100,
+            question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+            question_text="Old question?",
+            intro_text="",
+        )
+        session.add_all([page, old_question])
+        await session.flush()
+
+        result = await lecture_slide_service.apply_lecture_slide_question_drafts(
+            session,
+            deck,
+            [
+                schemas.LectureSlideQuestionInput(
+                    slide_position=0,
+                    question_text="New question?",
+                    options=[
+                        schemas.LectureSlideQuestionOptionInput(
+                            option_text="Correct",
+                            correct=True,
+                        ),
+                        schemas.LectureSlideQuestionOptionInput(
+                            option_text="Incorrect",
+                            correct=False,
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        assert result.requires_question_generation
+        assert result.questions_changed
+        assert deck.context_data == {
+            schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY: [
+                {
+                    "id": None,
+                    "mode": "complete",
+                    "slide_position": 0,
+                    "question_text": "New question?",
+                    "intro_text": "",
+                    "options": [
+                        {
+                            "id": None,
+                            "option_text": "Correct",
+                            "post_answer_text": "",
+                            "correct": True,
+                        },
+                        {
+                            "id": None,
+                            "option_text": "Incorrect",
+                            "post_answer_text": "",
+                            "correct": False,
+                        },
+                    ],
+                }
+            ]
+        }
+        assert (
+            await session.scalar(
+                select(models.LectureSlideQuestion.question_text).where(
+                    models.LectureSlideQuestion.id == old_question.id
+                )
+            )
+        ) == "Old question?"
+
+
+async def test_apply_question_drafts_matches_questions_and_options_by_id(db):
+    await _create_class_and_deck(db, slide_count=2)
+    async with db.async_session() as session:
+        session.add_all(
+            [
+                models.LectureSlidePage(
+                    lecture_slide_deck_id=1,
+                    position=0,
+                    start_offset_ms=0,
+                    end_offset_ms=500,
+                ),
+                models.LectureSlidePage(
+                    lecture_slide_deck_id=1,
+                    position=1,
+                    start_offset_ms=500,
+                    end_offset_ms=1000,
+                ),
+            ]
+        )
+        intro_narration = models.LectureSlideNarration(
+            status=schemas.LectureSlideNarrationStatus.READY
+        )
+        option_narration = models.LectureSlideNarration(
+            status=schemas.LectureSlideNarrationStatus.READY
+        )
+        question = models.LectureSlideQuestion(
+            lecture_slide_deck_id=1,
+            position=0,
+            slide_position=0,
+            slide_offset_ms=500,
+            stop_offset_ms=500,
+            question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+            question_text="Existing question?",
+            intro_text="Existing intro.",
+            intro_narration=intro_narration,
+            options=[
+                models.LectureSlideQuestionOption(
+                    position=0,
+                    option_text="First",
+                    post_answer_text="First feedback.",
+                    post_narration=option_narration,
+                    continue_slide_position=0,
+                    continue_slide_offset_ms=500,
+                    continue_offset_ms=500,
+                ),
+                models.LectureSlideQuestionOption(
+                    position=1,
+                    option_text="Second",
+                    post_answer_text="Second feedback.",
+                    continue_slide_position=0,
+                    continue_slide_offset_ms=500,
+                    continue_offset_ms=500,
+                ),
+            ],
+        )
+        session.add(question)
+        await session.flush()
+        await session.execute(
+            models.lecture_slide_question_single_select_correct_option_association.insert().values(
+                question_id=question.id,
+                option_id=question.options[0].id,
+            )
+        )
+        question_id = question.id
+        first_option_id = question.options[0].id
+        second_option_id = question.options[1].id
+        intro_narration_id = intro_narration.id
+        option_narration_id = option_narration.id
+
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        result = await lecture_slide_service.apply_lecture_slide_question_drafts(
+            session,
+            deck,
+            [
+                schemas.LectureSlideQuestionInput(
+                    slide_position=0,
+                    question_text="Inserted question?",
+                    intro_text="Inserted intro.",
+                    options=[
+                        schemas.LectureSlideQuestionOptionInput(
+                            option_text="Inserted correct",
+                            correct=True,
+                        ),
+                        schemas.LectureSlideQuestionOptionInput(
+                            option_text="Inserted incorrect",
+                            correct=False,
+                        ),
+                    ],
+                ),
+                schemas.LectureSlideQuestionInput(
+                    id=question_id,
+                    slide_position=1,
+                    question_text="Existing question?",
+                    intro_text="Existing intro.",
+                    options=[
+                        schemas.LectureSlideQuestionOptionInput(
+                            id=second_option_id,
+                            option_text="Second",
+                            post_answer_text="Second feedback.",
+                            correct=True,
+                        ),
+                        schemas.LectureSlideQuestionOptionInput(
+                            id=first_option_id,
+                            option_text="First",
+                            post_answer_text="First feedback.",
+                            correct=False,
+                        ),
+                    ],
+                ),
+            ],
+        )
+        await session.commit()
+
+    assert result.questions_changed is True
+    async with db.async_session() as session:
+        questions = (
+            await session.scalars(
+                select(models.LectureSlideQuestion)
+                .where(models.LectureSlideQuestion.lecture_slide_deck_id == 1)
+                .options(selectinload(models.LectureSlideQuestion.options))
+                .options(selectinload(models.LectureSlideQuestion.correct_option))
+                .order_by(models.LectureSlideQuestion.position)
+            )
+        ).all()
+
+    assert len(questions) == 2
+    inserted_question, existing_question = questions
+    assert inserted_question.id != question_id
+    assert existing_question.id == question_id
+    assert existing_question.position == 1
+    assert existing_question.slide_position == 1
+    assert existing_question.intro_narration_id == intro_narration_id
+    assert [option.id for option in existing_question.options] == [
+        second_option_id,
+        first_option_id,
+    ]
+    assert existing_question.options[1].post_narration_id == option_narration_id
+    assert existing_question.correct_option is not None
+    assert existing_question.correct_option.id == second_option_id
 
 
 async def test_parse_responses_output_retries_transient_openai_failure(monkeypatch):
@@ -975,6 +1310,42 @@ async def test_slide_manifest_generation_window_prompt_matches_filter_contract()
         "requested generation window"
     ) in instructions
     assert "from 1000ms through 2000ms" not in instructions
+
+
+async def test_slide_manifest_question_request_prompt_allows_unmarked_questions():
+    instructions = (
+        lecture_slide_processing._build_slide_manifest_generation_instructions(
+            "Manifest prompt",
+            total_duration_ms=3000,
+            question_requests=[
+                schemas.LectureSlideQuestionInput(
+                    mode=schemas.LectureSlideQuestionDraftMode.PARTIAL,
+                    slide_position=1,
+                    question_text="Start from this prompt.",
+                ),
+                schemas.LectureSlideQuestionInput(
+                    mode=schemas.LectureSlideQuestionDraftMode.MARKER,
+                    slide_position=2,
+                ),
+                schemas.LectureSlideQuestionInput(
+                    mode=schemas.LectureSlideQuestionDraftMode.MARKER,
+                    slide_position=2,
+                ),
+            ],
+        )
+    )
+
+    assert "Partial question drafts to complete: [1]" in instructions
+    assert "Marker-only required questions to create: [2, 2]" in instructions
+    assert "required minimums, not an exclusive list" in instructions
+    assert (
+        "You may generate additional questions at other useful slide breakpoints "
+        "that were not selected by the instructor."
+    ) in instructions
+    assert (
+        "Do not generate additional unrequested questions after "
+        "instructor-selected slide positions."
+    ) in instructions
 
 
 async def test_filter_slide_questions_keeps_non_final_chunk_end_boundary():

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -708,6 +708,115 @@ async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatc
         ] == [500, 500, 1200, 1200]
 
 
+async def test_persist_slide_manifest_includes_manual_questions_from_context(db):
+    await _create_class_and_deck(db)
+    manual_question = {
+        "slide_position": 0,
+        "question_text": "Instructor question?",
+        "intro_text": "Answer this instructor question.",
+        "options": [
+            {
+                "option_text": "Instructor correct",
+                "post_answer_text": "Correct.",
+                "correct": True,
+            },
+            {
+                "option_text": "Instructor incorrect",
+                "post_answer_text": "Try again.",
+                "correct": False,
+            },
+        ],
+    }
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        deck.context_data = {
+            schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY: [manual_question]
+        }
+        first_page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=0,
+            start_offset_ms=0,
+            end_offset_ms=500,
+        )
+        second_page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=1,
+            start_offset_ms=500,
+            end_offset_ms=1200,
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.MANIFEST_GENERATION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([deck, first_page, second_page, run])
+        await session.commit()
+        run_id = run.id
+
+    manifest = lecture_slide_processing.GeneratedSlideManifest(
+        questions=[
+            lecture_slide_processing.GeneratedSlideQuestion(
+                slide_position=0,
+                question_text="Generated duplicate?",
+                options=[
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Generated correct",
+                        correct=True,
+                    ),
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Generated incorrect",
+                        correct=False,
+                    ),
+                ],
+            ),
+            lecture_slide_processing.GeneratedSlideQuestion(
+                slide_position=1,
+                question_text="Generated follow-up?",
+                options=[
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Follow-up correct",
+                        correct=True,
+                    ),
+                    lecture_slide_processing.GeneratedSlideChoice(
+                        option_text="Follow-up incorrect",
+                        correct=False,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    await lecture_slide_processing._persist_slide_manifest(
+        run_id,
+        "lease",
+        1,
+        manifest,
+        [],
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.context_data == {}
+        assert [question.question_text for question in deck.questions] == [
+            "Instructor question?",
+            "Generated follow-up?",
+        ]
+        assert deck.questions[0].intro_narration is not None
+        assert deck.questions[0].options[0].post_narration is not None
+        assert deck.questions[0].correct_option is not None
+        assert deck.questions[0].correct_option.option_text == "Instructor correct"
+
+
 async def test_parse_responses_output_retries_transient_openai_failure(monkeypatch):
     attempts = 0
 

--- a/pingpong/test_lecture_slide_server.py
+++ b/pingpong/test_lecture_slide_server.py
@@ -134,13 +134,15 @@ async def test_retry_lecture_slide_endpoint_queues_processing_after_failure(
     api, db, institution, valid_user_token
 ):
     async with db.async_session() as session:
-        class_ = models.Class(
-            id=1,
-            name="Test Class",
-            institution_id=institution.id,
-            api_key="test-key",
-        )
-        session.add(class_)
+        class_ = await session.get(models.Class, 1)
+        if class_ is None:
+            class_ = models.Class(
+                id=1,
+                name="Test Class",
+                institution_id=institution.id,
+                api_key="test-key",
+            )
+            session.add(class_)
         await session.flush()
         source = await models.LectureSlideSourceStoredObject.create(
             session,
@@ -222,6 +224,96 @@ async def test_retry_lecture_slide_endpoint_queues_processing_after_failure(
     assert runs[1].attempt_number == 2
 
 
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "admin", "class:1"),
+        ("user:123", "can_create_assistants", "class:1"),
+        ("user:123", "can_edit", "assistant:1"),
+    ]
+)
+async def test_lecture_slide_config_returns_pending_question_drafts(
+    api, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=2,
+            voice_id="voice-test-id",
+            context_data={
+                schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY: [
+                    {
+                        "mode": schemas.LectureSlideQuestionDraftMode.PARTIAL.value,
+                        "slide_position": 0,
+                        "question_text": "Use this prompt.",
+                        "intro_text": "",
+                        "options": [],
+                    },
+                    {
+                        "mode": schemas.LectureSlideQuestionDraftMode.MARKER.value,
+                        "slide_position": 1,
+                        "question_text": "",
+                        "intro_text": "",
+                        "options": [],
+                    },
+                ]
+            },
+        )
+        session.add(
+            models.Assistant(
+                id=1,
+                name="Physics Slides",
+                class_id=class_.id,
+                interaction_mode=schemas.InteractionMode.LECTURE_SLIDES,
+                version=3,
+                lecture_slide_deck_id=deck.id,
+                instructions="You are a lecture assistant.",
+                model="gpt-4o-mini",
+                tools="[]",
+                use_latex=False,
+                use_image_descriptions=False,
+                hide_prompt=False,
+            )
+        )
+        await session.commit()
+
+    response = api.get(
+        "/api/v1/class/1/assistant/1/lecture-slides/config",
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["questions"] == []
+    assert [
+        (question["mode"], question["slide_position"], question["question_text"])
+        for question in body["question_drafts"]
+    ] == [
+        ("partial", 0, "Use this prompt."),
+        ("marker", 1, ""),
+    ]
+
+
 @with_institution(11, "Test Institution")
 async def test_apply_lecture_slide_page_notes_handles_unloaded_pages(db, institution):
     async with db.async_session() as session:
@@ -291,6 +383,106 @@ async def test_apply_lecture_slide_page_notes_handles_unloaded_pages(db, institu
     assert page is not None
     assert page.user_notes == "New notes"
     assert page.narration_text == "Narrate this."
+
+
+@with_institution(11, "Test Institution")
+async def test_apply_lecture_slide_page_notes_deletes_replaced_narration_audio(
+    db, institution, config, monkeypatch, tmp_path
+):
+    narration_dir = tmp_path / "narrations"
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        LocalAudioStoreSettings(save_target=str(narration_dir)),
+    )
+
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1,
+            name="Test Class",
+            institution_id=institution.id,
+            api_key="test-key",
+        )
+        session.add(class_)
+        await session.flush()
+        source = await models.LectureSlideSourceStoredObject.create(
+            session,
+            key="lecture04.pdf",
+            original_filename="lecture04.pdf",
+            content_type="application/pdf",
+            content_length=128,
+        )
+        deck = await models.LectureSlideDeck.create(
+            session,
+            class_id=class_.id,
+            source_stored_object_id=source.id,
+            uploader_id=123,
+            display_name="lecture04.pdf",
+            slide_count=1,
+            voice_id="voice-test-id",
+        )
+        stored_object = models.LectureSlideNarrationStoredObject(
+            key="edited-slide.ogg",
+            content_type="audio/ogg",
+            content_length=100,
+        )
+        session.add(stored_object)
+        await session.flush()
+        narration_dir.mkdir(parents=True, exist_ok=True)
+        (narration_dir / stored_object.key).write_bytes(b"slide-audio")
+        narration = models.LectureSlideNarration(
+            stored_object_id=stored_object.id,
+            status=schemas.LectureSlideNarrationStatus.READY,
+        )
+        session.add(narration)
+        await session.flush()
+        page = models.LectureSlidePage(
+            lecture_slide_deck_id=deck.id,
+            position=0,
+            narration_text="Old narration.",
+            narration_id=narration.id,
+            start_offset_ms=0,
+            end_offset_ms=100,
+        )
+        session.add(page)
+        await session.commit()
+        deck_id = deck.id
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id(session, deck_id)
+        assert deck is not None
+        result = await lecture_slide_service.apply_lecture_slide_page_notes(
+            session,
+            deck,
+            [
+                schemas.LectureSlidePageNotes(
+                    position=0,
+                    narration_text="New narration.",
+                )
+            ],
+        )
+        await session.commit()
+        page_after_edit = await session.scalar(
+            select(models.LectureSlidePage).where(
+                models.LectureSlidePage.lecture_slide_deck_id == deck_id,
+                models.LectureSlidePage.position == 0,
+            )
+        )
+        narration_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarration)
+        )
+        stored_object_count = await session.scalar(
+            select(func.count()).select_from(models.LectureSlideNarrationStoredObject)
+        )
+
+    assert result.narration_changed is True
+    assert page_after_edit is not None
+    assert page_after_edit.narration_id is None
+    assert page_after_edit.start_offset_ms is None
+    assert page_after_edit.end_offset_ms is None
+    assert narration_count == 0
+    assert stored_object_count == 0
+    assert not (narration_dir / "edited-slide.ogg").exists()
 
 
 @with_institution(11, "Test Institution")

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1877,6 +1877,7 @@ export type LectureSlidePageNotes = {
 };
 
 export type LectureSlideQuestionType = 'single_select';
+export type LectureSlideQuestionDraftMode = 'complete' | 'partial' | 'marker';
 
 export type LectureSlideQuestionOption = {
 	id: number;
@@ -1885,6 +1886,13 @@ export type LectureSlideQuestionOption = {
 	continue_slide_position?: number | null;
 	continue_slide_offset_ms?: number | null;
 	continue_offset_ms: number;
+	correct: boolean;
+};
+
+export type LectureSlideQuestionOptionInput = {
+	id?: number | null;
+	option_text: string;
+	post_answer_text: string;
 	correct: boolean;
 };
 
@@ -1898,6 +1906,15 @@ export type LectureSlideQuestion = {
 	question_text: string;
 	intro_text: string;
 	options: LectureSlideQuestionOption[];
+};
+
+export type LectureSlideQuestionInput = {
+	id?: number | null;
+	mode?: LectureSlideQuestionDraftMode;
+	slide_position: number;
+	question_text: string;
+	intro_text: string;
+	options: LectureSlideQuestionOptionInput[];
 };
 
 export type LectureSlideConfigResponse = {
@@ -2939,6 +2956,7 @@ export type CreateAssistantRequest = {
 	lecture_video_manifest?: LectureVideoManifest | null;
 	lecture_slide_deck_id?: number | null;
 	lecture_slide_page_notes?: LectureSlidePageNotes[];
+	lecture_slide_questions?: LectureSlideQuestionInput[];
 	voice_id?: string | null;
 	generation_prompt?: string | null;
 	narration_prompt?: string | null;
@@ -3005,6 +3023,7 @@ export type UpdateAssistantRequest = {
 	lecture_video_manifest?: LectureVideoManifest | null;
 	lecture_slide_deck_id?: number | null;
 	lecture_slide_page_notes?: LectureSlidePageNotes[] | null;
+	lecture_slide_questions?: LectureSlideQuestionInput[] | null;
 	voice_id?: string | null;
 	generation_prompt?: string | null;
 	narration_prompt?: string | null;

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1924,6 +1924,7 @@ export type LectureSlideConfigResponse = {
 	narration_prompt?: string | null;
 	pages: LectureSlidePage[];
 	questions: LectureSlideQuestion[];
+	question_drafts: LectureSlideQuestionInput[];
 	processing_status?: LectureVideoProcessingRunSummary | null;
 };
 

--- a/web/pingpong/src/lib/components/LectureSlideFilmstrip.svelte
+++ b/web/pingpong/src/lib/components/LectureSlideFilmstrip.svelte
@@ -31,6 +31,7 @@
 	let currentSourceUrl = '';
 	let loadToken = 0;
 	let thumbnails: Record<number, string> = {};
+	let renderInProgress: Promise<void> | null = null;
 
 	const questionSequence = (clientId: string) => {
 		const sequence = Number(clientId.replace('lecture-slide-question-draft-', ''));
@@ -55,33 +56,50 @@
 
 	const renderThumbnails = async (doc: PDFDocumentProxy) => {
 		const token = loadToken;
-		for (const page of pages) {
-			if (token !== loadToken) {
-				return;
+		if (renderInProgress) {
+			await renderInProgress;
+			if (token === loadToken) {
+				await renderThumbnails(doc);
 			}
-			if (thumbnails[page.position]) {
-				continue;
-			}
-			const pageNumber = Math.min(Math.max(page.position + 1, 1), doc.numPages);
-			try {
-				const pdfPage = await doc.getPage(pageNumber);
-				const base = pdfPage.getViewport({ scale: 1 });
-				const scale = THUMB_WIDTH / base.width;
-				const viewport = pdfPage.getViewport({ scale });
-				const canvas = document.createElement('canvas');
-				canvas.width = Math.floor(viewport.width);
-				canvas.height = Math.floor(viewport.height);
-				const context = canvas.getContext('2d');
-				if (!context) {
-					continue;
-				}
-				await pdfPage.render({ canvas, canvasContext: context, viewport }).promise;
+			return;
+		}
+		const renderPromise = (async () => {
+			for (const page of pages) {
 				if (token !== loadToken) {
 					return;
 				}
-				thumbnails = { ...thumbnails, [page.position]: canvas.toDataURL('image/png') };
-			} catch {
-				// Skip thumbnails that fail to render; the label fallback is shown instead.
+				if (thumbnails[page.position]) {
+					continue;
+				}
+				const pageNumber = Math.min(Math.max(page.position + 1, 1), doc.numPages);
+				try {
+					const pdfPage = await doc.getPage(pageNumber);
+					const base = pdfPage.getViewport({ scale: 1 });
+					const scale = THUMB_WIDTH / base.width;
+					const viewport = pdfPage.getViewport({ scale });
+					const canvas = document.createElement('canvas');
+					canvas.width = Math.floor(viewport.width);
+					canvas.height = Math.floor(viewport.height);
+					const context = canvas.getContext('2d');
+					if (!context) {
+						continue;
+					}
+					await pdfPage.render({ canvas, canvasContext: context, viewport }).promise;
+					if (token !== loadToken) {
+						return;
+					}
+					thumbnails = { ...thumbnails, [page.position]: canvas.toDataURL('image/png') };
+				} catch {
+					// Skip thumbnails that fail to render; the label fallback is shown instead.
+				}
+			}
+		})();
+		renderInProgress = renderPromise;
+		try {
+			await renderPromise;
+		} finally {
+			if (renderInProgress === renderPromise) {
+				renderInProgress = null;
 			}
 		}
 	};
@@ -90,9 +108,13 @@
 		const token = ++loadToken;
 		currentSourceUrl = url;
 		thumbnails = {};
-		if (pdfDocument) {
-			await pdfDocument.destroy();
-			pdfDocument = null;
+		const previousDocument = pdfDocument;
+		pdfDocument = null;
+		if (previousDocument) {
+			await previousDocument.destroy();
+		}
+		if (token !== loadToken) {
+			return;
 		}
 		if (!url) {
 			return;

--- a/web/pingpong/src/lib/components/LectureSlideFilmstrip.svelte
+++ b/web/pingpong/src/lib/components/LectureSlideFilmstrip.svelte
@@ -1,0 +1,206 @@
+<script
+	lang="ts"
+	generics="Q extends { client_id: string; slide_position: number; question_text: string }"
+>
+	import { browser } from '$app/environment';
+	import { onDestroy } from 'svelte';
+	import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
+	import pdfWorkerUrl from 'pdfjs-dist/legacy/build/pdf.worker.mjs?url';
+	import type { PDFDocumentProxy } from 'pdfjs-dist/types/src/pdf';
+	import { QuestionCircleOutline, PlusOutline } from 'flowbite-svelte-icons';
+
+	type FilmstripPage = {
+		position: number;
+		narration_text?: string | null;
+	};
+
+	export let sourceUrl = '';
+	export let pages: FilmstripPage[] = [];
+	export let questions: Q[] = [];
+	export let selectedPosition = 0;
+	export let selectedQuestionClientId: string | null = null;
+	export let onSelectSlide: (position: number) => void = () => {};
+	export let onSelectQuestion: (question: Q) => void = () => {};
+	export let onAddQuestion: ((position: number) => void) | null = null;
+
+	pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+	const THUMB_WIDTH = 220;
+
+	let pdfDocument: PDFDocumentProxy | null = null;
+	let currentSourceUrl = '';
+	let loadToken = 0;
+	let thumbnails: Record<number, string> = {};
+
+	const questionSequence = (clientId: string) => {
+		const sequence = Number(clientId.replace('lecture-slide-question-draft-', ''));
+		return Number.isFinite(sequence) ? sequence : 0;
+	};
+
+	$: orderedQuestions = [...questions].sort((left, right) =>
+		left.slide_position === right.slide_position
+			? questionSequence(left.client_id) - questionSequence(right.client_id)
+			: left.slide_position - right.slide_position
+	);
+	$: questionsByPosition = orderedQuestions.reduce(
+		(grouped, question) => {
+			grouped[question.slide_position] = [...(grouped[question.slide_position] || []), question];
+			return grouped;
+		},
+		{} as Record<number, Q[]>
+	);
+
+	const questionNumber = (questionClientId: string) =>
+		orderedQuestions.findIndex((question) => question.client_id === questionClientId) + 1;
+
+	const renderThumbnails = async (doc: PDFDocumentProxy) => {
+		const token = loadToken;
+		for (const page of pages) {
+			if (token !== loadToken) {
+				return;
+			}
+			if (thumbnails[page.position]) {
+				continue;
+			}
+			const pageNumber = Math.min(Math.max(page.position + 1, 1), doc.numPages);
+			try {
+				const pdfPage = await doc.getPage(pageNumber);
+				const base = pdfPage.getViewport({ scale: 1 });
+				const scale = THUMB_WIDTH / base.width;
+				const viewport = pdfPage.getViewport({ scale });
+				const canvas = document.createElement('canvas');
+				canvas.width = Math.floor(viewport.width);
+				canvas.height = Math.floor(viewport.height);
+				const context = canvas.getContext('2d');
+				if (!context) {
+					continue;
+				}
+				await pdfPage.render({ canvas, canvasContext: context, viewport }).promise;
+				if (token !== loadToken) {
+					return;
+				}
+				thumbnails = { ...thumbnails, [page.position]: canvas.toDataURL('image/png') };
+			} catch {
+				// Skip thumbnails that fail to render; the label fallback is shown instead.
+			}
+		}
+	};
+
+	const loadDocument = async (url: string) => {
+		const token = ++loadToken;
+		currentSourceUrl = url;
+		thumbnails = {};
+		if (pdfDocument) {
+			await pdfDocument.destroy();
+			pdfDocument = null;
+		}
+		if (!url) {
+			return;
+		}
+		try {
+			const loadingTask = pdfjsLib.getDocument({ url, withCredentials: true });
+			const doc = await loadingTask.promise;
+			if (token !== loadToken) {
+				await doc.destroy();
+				return;
+			}
+			pdfDocument = doc;
+			await renderThumbnails(doc);
+		} catch {
+			// Leave thumbnails empty; label fallbacks render in their place.
+		}
+	};
+
+	$: if (browser && sourceUrl !== currentSourceUrl) {
+		void loadDocument(sourceUrl);
+	}
+
+	$: if (browser && pdfDocument && pages.length) {
+		void renderThumbnails(pdfDocument);
+	}
+
+	onDestroy(() => {
+		loadToken += 1;
+		void pdfDocument?.destroy();
+		pdfDocument = null;
+	});
+</script>
+
+<div class="flex items-stretch gap-1.5 overflow-x-auto px-1 pb-2 pt-2">
+	{#each pages as page, pageIndex (page.position)}
+		{@const isSlideActive = !selectedQuestionClientId && page.position === selectedPosition}
+		{@const pageQuestions = questionsByPosition[page.position] || []}
+		<button
+			type="button"
+			onclick={() => onSelectSlide(page.position)}
+			aria-label={`Slide ${pageIndex + 1}`}
+			aria-pressed={isSlideActive}
+			class="group relative flex w-32 shrink-0 flex-col overflow-hidden rounded-xl border bg-white transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/15 {isSlideActive
+				? 'border-gray-900 shadow-md'
+				: 'border-gray-200 hover:border-gray-400 hover:shadow-sm'}"
+		>
+			<div class="relative aspect-video w-full overflow-hidden bg-gray-50">
+				{#if thumbnails[page.position]}
+					<img
+						src={thumbnails[page.position]}
+						alt={`Slide ${pageIndex + 1} thumbnail`}
+						class="h-full w-full object-contain"
+						draggable="false"
+					/>
+				{:else}
+					<div class="flex h-full w-full items-center justify-center text-xs text-gray-400">
+						Slide {pageIndex + 1}
+					</div>
+				{/if}
+				<span
+					class="absolute left-1.5 top-1.5 rounded-md bg-gray-900/85 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white backdrop-blur-sm"
+				>
+					{pageIndex + 1}
+				</span>
+			</div>
+			<div class="px-2 py-1.5">
+				<span
+					class="block truncate text-[11px] font-medium {isSlideActive
+						? 'text-gray-900'
+						: 'text-gray-600'}"
+				>
+					Slide {pageIndex + 1}
+				</span>
+			</div>
+		</button>
+
+		{#each pageQuestions as question (question.client_id)}
+			{@const isQuestionActive = selectedQuestionClientId === question.client_id}
+			{@const number = questionNumber(question.client_id)}
+			<button
+				type="button"
+				onclick={() => onSelectQuestion(question)}
+				aria-label={`Question ${number} after slide ${pageIndex + 1}`}
+				aria-pressed={isQuestionActive}
+				title={question.question_text || `Question ${number}`}
+				class="group flex w-14 shrink-0 flex-col items-center justify-center gap-1 rounded-xl border border-dashed transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/15 {isQuestionActive
+					? 'border-gray-900 bg-gray-900 text-white shadow-md'
+					: 'border-gray-300 bg-gray-50 text-gray-700 hover:border-gray-600 hover:bg-white hover:shadow-sm'}"
+			>
+				<QuestionCircleOutline class="h-5 w-5" />
+				<span class="text-[10px] font-semibold leading-none">Q{number}</span>
+			</button>
+		{/each}
+
+		{#if onAddQuestion}
+			<button
+				type="button"
+				onclick={() => onAddQuestion?.(page.position)}
+				aria-label={`Add a question after slide ${pageIndex + 1}`}
+				title={`Add a question after slide ${pageIndex + 1}`}
+				class="group/add flex w-6 shrink-0 items-center justify-center self-stretch rounded-lg text-gray-300 hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/15"
+			>
+				<span
+					class="flex h-6 w-6 items-center justify-center rounded-full border border-dashed border-gray-300 bg-white group-hover/add:border-gray-700 group-hover/add:bg-gray-900 group-hover/add:text-white"
+				>
+					<PlusOutline class="h-3 w-3" />
+				</span>
+			</button>
+		{/if}
+	{/each}
+</div>

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -248,6 +248,53 @@
 		}))
 	});
 
+	const lectureSlideQuestionInputToDraft = (
+		question: api.LectureSlideQuestionInput
+	): LectureSlideQuestionDraft => ({
+		id: question.id,
+		client_id: nextLectureSlideQuestionDraftId(),
+		mode: question.mode || 'complete',
+		slide_position: question.slide_position,
+		question_text: question.question_text,
+		intro_text: question.intro_text || '',
+		options: question.options.map((option) => ({
+			id: option.id,
+			client_id: nextLectureSlideQuestionDraftId(),
+			option_text: option.option_text,
+			post_answer_text: option.post_answer_text || '',
+			correct: option.correct
+		}))
+	});
+
+	const currentLectureSlideQuestionDraftInputs = () =>
+		data.lectureSlideConfig?.question_drafts ||
+		(data.lectureSlideConfig?.questions || []).map((question) => ({
+			id: question.id,
+			mode: 'complete' as api.LectureSlideQuestionDraftMode,
+			slide_position: question.slide_position,
+			question_text: question.question_text,
+			intro_text: question.intro_text || '',
+			options: question.options.map((option) => ({
+				id: option.id,
+				option_text: option.option_text,
+				post_answer_text: option.post_answer_text || '',
+				correct: option.correct
+			}))
+		}));
+
+	const hydrateLectureSlideQuestionDrafts = (questions: api.LectureSlideQuestionInput[]) => {
+		const selectedQuestion = lectureSlideQuestionDrafts.find(
+			(question) => question.client_id === selectedLectureSlideQuestionClientId
+		);
+		const nextDrafts = questions.map(lectureSlideQuestionInputToDraft);
+		lectureSlideQuestionDrafts = nextDrafts;
+		selectedLectureSlideQuestionClientId =
+			selectedQuestion?.id == null
+				? null
+				: nextDrafts.find((question) => question.id === selectedQuestion.id)?.client_id || null;
+		hasSetLectureSlideQuestionDrafts = true;
+	};
+
 	const lectureSlideQuestionDraftToInput = (
 		question: LectureSlideQuestionDraft
 	): api.LectureSlideQuestionInput => ({
@@ -290,8 +337,8 @@
 				: left.slide_position - right.slide_position
 		);
 
-	const lectureSlideQuestionFromServerComparable = (question: api.LectureSlideQuestion) => ({
-		mode: 'complete',
+	const lectureSlideQuestionInputComparable = (question: api.LectureSlideQuestionInput) => ({
+		mode: question.mode || 'complete',
 		slide_position: question.slide_position,
 		question_text: question.question_text.trim(),
 		intro_text: (question.intro_text || '').trim(),
@@ -1176,10 +1223,7 @@
 		hasSetLectureSlidePageDrafts = true;
 	}
 	$: if (!hasSetLectureSlideQuestionDrafts && !lectureSlideConfigLoadError) {
-		lectureSlideQuestionDrafts = (data.lectureSlideConfig?.questions || []).map(
-			lectureSlideQuestionToDraft
-		);
-		hasSetLectureSlideQuestionDrafts = true;
+		hydrateLectureSlideQuestionDrafts(currentLectureSlideQuestionDraftInputs());
 	}
 	$: if (!hasSetSlideGenerationPrompt && !lectureSlideConfigLoadError) {
 		slideGenerationPrompt =
@@ -1221,7 +1265,7 @@
 		JSON.stringify(lectureSlidePageDrafts) !== currentLectureSlidePagesNormalized;
 	$: currentLectureSlideQuestionsNormalized = JSON.stringify(
 		sortLectureSlideQuestionComparables(
-			(data.lectureSlideConfig?.questions || []).map(lectureSlideQuestionFromServerComparable)
+			currentLectureSlideQuestionDraftInputs().map(lectureSlideQuestionInputComparable)
 		)
 	);
 	$: lectureSlideQuestionsNormalized = JSON.stringify(
@@ -3041,6 +3085,7 @@
 			);
 			lectureSlideQuestionDrafts = [];
 			selectedLectureSlideQuestionClientId = null;
+			hasSetLectureSlideQuestionDrafts = true;
 			selectedLectureSlidePosition = 0;
 			happyToast('Lecture slides uploaded');
 		} catch (error) {
@@ -3122,6 +3167,7 @@
 				user_notes: page.user_notes || '',
 				narration_text: page.narration_text || ''
 			}));
+			hydrateLectureSlideQuestionDrafts(expanded.data.question_drafts || []);
 		} finally {
 			refreshingLectureSlideStatus = false;
 		}
@@ -3534,13 +3580,19 @@
 				regenerateSlideNarrationRequested ||
 				regenerateSlideQuestionsRequested ||
 				regenerateSlideAudioRequested;
+			const shouldSubmitLectureSlideQuestions =
+				data.isCreating || lectureSlideDeckIdChanged || lectureSlideQuestionsChanged;
 
 			if (data.isCreating || lectureSlideFieldsChanged) {
 				params.lecture_slide_deck_id = selectedLectureSlideDeckId;
 				params.lecture_slide_page_notes = lectureSlidePageDrafts;
-				params.lecture_slide_questions = lectureSlideQuestionDrafts.map(
-					lectureSlideQuestionDraftToInput
-				);
+				if (shouldSubmitLectureSlideQuestions) {
+					params.lecture_slide_questions = lectureSlideQuestionDrafts.map(
+						lectureSlideQuestionDraftToInput
+					);
+				} else {
+					delete params.lecture_slide_questions;
+				}
 				params.voice_id = trimmedVoiceId;
 				params.generation_prompt = slideGenerationPrompt;
 				params.narration_prompt = slideNarrationPrompt;

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -17,8 +17,7 @@
 		RadioButton,
 		InputAddon,
 		Tooltip,
-		Spinner,
-		Alert
+		Spinner
 	} from 'flowbite-svelte';
 	import type {
 		Tool,
@@ -61,7 +60,14 @@
 		ClapperboardPlayOutline,
 		CheckCircleOutline,
 		ExclamationCircleOutline,
-		RefreshOutline
+		RefreshOutline,
+		PlusOutline,
+		TrashBinOutline,
+		QuestionCircleOutline,
+		CheckOutline,
+		ClipboardCheckOutline,
+		WandMagicSparklesOutline,
+		MapPinAltOutline
 	} from 'flowbite-svelte-icons';
 	import MultiSelectWithUpload from '$lib/components/MultiSelectWithUpload.svelte';
 	import { writable, type Writable } from 'svelte/store';
@@ -81,6 +87,7 @@
 	import WebSourceChip from '$lib/components/WebSourceChip.svelte';
 	import MCPServerModal from '$lib/components/MCPServerModal.svelte';
 	import PdfPageViewer from '$lib/components/PdfPageViewer.svelte';
+	import LectureSlideFilmstrip from '$lib/components/LectureSlideFilmstrip.svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	export let data;
 	$: lectureVideoDefaultInstructions = data.lectureVideoDefaults?.instructions || '';
@@ -127,6 +134,13 @@
 	const DEFAULT_ELEVENLABS_USE_SPEAKER_BOOST = true;
 	const DEFAULT_ELEVENLABS_STYLE = 0.0;
 	const DEFAULT_ELEVENLABS_SPEED = 1.0;
+	let lectureSlideQuestionDraftCounter = 0;
+	const nextLectureSlideQuestionDraftId = () =>
+		`lecture-slide-question-draft-${lectureSlideQuestionDraftCounter++}`;
+	const lectureSlideQuestionDraftSequence = (clientId: string) => {
+		const sequence = Number(clientId.replace('lecture-slide-question-draft-', ''));
+		return Number.isFinite(sequence) ? sequence : 0;
+	};
 
 	type LectureVideoOptionInput = {
 		option_text: string;
@@ -171,6 +185,152 @@
 			at: string;
 			after: string;
 		}[];
+	};
+
+	type LectureSlideQuestionDraftOption = api.LectureSlideQuestionOptionInput & {
+		client_id: string;
+	};
+
+	type LectureSlideQuestionDraft = Omit<api.LectureSlideQuestionInput, 'options'> & {
+		client_id: string;
+		mode: api.LectureSlideQuestionDraftMode;
+		options: LectureSlideQuestionDraftOption[];
+	};
+
+	const lectureSlideQuestionModeDetails: Record<
+		api.LectureSlideQuestionDraftMode,
+		{
+			label: string;
+			tagline: string;
+			description: string;
+			result: string;
+			icon: typeof ClipboardCheckOutline;
+		}
+	> = {
+		complete: {
+			label: 'Full question',
+			tagline: 'You write it',
+			description: 'Write the prompt, narration, answers, and correct choice.',
+			result: 'Saved exactly as written. The model will not add another question here.',
+			icon: ClipboardCheckOutline
+		},
+		partial: {
+			label: 'Draft for model',
+			tagline: 'You start, AI finishes',
+			description: 'Add any prompt, narration, answer, or correct-answer hints you have.',
+			result: 'The model will keep your hints and fill in the missing details.',
+			icon: WandMagicSparklesOutline
+		},
+		marker: {
+			label: 'Marker only',
+			tagline: 'AI writes it',
+			description: 'Only choose the slide break where a question belongs.',
+			result: 'The model will add a question at this slide break.',
+			icon: MapPinAltOutline
+		}
+	};
+
+	const lectureSlideQuestionToDraft = (
+		question: api.LectureSlideQuestion
+	): LectureSlideQuestionDraft => ({
+		id: question.id,
+		client_id: nextLectureSlideQuestionDraftId(),
+		mode: 'complete',
+		slide_position: question.slide_position,
+		question_text: question.question_text,
+		intro_text: question.intro_text || '',
+		options: question.options.map((option) => ({
+			id: option.id,
+			client_id: nextLectureSlideQuestionDraftId(),
+			option_text: option.option_text,
+			post_answer_text: option.post_answer_text || '',
+			correct: option.correct
+		}))
+	});
+
+	const lectureSlideQuestionDraftToInput = (
+		question: LectureSlideQuestionDraft
+	): api.LectureSlideQuestionInput => ({
+		id: question.id,
+		mode: question.mode,
+		slide_position: question.slide_position,
+		question_text: question.mode === 'marker' ? '' : question.question_text.trim(),
+		intro_text: question.mode === 'marker' ? '' : question.intro_text.trim(),
+		options:
+			question.mode === 'marker'
+				? []
+				: question.options.map((option) => ({
+						id: option.id,
+						option_text: option.option_text.trim(),
+						post_answer_text: option.post_answer_text.trim(),
+						correct: option.correct
+					}))
+	});
+
+	const lectureSlideQuestionComparable = (question: LectureSlideQuestionDraft) => ({
+		mode: question.mode,
+		slide_position: question.slide_position,
+		question_text: question.question_text.trim(),
+		intro_text: question.intro_text.trim(),
+		options: question.options.map((option) => ({
+			option_text: option.option_text.trim(),
+			post_answer_text: option.post_answer_text.trim(),
+			correct: option.correct
+		}))
+	});
+
+	const sortLectureSlideQuestionComparables = <
+		T extends { slide_position: number; question_text: string }
+	>(
+		questions: T[]
+	) =>
+		[...questions].sort((left, right) =>
+			left.slide_position === right.slide_position
+				? JSON.stringify(left).localeCompare(JSON.stringify(right))
+				: left.slide_position - right.slide_position
+		);
+
+	const lectureSlideQuestionFromServerComparable = (question: api.LectureSlideQuestion) => ({
+		mode: 'complete',
+		slide_position: question.slide_position,
+		question_text: question.question_text.trim(),
+		intro_text: (question.intro_text || '').trim(),
+		options: question.options.map((option) => ({
+			option_text: option.option_text.trim(),
+			post_answer_text: (option.post_answer_text || '').trim(),
+			correct: option.correct
+		}))
+	});
+
+	const validateLectureSlideQuestionDrafts = (questions: LectureSlideQuestionDraft[]) => {
+		const sortedQuestions = [...questions].sort((left, right) =>
+			left.slide_position === right.slide_position
+				? lectureSlideQuestionDraftSequence(left.client_id) -
+					lectureSlideQuestionDraftSequence(right.client_id)
+				: left.slide_position - right.slide_position
+		);
+		for (let index = 0; index < sortedQuestions.length; index += 1) {
+			const question = sortedQuestions[index];
+			if (question.mode !== 'complete') {
+				continue;
+			}
+			if (!question.question_text.trim()) {
+				return `Question ${index + 1} needs question text.`;
+			}
+			if (question.options.length < 2) {
+				return `Question ${index + 1} needs at least two answer options.`;
+			}
+			const correctCount = question.options.filter((option) => option.correct).length;
+			if (correctCount !== 1) {
+				return `Question ${index + 1} needs exactly one correct answer.`;
+			}
+			for (let optionIndex = 0; optionIndex < question.options.length; optionIndex += 1) {
+				if (!question.options[optionIndex].option_text.trim()) {
+					return `Question ${index + 1}, option ${optionIndex + 1} needs answer text.`;
+				}
+			}
+		}
+		return null;
 	};
 
 	type LectureVideoSaveAffordances = {
@@ -325,6 +485,9 @@
 	let selectedLectureSlidePosition = 0;
 	let lectureSlidePageDrafts: api.LectureSlidePageNotes[] = [];
 	let hasSetLectureSlidePageDrafts = false;
+	let lectureSlideQuestionDrafts: LectureSlideQuestionDraft[] = [];
+	let selectedLectureSlideQuestionClientId: string | null = null;
+	let hasSetLectureSlideQuestionDrafts = false;
 	let slideGenerationPrompt =
 		data.lectureSlideConfig?.generation_prompt || lectureSlideDefaultGenerationPrompt;
 	let hasSetSlideGenerationPrompt = false;
@@ -956,6 +1119,7 @@
 		(data.isCreating ||
 			lectureSlideDeckIdChanged ||
 			lectureSlidePagesChanged ||
+			lectureSlideQuestionsChanged ||
 			lectureSlideVoiceChanged ||
 			slideGenerationPromptChanged ||
 			slideNarrationPromptChanged ||
@@ -1011,6 +1175,12 @@
 		}));
 		hasSetLectureSlidePageDrafts = true;
 	}
+	$: if (!hasSetLectureSlideQuestionDrafts && !lectureSlideConfigLoadError) {
+		lectureSlideQuestionDrafts = (data.lectureSlideConfig?.questions || []).map(
+			lectureSlideQuestionToDraft
+		);
+		hasSetLectureSlideQuestionDrafts = true;
+	}
 	$: if (!hasSetSlideGenerationPrompt && !lectureSlideConfigLoadError) {
 		slideGenerationPrompt =
 			data.lectureSlideConfig?.generation_prompt || lectureSlideDefaultGenerationPrompt;
@@ -1049,6 +1219,18 @@
 	);
 	$: lectureSlidePagesChanged =
 		JSON.stringify(lectureSlidePageDrafts) !== currentLectureSlidePagesNormalized;
+	$: currentLectureSlideQuestionsNormalized = JSON.stringify(
+		sortLectureSlideQuestionComparables(
+			(data.lectureSlideConfig?.questions || []).map(lectureSlideQuestionFromServerComparable)
+		)
+	);
+	$: lectureSlideQuestionsNormalized = JSON.stringify(
+		sortLectureSlideQuestionComparables(
+			lectureSlideQuestionDrafts.map(lectureSlideQuestionComparable)
+		)
+	);
+	$: lectureSlideQuestionsChanged =
+		lectureSlideQuestionsNormalized !== currentLectureSlideQuestionsNormalized;
 	$: lectureSlideDeckIdChanged =
 		(selectedLectureSlideDeck?.id ?? null) !== (currentLectureSlideDeck?.id ?? null);
 	$: originalSlideGenerationPrompt =
@@ -1082,17 +1264,212 @@
 		) ||
 			(selectedLectureSlidePage.narration_text || '').trim().length > 0);
 	$: selectedLectureSlideQuestions = selectedLectureSlidePage
-		? (data.lectureSlideConfig?.questions || []).filter(
+		? orderedLectureSlideQuestions.filter(
 				(question) => question.slide_position === selectedLectureSlidePage?.position
 			)
 		: [];
+	$: selectedLectureSlideQuestion =
+		lectureSlideQuestionDrafts.find(
+			(question) => question.client_id === selectedLectureSlideQuestionClientId
+		) || null;
+	$: orderedLectureSlideQuestions = [...lectureSlideQuestionDrafts].sort((left, right) =>
+		left.slide_position === right.slide_position
+			? lectureSlideQuestionDraftSequence(left.client_id) -
+				lectureSlideQuestionDraftSequence(right.client_id)
+			: left.slide_position - right.slide_position
+	);
+	const lectureSlideQuestionNumber = (questionClientId: string | null | undefined) =>
+		orderedLectureSlideQuestions.findIndex((question) => question.client_id === questionClientId) +
+		1;
+	$: selectedLectureSlideQuestionNumber = lectureSlideQuestionNumber(
+		selectedLectureSlideQuestion?.client_id
+	);
+	$: selectedLectureSlideQuestionModeDetails = selectedLectureSlideQuestion
+		? lectureSlideQuestionModeDetails[selectedLectureSlideQuestion.mode]
+		: null;
+	const selectLectureSlide = (position: number) => {
+		selectedLectureSlidePosition = position;
+		selectedLectureSlideQuestionClientId = null;
+	};
+	const selectLectureSlideQuestion = (question: LectureSlideQuestionDraft) => {
+		selectedLectureSlidePosition = question.slide_position;
+		selectedLectureSlideQuestionClientId = question.client_id;
+	};
 	const goToAdjacentLectureSlide = (delta: number) => {
 		if (selectedLectureSlideIndex < 0) {
 			return;
 		}
 		const next = lectureSlidePages[selectedLectureSlideIndex + delta];
 		if (next) {
-			selectedLectureSlidePosition = next.position;
+			selectLectureSlide(next.position);
+		}
+	};
+
+	const addLectureSlideQuestion = (
+		slidePosition = selectedLectureSlidePosition,
+		mode: api.LectureSlideQuestionDraftMode = 'complete'
+	) => {
+		const question: LectureSlideQuestionDraft = {
+			id: null,
+			client_id: nextLectureSlideQuestionDraftId(),
+			mode,
+			slide_position: slidePosition,
+			question_text: '',
+			intro_text: '',
+			options:
+				mode === 'complete'
+					? [
+							{
+								id: null,
+								client_id: nextLectureSlideQuestionDraftId(),
+								option_text: '',
+								post_answer_text: '',
+								correct: true
+							},
+							{
+								id: null,
+								client_id: nextLectureSlideQuestionDraftId(),
+								option_text: '',
+								post_answer_text: '',
+								correct: false
+							}
+						]
+					: []
+		};
+		lectureSlideQuestionDrafts = [...lectureSlideQuestionDrafts, question].sort((left, right) =>
+			left.slide_position === right.slide_position
+				? lectureSlideQuestionDraftSequence(left.client_id) -
+					lectureSlideQuestionDraftSequence(right.client_id)
+				: left.slide_position - right.slide_position
+		);
+		selectLectureSlideQuestion(question);
+	};
+
+	const setLectureSlideQuestionMode = (
+		questionClientId: string,
+		mode: api.LectureSlideQuestionDraftMode
+	) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) => {
+			if (question.client_id !== questionClientId) {
+				return question;
+			}
+			if (mode === 'complete') {
+				const hasSingleCorrectOption =
+					question.options.filter((option) => option.correct).length === 1;
+				const existingOptions = question.options.map((option, index) => ({
+					...option,
+					correct: hasSingleCorrectOption ? option.correct : index === 0
+				}));
+				return {
+					...question,
+					mode,
+					options: [
+						...existingOptions,
+						...Array.from({ length: Math.max(0, 2 - existingOptions.length) }, (_, index) => ({
+							id: null,
+							client_id: nextLectureSlideQuestionDraftId(),
+							option_text: '',
+							post_answer_text: '',
+							correct: existingOptions.length === 0 && index === 0
+						}))
+					]
+				};
+			}
+			return { ...question, mode };
+		});
+	};
+
+	const updateLectureSlideQuestionDraft = (
+		questionClientId: string,
+		field: 'question_text' | 'intro_text',
+		value: string
+	) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) =>
+			question.client_id === questionClientId ? { ...question, [field]: value } : question
+		);
+	};
+
+	const updateLectureSlideQuestionOptionDraft = (
+		questionClientId: string,
+		optionClientId: string,
+		field: 'option_text' | 'post_answer_text',
+		value: string
+	) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) =>
+			question.client_id === questionClientId
+				? {
+						...question,
+						options: question.options.map((option) =>
+							option.client_id === optionClientId ? { ...option, [field]: value } : option
+						)
+					}
+				: question
+		);
+	};
+
+	const setLectureSlideQuestionCorrectOption = (
+		questionClientId: string,
+		optionClientId: string
+	) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) =>
+			question.client_id === questionClientId
+				? {
+						...question,
+						options: question.options.map((option) => ({
+							...option,
+							correct: option.client_id === optionClientId
+						}))
+					}
+				: question
+		);
+	};
+
+	const addLectureSlideQuestionOption = (questionClientId: string) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) =>
+			question.client_id === questionClientId
+				? {
+						...question,
+						options: [
+							...question.options,
+							{
+								id: null,
+								client_id: nextLectureSlideQuestionDraftId(),
+								option_text: '',
+								post_answer_text: '',
+								correct: false
+							}
+						]
+					}
+				: question
+		);
+	};
+
+	const removeLectureSlideQuestionOption = (questionClientId: string, optionClientId: string) => {
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.map((question) => {
+			if (question.client_id !== questionClientId || question.options.length <= 2) {
+				return question;
+			}
+			const removedOption = question.options.find((option) => option.client_id === optionClientId);
+			const nextOptions = question.options.filter((option) => option.client_id !== optionClientId);
+			if (removedOption?.correct && nextOptions.length > 0) {
+				nextOptions[0] = { ...nextOptions[0], correct: true };
+			}
+			return { ...question, options: nextOptions };
+		});
+	};
+
+	const removeLectureSlideQuestion = (questionClientId: string) => {
+		const removedQuestion = lectureSlideQuestionDrafts.find(
+			(question) => question.client_id === questionClientId
+		);
+		lectureSlideQuestionDrafts = lectureSlideQuestionDrafts.filter(
+			(question) => question.client_id !== questionClientId
+		);
+		if (selectedLectureSlideQuestionClientId === questionClientId) {
+			selectedLectureSlideQuestionClientId = null;
+			if (removedQuestion) {
+				selectedLectureSlidePosition = removedQuestion.slide_position;
+			}
 		}
 	};
 	let hidePrompt = data.isCreating;
@@ -2270,6 +2647,9 @@
 		if (lectureSlidePagesChanged) {
 			modifiedFields.push('lecture slide content');
 		}
+		if (lectureSlideQuestionsChanged) {
+			modifiedFields.push('lecture slide questions');
+		}
 		if (slideGenerationPromptChanged) {
 			modifiedFields.push('question generation prompt');
 		}
@@ -2295,6 +2675,7 @@
 			lecture_video_manifest?: api.LectureVideoManifest;
 			lecture_slide_deck_id?: number;
 			lecture_slide_page_notes?: api.LectureSlidePageNotes[];
+			lecture_slide_questions?: api.LectureSlideQuestionInput[];
 			voice_id?: string;
 		};
 
@@ -2447,6 +2828,9 @@
 				? (selectedLectureSlideDeck?.id ?? undefined)
 				: undefined,
 			lecture_slide_page_notes: isLectureSlideMode ? lectureSlidePageDrafts : undefined,
+			lecture_slide_questions: isLectureSlideMode
+				? lectureSlideQuestionDrafts.map(lectureSlideQuestionDraftToInput)
+				: undefined,
 			voice_id: isLectureMode ? voiceId.trim() : undefined,
 			generation_prompt: isLectureVideoMode
 				? generationPrompt
@@ -2655,6 +3039,8 @@
 					narration_text: ''
 				})
 			);
+			lectureSlideQuestionDrafts = [];
+			selectedLectureSlideQuestionClientId = null;
 			selectedLectureSlidePosition = 0;
 			happyToast('Lecture slides uploaded');
 		} catch (error) {
@@ -3128,10 +3514,20 @@
 				$loadingMessage = '';
 				return;
 			}
+			const lectureSlideQuestionError = validateLectureSlideQuestionDrafts(
+				lectureSlideQuestionDrafts
+			);
+			if (lectureSlideQuestionError) {
+				sadToast(lectureSlideQuestionError);
+				$loading = false;
+				$loadingMessage = '';
+				return;
+			}
 
 			const lectureSlideFieldsChanged =
 				lectureSlideDeckIdChanged ||
 				lectureSlidePagesChanged ||
+				lectureSlideQuestionsChanged ||
 				lectureSlideVoiceChanged ||
 				slideGenerationPromptChanged ||
 				slideNarrationPromptChanged ||
@@ -3142,6 +3538,9 @@
 			if (data.isCreating || lectureSlideFieldsChanged) {
 				params.lecture_slide_deck_id = selectedLectureSlideDeckId;
 				params.lecture_slide_page_notes = lectureSlidePageDrafts;
+				params.lecture_slide_questions = lectureSlideQuestionDrafts.map(
+					lectureSlideQuestionDraftToInput
+				);
 				params.voice_id = trimmedVoiceId;
 				params.generation_prompt = slideGenerationPrompt;
 				params.narration_prompt = slideNarrationPrompt;
@@ -3151,6 +3550,7 @@
 			} else {
 				delete params.lecture_slide_deck_id;
 				delete params.lecture_slide_page_notes;
+				delete params.lecture_slide_questions;
 				delete params.voice_id;
 				delete params.generation_prompt;
 				delete params.narration_prompt;
@@ -3402,164 +3802,526 @@
 		onclose={() => (lectureSlideEditorOpen = false)}
 	>
 		<slot name="header">
-			<Heading tag="h3" class="font-serif text-2xl font-medium text-blue-dark-40">
-				Edit Lecture Slides
-			</Heading>
-		</slot>
-		<div
-			class="grid max-h-[78vh] gap-4 overflow-hidden lg:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]"
-		>
-			<div class="min-h-[420px] overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
-				{#if lectureSlideSourceUrl && selectedLectureSlidePage}
-					<PdfPageViewer
-						sourceUrl={lectureSlideSourceUrl}
-						pageNumber={selectedLectureSlidePage.position + 1}
-						slideLabel={selectedLectureSlideLabel}
-						previousDisabled={selectedLectureSlideIndex <= 0}
-						nextDisabled={selectedLectureSlideIndex < 0 ||
-							selectedLectureSlideIndex >= lectureSlidePages.length - 1}
-						onPrevious={() => goToAdjacentLectureSlide(-1)}
-						onNext={() => goToAdjacentLectureSlide(1)}
-					/>
-				{:else}
-					<div class="flex h-full min-h-[420px] items-center justify-center text-sm text-gray-600">
-						No slide source is available.
-					</div>
-				{/if}
+			<div class="space-y-1">
+				<Heading tag="h3" class="font-serif text-2xl font-medium text-blue-dark-40">
+					Edit Lecture Slides
+				</Heading>
+				<p class="text-sm text-gray-500">
+					Review each slide, fine-tune narration, and add knowledge checks between slides.
+				</p>
 			</div>
-			<div class="flex min-h-0 flex-col overflow-hidden">
-				<div class="mb-3 flex items-center justify-between gap-3 border-b border-gray-200 pb-3">
-					<div>
-						<div class="text-sm font-semibold text-gray-900">{selectedLectureSlideLabel}</div>
-						<div class="text-xs text-gray-500">
-							{selectedLectureSlideDeck?.filename || 'Lecture slides'}
+		</slot>
+		<div class="flex max-h-[80vh] min-h-[560px] flex-col overflow-hidden">
+			<div
+				class="grid min-h-0 flex-1 border-y border-gray-200 lg:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]"
+			>
+				<div class="flex min-h-[420px] overflow-hidden bg-gray-50 lg:border-r lg:border-gray-200">
+					{#if lectureSlideSourceUrl && selectedLectureSlidePage}
+						<PdfPageViewer
+							sourceUrl={lectureSlideSourceUrl}
+							pageNumber={selectedLectureSlidePage.position + 1}
+							slideLabel={selectedLectureSlideLabel}
+							previousDisabled={selectedLectureSlideIndex <= 0}
+							nextDisabled={selectedLectureSlideIndex < 0 ||
+								selectedLectureSlideIndex >= lectureSlidePages.length - 1}
+							onPrevious={() => goToAdjacentLectureSlide(-1)}
+							onNext={() => goToAdjacentLectureSlide(1)}
+						/>
+					{:else}
+						<div
+							class="flex h-full min-h-[420px] w-full items-center justify-center text-sm text-gray-500"
+						>
+							No slide source is available.
 						</div>
-					</div>
+					{/if}
 				</div>
-				{#if selectedLectureSlidePage}
-					<div class="min-h-0 flex-1 overflow-hidden pr-1">
-						<Accordion class="w-full text-left" flush>
-							<AccordionItem paddingFlush="py-2" open>
-								<span slot="header" class="mr-3 w-full">
-									<div class="flex w-full flex-row items-center justify-between gap-2">
-										<div>Slide Content</div>
-										<div class="text-sm font-light text-gray-500">Notes and narration</div>
-									</div>
-								</span>
-								<div class="my-3 max-h-[calc(78vh-14rem)] overflow-y-auto pr-1">
-									<div>
-										<Label for="slide_author_notes">Author Notes</Label>
-										<Helper class="pb-1"
-											>Instructor notes used when generating narration for this slide.</Helper
-										>
-										<Textarea
-											id="slide_author_notes"
-											rows={8}
-											value={selectedLectureSlidePage.user_notes || ''}
-											disabled={preventEdits}
-											oninput={(event) =>
-												updateLectureSlidePageDraft(
-													selectedLectureSlidePage.position,
-													'user_notes',
-													(event.target as HTMLTextAreaElement).value
-												)}
-										/>
-									</div>
-									<div class="mt-4 mb-3">
-										<Label for="slide_narration_text">Narration</Label>
-										<Helper class="pb-1"
-											>Edit the spoken narration for this slide. Saving manual narration edits
-											regenerates audio.</Helper
-										>
-										{#if !selectedLectureSlideHasNarration}
-											<Alert color="blue" defaultClass="mb-3 p-3 text-sm">
-												Narration will become editable after it has been generated.
-											</Alert>
-										{/if}
-										<Textarea
-											id="slide_narration_text"
-											rows={12}
-											value={selectedLectureSlidePage.narration_text || ''}
-											disabled={preventEdits || !selectedLectureSlideHasNarration}
-											oninput={(event) =>
-												updateLectureSlidePageDraft(
-													selectedLectureSlidePage.position,
-													'narration_text',
-													(event.target as HTMLTextAreaElement).value
-												)}
-										/>
-									</div>
+				<div class="flex min-h-0 flex-col overflow-hidden bg-white">
+					<div class="flex items-center justify-between gap-3 border-b border-gray-200 px-5 py-4">
+						<div class="flex min-w-0 items-center gap-2.5">
+							<span
+								class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg {selectedLectureSlideQuestion
+									? 'bg-gray-900 text-white'
+									: 'bg-gray-100 text-gray-600'}"
+							>
+								{#if selectedLectureSlideQuestion}
+									<QuestionCircleOutline class="h-5 w-5" />
+								{:else}
+									<FilePdfOutline class="h-5 w-5" />
+								{/if}
+							</span>
+							<div class="min-w-0">
+								<div class="truncate text-sm font-semibold text-gray-900">
+									{#if selectedLectureSlideQuestion}
+										Q{selectedLectureSlideQuestionNumber}: after slide {selectedLectureSlideQuestion.slide_position +
+											1}
+									{:else}
+										{selectedLectureSlideLabel}
+									{/if}
 								</div>
-							</AccordionItem>
-							{#if selectedLectureSlideQuestions.length > 0}
-								<AccordionItem paddingFlush="py-2">
-									<span slot="header" class="mr-3 w-full">
-										<div class="flex w-full flex-row items-center justify-between gap-2">
-											<div>Knowledge Checks</div>
-											<div class="text-sm font-light text-gray-500">
-												{selectedLectureSlideQuestions.length}
-												{selectedLectureSlideQuestions.length === 1 ? 'question' : 'questions'}
-											</div>
-										</div>
-									</span>
-									<div
-										class="my-3 flex max-h-[calc(78vh-14rem)] flex-col gap-3 overflow-y-auto pr-1"
-									>
-										{#each selectedLectureSlideQuestions as question, questionIndex (question.id)}
-											<div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-												<div class="mb-2 text-xs font-semibold text-gray-500 uppercase">
-													Question {questionIndex + 1}
-												</div>
-												<div class="text-sm font-semibold text-gray-900">
-													{question.question_text}
-												</div>
-												{#if question.intro_text}
-													<div class="mt-1 text-xs text-gray-600">{question.intro_text}</div>
+								<div class="truncate text-xs text-gray-500">
+									{selectedLectureSlideDeck?.filename || 'Lecture slides'}
+								</div>
+							</div>
+						</div>
+						{#if selectedLectureSlidePage && !selectedLectureSlideQuestion}
+							<button
+								type="button"
+								disabled={preventEdits}
+								onclick={() => addLectureSlideQuestion(selectedLectureSlidePage?.position ?? 0)}
+								class="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/20 disabled:cursor-not-allowed disabled:opacity-50"
+							>
+								<PlusOutline class="h-3.5 w-3.5" />
+								Add question
+							</button>
+						{/if}
+					</div>
+					{#if selectedLectureSlideQuestion}
+						<div class="min-h-0 flex-1 overflow-y-auto">
+							<div class="space-y-5 px-5 py-5">
+								<div class="space-y-2.5">
+									<div class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+										How should this question be handled?
+									</div>
+									<div class="grid gap-2 sm:grid-cols-3">
+										{#each Object.entries(lectureSlideQuestionModeDetails) as [mode, details] (mode)}
+											{@const Icon = details.icon}
+											{@const isActive = selectedLectureSlideQuestion.mode === mode}
+											<button
+												type="button"
+												disabled={preventEdits}
+												aria-pressed={isActive}
+												class="group relative flex flex-col gap-2 rounded-xl border p-3 text-left transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/15 disabled:cursor-not-allowed disabled:opacity-60 {isActive
+													? 'border-gray-900 bg-gray-50 shadow-sm'
+													: 'border-gray-200 bg-white hover:border-gray-400 hover:shadow-sm'}"
+												onclick={() =>
+													setLectureSlideQuestionMode(
+														selectedLectureSlideQuestion.client_id,
+														mode as api.LectureSlideQuestionDraftMode
+													)}
+											>
+												<span
+													class="flex h-8 w-8 items-center justify-center rounded-lg transition-colors {isActive
+														? 'bg-gray-900 text-white'
+														: 'bg-gray-100 text-gray-500 group-hover:bg-gray-200'}"
+												>
+													<Icon class="h-4 w-4" />
+												</span>
+												<span class="block">
+													<span class="block text-sm font-semibold text-gray-900"
+														>{details.label}</span
+													>
+													<span class="mt-0.5 block text-[11px] font-medium text-gray-400"
+														>{details.tagline}</span
+													>
+												</span>
+												{#if isActive}
+													<span
+														class="absolute right-2 top-2 flex h-4 w-4 items-center justify-center rounded-full bg-gray-900 text-white"
+													>
+														<CheckOutline class="h-2.5 w-2.5" />
+													</span>
 												{/if}
-												<div class="mt-3 flex flex-col gap-2">
-													{#each question.options as option (option.id)}
-														<div class="rounded-md border border-gray-200 bg-white p-2">
-															<div class="flex items-start justify-between gap-2">
-																<div class="text-sm text-gray-900">{option.option_text}</div>
-																{#if option.correct}
-																	<Badge
-																		class="flex shrink-0 flex-row items-center gap-1 rounded-md border border-green-300 bg-green-50 px-2 py-0.5 text-xs text-green-800 normal-case"
-																	>
-																		<CheckCircleOutline class="h-3.5 w-3.5" />
-																		<div>Correct</div>
-																	</Badge>
-																{/if}
-															</div>
-															{#if option.post_answer_text}
-																<div class="mt-1 text-xs text-gray-600">
-																	{option.post_answer_text}
-																</div>
-															{/if}
-														</div>
-													{/each}
-												</div>
-											</div>
+											</button>
 										{/each}
 									</div>
-								</AccordionItem>
-							{:else}
-								<div class="border-t border-gray-200 py-2 opacity-60">
+									{#if selectedLectureSlideQuestionModeDetails}
+										{@const ResultIcon = selectedLectureSlideQuestionModeDetails.icon}
+										<div
+											class="flex items-start gap-2 rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600"
+										>
+											<ResultIcon class="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+											<span>{selectedLectureSlideQuestionModeDetails.result}</span>
+										</div>
+									{/if}
+								</div>
+								{#if selectedLectureSlideQuestion.mode === 'marker'}
+									<div class="rounded-lg border border-dashed border-gray-300 bg-white p-4">
+										<div class="text-sm font-semibold text-gray-900">
+											Question marker after slide {selectedLectureSlideQuestion.slide_position + 1}
+										</div>
+										<p class="mt-1 text-sm text-gray-500">
+											No prompt, narration, answers, or correct answer are needed. On save, the
+											model will generate one complete question for this slide break.
+										</p>
+									</div>
+								{:else}
+									<div class="space-y-1.5">
+										<Label
+											for="slide_question_text"
+											class="text-xs font-semibold uppercase text-gray-500"
+										>
+											Question prompt{selectedLectureSlideQuestion.mode === 'partial'
+												? ' hint'
+												: ''}
+										</Label>
+										<Textarea
+											id="slide_question_text"
+											rows={2}
+											placeholder={selectedLectureSlideQuestion.mode === 'partial'
+												? 'Optional: start the question and let the model finish it.'
+												: 'What do you want to ask after this slide?'}
+											class="resize-none rounded-lg border-gray-300 text-base font-medium text-gray-900 focus:border-gray-900 focus:ring-gray-900"
+											value={selectedLectureSlideQuestion.question_text}
+											disabled={preventEdits}
+											oninput={(event) =>
+												updateLectureSlideQuestionDraft(
+													selectedLectureSlideQuestion.client_id,
+													'question_text',
+													(event.target as HTMLTextAreaElement).value
+												)}
+										/>
+									</div>
+									<div class="space-y-1.5">
+										<Label
+											for="slide_question_intro_text"
+											class="text-xs font-semibold uppercase text-gray-500"
+										>
+											Spoken intro{selectedLectureSlideQuestion.mode === 'partial' ? ' hint' : ''}
+										</Label>
+										<Textarea
+											id="slide_question_intro_text"
+											rows={3}
+											placeholder={selectedLectureSlideQuestion.mode === 'partial'
+												? 'Optional: give the model a narration cue to preserve.'
+												: 'Optional narration spoken right before the question.'}
+											class="resize-none rounded-lg border-gray-300 text-sm focus:border-gray-900 focus:ring-gray-900"
+											value={selectedLectureSlideQuestion.intro_text}
+											disabled={preventEdits}
+											oninput={(event) =>
+												updateLectureSlideQuestionDraft(
+													selectedLectureSlideQuestion.client_id,
+													'intro_text',
+													(event.target as HTMLTextAreaElement).value
+												)}
+										/>
+										<Helper class="text-xs text-gray-400"
+											>Saving narration changes regenerates this question's audio.</Helper
+										>
+									</div>
+									<div class="space-y-2.5">
+										<div class="flex items-end justify-between">
+											<div>
+												<div class="text-xs font-semibold uppercase text-gray-500">
+													Answers{selectedLectureSlideQuestion.mode === 'partial' ? ' / hints' : ''}
+												</div>
+												<div class="text-xs text-gray-400">
+													{selectedLectureSlideQuestion.mode === 'partial'
+														? 'Optional: add answer hints or mark a correct-answer hint.'
+														: 'Tap the circle to mark the correct one.'}
+												</div>
+											</div>
+											<Button
+												type="button"
+												color="light"
+												size="xs"
+												class="gap-1 rounded-lg border-gray-300"
+												disabled={preventEdits}
+												onclick={() =>
+													addLectureSlideQuestionOption(selectedLectureSlideQuestion.client_id)}
+											>
+												<PlusOutline class="h-3.5 w-3.5" />
+												Add
+											</Button>
+										</div>
+										{#if selectedLectureSlideQuestion.options.length > 0}
+											<div class="space-y-2.5">
+												{#each selectedLectureSlideQuestion.options as option, optionIndex (option.client_id)}
+													<div
+														class="group relative rounded-lg border p-3 transition-all duration-150 {option.correct
+															? 'border-gray-900 bg-gray-50'
+															: 'border-gray-200 bg-white hover:border-gray-400'}"
+													>
+														{#if option.correct}
+															<span
+																class="absolute -top-2 left-9 rounded bg-gray-900 px-2 py-0.5 text-[10px] font-semibold leading-none text-white"
+															>
+																Correct
+															</span>
+														{/if}
+														<div class="flex items-start gap-3">
+															<button
+																type="button"
+																role="radio"
+																aria-checked={option.correct}
+																aria-label={`Mark option ${optionIndex + 1} as correct`}
+																disabled={preventEdits}
+																onclick={() =>
+																	setLectureSlideQuestionCorrectOption(
+																		selectedLectureSlideQuestion.client_id,
+																		option.client_id
+																	)}
+																class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition disabled:cursor-not-allowed {option.correct
+																	? 'border-gray-900 bg-gray-900 text-white'
+																	: 'border-gray-300 text-transparent hover:border-gray-700 hover:text-gray-700'}"
+															>
+																<CheckOutline class="h-3.5 w-3.5" />
+															</button>
+															<div class="min-w-0 flex-1 space-y-2">
+																<input
+																	id={`slide_question_option_${option.client_id}`}
+																	value={option.option_text}
+																	placeholder={`Answer option ${optionIndex + 1}`}
+																	disabled={preventEdits}
+																	class="w-full border-0 border-b border-transparent bg-transparent p-0 pb-1 text-sm font-medium text-gray-900 placeholder:font-normal placeholder:text-gray-400 focus:border-gray-700 focus:outline-none focus:ring-0 disabled:cursor-not-allowed"
+																	oninput={(event) =>
+																		updateLectureSlideQuestionOptionDraft(
+																			selectedLectureSlideQuestion.client_id,
+																			option.client_id,
+																			'option_text',
+																			(event.target as HTMLInputElement).value
+																		)}
+																/>
+																<textarea
+																	id={`slide_question_feedback_${option.client_id}`}
+																	rows={2}
+																	value={option.post_answer_text}
+																	placeholder="Spoken feedback when this answer is chosen (optional)"
+																	disabled={preventEdits}
+																	class="w-full resize-none rounded-lg bg-gray-50 px-2.5 py-1.5 text-xs text-gray-600 placeholder:text-gray-400 focus:bg-white focus:outline-none focus:ring-1 focus:ring-gray-700 disabled:cursor-not-allowed"
+																	oninput={(event) =>
+																		updateLectureSlideQuestionOptionDraft(
+																			selectedLectureSlideQuestion.client_id,
+																			option.client_id,
+																			'post_answer_text',
+																			(event.target as HTMLTextAreaElement).value
+																		)}
+																></textarea>
+															</div>
+															<button
+																type="button"
+																class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-gray-400 opacity-0 transition hover:bg-gray-100 hover:text-red-600 focus:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-0"
+																disabled={preventEdits ||
+																	selectedLectureSlideQuestion.options.length <= 2}
+																aria-label={`Remove option ${optionIndex + 1}`}
+																title={`Remove option ${optionIndex + 1}`}
+																onclick={() =>
+																	removeLectureSlideQuestionOption(
+																		selectedLectureSlideQuestion.client_id,
+																		option.client_id
+																	)}
+															>
+																<TrashBinOutline class="h-4 w-4" />
+															</button>
+														</div>
+													</div>
+												{/each}
+											</div>
+										{:else}
+											<button
+												type="button"
+												disabled={preventEdits}
+												onclick={() =>
+													addLectureSlideQuestionOption(selectedLectureSlideQuestion.client_id)}
+												class="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm font-medium text-gray-700 transition hover:border-gray-500 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+											>
+												<PlusOutline class="h-4 w-4" />
+												Add an answer hint
+											</button>
+										{/if}
+									</div>
+								{/if}
+							</div>
+							<div
+								class="sticky bottom-0 z-10 flex items-center justify-between border-t border-gray-200 bg-white px-5 py-4"
+							>
+								<Button
+									type="button"
+									color="light"
+									size="sm"
+									class="gap-1.5 rounded-lg border-gray-300"
+									onclick={() => selectLectureSlide(selectedLectureSlideQuestion.slide_position)}
+								>
+									<ArrowLeftOutline class="h-4 w-4" />
+									Back to slide
+								</Button>
+								<Button
+									type="button"
+									color="red"
+									size="sm"
+									class="gap-1.5"
+									disabled={preventEdits}
+									onclick={() =>
+										removeLectureSlideQuestion(selectedLectureSlideQuestion?.client_id || '')}
+								>
+									<TrashBinOutline class="h-4 w-4" />
+									Delete question
+								</Button>
+							</div>
+						</div>
+					{:else if selectedLectureSlidePage}
+						<div class="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5">
+							<div class="space-y-1.5">
+								<Label
+									for="slide_author_notes"
+									class="text-xs font-semibold uppercase text-gray-500"
+								>
+									Author notes
+								</Label>
+								<Textarea
+									id="slide_author_notes"
+									rows={6}
+									placeholder="Instructor notes used when generating narration for this slide."
+									class="resize-none rounded-lg border-gray-300 text-sm focus:border-gray-900 focus:ring-gray-900"
+									value={selectedLectureSlidePage.user_notes || ''}
+									disabled={preventEdits}
+									oninput={(event) =>
+										updateLectureSlidePageDraft(
+											selectedLectureSlidePage.position,
+											'user_notes',
+											(event.target as HTMLTextAreaElement).value
+										)}
+								/>
+							</div>
+							<div class="space-y-1.5">
+								<Label
+									for="slide_narration_text"
+									class="text-xs font-semibold uppercase text-gray-500"
+								>
+									Narration
+								</Label>
+								{#if !selectedLectureSlideHasNarration}
 									<div
-										class="flex w-full cursor-not-allowed flex-row items-center justify-between gap-2 py-3 text-sm font-medium text-gray-500"
+										class="mb-1 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600"
 									>
-										<div>Knowledge Checks</div>
-										<div class="font-light">No questions generated</div>
+										Narration will become editable after it has been generated.
+									</div>
+								{/if}
+								<Textarea
+									id="slide_narration_text"
+									rows={9}
+									placeholder="The spoken narration for this slide."
+									class="resize-none rounded-lg border-gray-300 text-sm focus:border-gray-900 focus:ring-gray-900"
+									value={selectedLectureSlidePage.narration_text || ''}
+									disabled={preventEdits || !selectedLectureSlideHasNarration}
+									oninput={(event) =>
+										updateLectureSlidePageDraft(
+											selectedLectureSlidePage.position,
+											'narration_text',
+											(event.target as HTMLTextAreaElement).value
+										)}
+								/>
+								<Helper class="text-xs text-gray-400"
+									>Saving manual narration edits regenerates audio.</Helper
+								>
+							</div>
+							<div class="space-y-3 border-t border-gray-200 pt-4">
+								<div class="flex items-center justify-between">
+									<div class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+										Questions after this slide
+									</div>
+									{#if selectedLectureSlideQuestions.length > 0}
+										<span
+											class="flex h-5 min-w-5 items-center justify-center rounded-full bg-gray-900 px-1.5 text-[11px] font-semibold text-white"
+										>
+											{selectedLectureSlideQuestions.length}
+										</span>
+									{/if}
+								</div>
+								{#if selectedLectureSlideQuestions.length > 0}
+									<div class="space-y-2">
+										{#each selectedLectureSlideQuestions as question (question.client_id)}
+											{@const questionNumber = lectureSlideQuestionNumber(question.client_id)}
+											{@const questionMode = lectureSlideQuestionModeDetails[question.mode]}
+											{@const QIcon = questionMode.icon}
+											<button
+												type="button"
+												class="group flex w-full items-center gap-3 rounded-xl border border-gray-200 bg-white p-2.5 text-left transition-all duration-150 hover:border-gray-400 hover:shadow-sm"
+												onclick={() => selectLectureSlideQuestion(question)}
+											>
+												<span
+													class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-xs font-semibold text-gray-700"
+												>
+													Q{questionNumber}
+												</span>
+												<span class="min-w-0 flex-1">
+													<span
+														class="flex items-center gap-1.5 text-[11px] font-semibold text-gray-500"
+													>
+														<QIcon class="h-3 w-3" />
+														{questionMode.label}
+													</span>
+													<span class="mt-0.5 block truncate text-sm text-gray-900"
+														>{question.question_text ||
+															(question.mode === 'marker'
+																? 'Marker only — the model will write this'
+																: 'Untitled question')}</span
+													>
+												</span>
+												<ArrowRightOutline
+													class="h-4 w-4 shrink-0 text-gray-300 transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-gray-500"
+												/>
+											</button>
+										{/each}
+									</div>
+								{/if}
+								<div class="space-y-2">
+									<div class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+										{selectedLectureSlideQuestions.length > 0 ? 'Add another' : 'Add a question'}
+									</div>
+									<div class="grid gap-2 sm:grid-cols-3">
+										{#each Object.entries(lectureSlideQuestionModeDetails) as [mode, details] (mode)}
+											{@const AddIcon = details.icon}
+											<button
+												type="button"
+												disabled={preventEdits}
+												title={details.description}
+												onclick={() =>
+													addLectureSlideQuestion(
+														selectedLectureSlidePage?.position ?? 0,
+														mode as api.LectureSlideQuestionDraftMode
+													)}
+												class="group relative flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-3 text-left transition-all duration-150 hover:border-gray-400 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/15 disabled:cursor-not-allowed disabled:opacity-60"
+											>
+												<span
+													class="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition-colors group-hover:bg-gray-200"
+												>
+													<AddIcon class="h-4 w-4" />
+												</span>
+												<span class="block">
+													<span class="block text-sm font-semibold text-gray-900"
+														>{details.label}</span
+													>
+													<span class="mt-0.5 block text-[11px] font-medium text-gray-400"
+														>{details.tagline}</span
+													>
+												</span>
+												<PlusOutline
+													class="absolute right-2.5 top-2.5 h-3.5 w-3.5 text-gray-300 transition-colors group-hover:text-gray-600"
+												/>
+											</button>
+										{/each}
 									</div>
 								</div>
-							{/if}
-						</Accordion>
-					</div>
-				{:else}
-					<div class="flex min-h-[320px] items-center justify-center text-sm text-gray-600">
-						Upload slides to edit slide content.
-					</div>
-				{/if}
+							</div>
+						</div>
+					{:else}
+						<div class="flex min-h-[320px] items-center justify-center text-sm text-gray-500">
+							Upload slides to edit slide content.
+						</div>
+					{/if}
+				</div>
 			</div>
+			{#if lectureSlidePages.length > 0}
+				<div class="border-b border-gray-200 bg-white px-4 pb-2 pt-3">
+					<div class="flex items-center justify-between px-1 pb-1.5">
+						<span class="text-xs font-semibold uppercase text-gray-500">Slides</span>
+						<span class="text-xs text-gray-400">
+							{lectureSlidePages.length}
+							{lectureSlidePages.length === 1 ? 'slide' : 'slides'}
+						</span>
+					</div>
+					<LectureSlideFilmstrip
+						sourceUrl={lectureSlideSourceUrl}
+						pages={lectureSlidePages}
+						questions={lectureSlideQuestionDrafts}
+						selectedPosition={selectedLectureSlidePosition}
+						selectedQuestionClientId={selectedLectureSlideQuestionClientId}
+						onSelectSlide={selectLectureSlide}
+						onSelectQuestion={selectLectureSlideQuestion}
+						onAddQuestion={preventEdits ? null : (position) => addLectureSlideQuestion(position)}
+					/>
+				</div>
+			{/if}
 		</div>
 		<svelte:fragment slot="footer">
 			<div class="flex w-full justify-end">

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -230,24 +230,6 @@
 		}
 	};
 
-	const lectureSlideQuestionToDraft = (
-		question: api.LectureSlideQuestion
-	): LectureSlideQuestionDraft => ({
-		id: question.id,
-		client_id: nextLectureSlideQuestionDraftId(),
-		mode: 'complete',
-		slide_position: question.slide_position,
-		question_text: question.question_text,
-		intro_text: question.intro_text || '',
-		options: question.options.map((option) => ({
-			id: option.id,
-			client_id: nextLectureSlideQuestionDraftId(),
-			option_text: option.option_text,
-			post_answer_text: option.post_answer_text || '',
-			correct: option.correct
-		}))
-	});
-
 	const lectureSlideQuestionInputToDraft = (
 		question: api.LectureSlideQuestionInput
 	): LectureSlideQuestionDraft => ({
@@ -266,9 +248,9 @@
 		}))
 	});
 
-	const currentLectureSlideQuestionDraftInputs = () =>
-		data.lectureSlideConfig?.question_drafts ||
-		(data.lectureSlideConfig?.questions || []).map((question) => ({
+	const currentLectureSlideQuestionDraftInputs = (lectureSlideConfig = data.lectureSlideConfig) =>
+		lectureSlideConfig?.question_drafts ||
+		(lectureSlideConfig?.questions || []).map((question) => ({
 			id: question.id,
 			mode: 'complete' as api.LectureSlideQuestionDraftMode,
 			slide_position: question.slide_position,
@@ -1223,7 +1205,9 @@
 		hasSetLectureSlidePageDrafts = true;
 	}
 	$: if (!hasSetLectureSlideQuestionDrafts && !lectureSlideConfigLoadError) {
-		hydrateLectureSlideQuestionDrafts(currentLectureSlideQuestionDraftInputs());
+		hydrateLectureSlideQuestionDrafts(
+			currentLectureSlideQuestionDraftInputs(data.lectureSlideConfig)
+		);
 	}
 	$: if (!hasSetSlideGenerationPrompt && !lectureSlideConfigLoadError) {
 		slideGenerationPrompt =
@@ -1265,7 +1249,9 @@
 		JSON.stringify(lectureSlidePageDrafts) !== currentLectureSlidePagesNormalized;
 	$: currentLectureSlideQuestionsNormalized = JSON.stringify(
 		sortLectureSlideQuestionComparables(
-			currentLectureSlideQuestionDraftInputs().map(lectureSlideQuestionInputComparable)
+			currentLectureSlideQuestionDraftInputs(data.lectureSlideConfig).map(
+				lectureSlideQuestionInputComparable
+			)
 		)
 	);
 	$: lectureSlideQuestionsNormalized = JSON.stringify(


### PR DESCRIPTION
## Lecture Slides (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Slides, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
>
> Lecture Slides mode is currently visible only to institutional admins when creating an assistant.

### New Features
* The Lecture Slides editor now includes a slide timeline with PDF thumbnails, slide selection, and question markers so instructors can move through a deck and its Knowledge Checks from one timeline-style view.
* Instructors can now add, edit, and delete Lecture Slide Knowledge Checks directly in the slide editor.
* Lecture Slide Knowledge Checks now support three authoring modes: full instructor-authored questions, partial drafts for the model to complete, and marker-only questions where the instructor chooses the slide break and lets the model write the full question.
* Instructors can now edit Knowledge Check prompts, spoken intros, answer choices, correct-answer selection, and per-answer spoken feedback from the assistant editor.
* Instructor-authored Knowledge Checks can now be included when creating or updating Lecture Slide assistants, instead of relying only on generated questions.

### Updates & Improvements
* Lecture Slide generation now preserves complete instructor-authored questions exactly and avoids generating duplicate questions after the same slide.
* Partial Knowledge Check drafts and marker-only question requests are now passed into manifest generation so the model can complete or create questions at the requested slide positions.
* Saving Knowledge Check narration or feedback edits now queues only the affected question audio for regeneration.
* Changing the Lecture Slides voice or requesting audio regeneration now resets both slide narration audio and Knowledge Check audio.
* The assistant save flow now treats Lecture Slide question edits as first-class changes and includes them in the unsaved-changes summary.