### PR TITLE
change(slides): use stored slide deck on openai for generation

### DIFF
--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -54,6 +54,7 @@ from pingpong.lecture_video_service import (
     TRANSCRIPT_DATA_VERSION,
     lecture_video_words_to_webvtt,
 )
+from pingpong.lecture_slide_service import upload_lecture_slide_source_to_openai
 from pingpong.now import utcnow
 from pingpong.worker_pool import (
     DEFAULT_WORKER_POLL_INTERVAL_SECONDS,
@@ -1090,6 +1091,7 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                     )
 
             transcript: list[schemas.LectureVideoManifestWordV3] | None = None
+            openai_input_file_id: str | None = None
 
             if (
                 start_stage
@@ -1112,6 +1114,11 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                 assert pdf_path is not None
                 assert openai_client is not None
                 assert responses_model is not None
+                openai_input_file_id = await _get_or_upload_openai_input_pdf(
+                    run_id, lease_token, deck_id, pdf_path
+                )
+                if openai_input_file_id is None:
+                    return
                 await _set_run_stage(
                     run_id,
                     lease_token,
@@ -1121,7 +1128,7 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                     run_id,
                     lease_token,
                     deck_id,
-                    pdf_path,
+                    openai_input_file_id,
                     responses_model,
                     openai_client,
                 )
@@ -1177,6 +1184,12 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                 assert pdf_path is not None
                 assert openai_client is not None
                 assert responses_model is not None
+                if openai_input_file_id is None:
+                    openai_input_file_id = await _get_or_upload_openai_input_pdf(
+                        run_id, lease_token, deck_id, pdf_path
+                    )
+                    if openai_input_file_id is None:
+                        return
                 await _set_run_stage(
                     run_id,
                     lease_token,
@@ -1186,7 +1199,7 @@ async def _process_claimed_slide_run(run_id: int, lease_token: str) -> None:
                     run_id,
                     lease_token,
                     deck_id,
-                    pdf_path,
+                    openai_input_file_id,
                     transcript,
                     responses_model,
                     openai_client,
@@ -1562,40 +1575,60 @@ def cleanup_extracted_slide_assets(assets: Sequence[ExtractedSlideAsset]) -> Non
         shutil.rmtree(output_dir, ignore_errors=True)
 
 
-async def _upload_openai_input_pdf(
-    openai_client: openai.AsyncClient | openai.AsyncAzureOpenAI,
+async def _get_or_upload_openai_input_pdf(
+    run_id: int,
+    lease_token: str,
+    deck_id: int,
     pdf_path: str,
-) -> str:
-    with open(pdf_path, "rb") as pdf_file:
-        uploaded_file = await openai_client.files.create(
-            file=pdf_file,
-            purpose="user_data",
-        )
-    file_id = getattr(uploaded_file, "id", None)
-    if not file_id and isinstance(uploaded_file, dict):
-        file_id = uploaded_file.get("id")
-    if not file_id:
-        raise RuntimeError("OpenAI did not return a file id for lecture slide PDF.")
-    return str(file_id)
+) -> str | None:
+    async def _resolve() -> str | None:
+        async with config.db.driver.async_session() as session:
+            deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+                session, deck_id
+            )
+            if deck is None:
+                run = await models.LectureSlideProcessingRun.get_by_id(session, run_id)
+                if run is not None and run.lease_token == lease_token:
+                    await _mark_run_cancelled(
+                        session,
+                        run,
+                        schemas.LectureSlideProcessingCancelReason.LECTURE_SLIDE_DECK_DELETED,
+                    )
+                    await session.commit()
+                return None
+            source = deck.source_stored_object
+            if source is None:
+                raise RuntimeError("Lecture slide source object is not loaded.")
+            if source.openai_file_object_id is not None:
+                file = await models.File.get_by_id(
+                    session, source.openai_file_object_id
+                )
+                if file is not None and file.file_id:
+                    return str(file.file_id)
 
+            source_bytes = await asyncio.to_thread(Path(pdf_path).read_bytes)
+            file = await upload_lecture_slide_source_to_openai(
+                session,
+                source,
+                class_id=deck.class_id,
+                uploader_id=deck.uploader_id,
+                source_bytes=source_bytes,
+            )
+            await session.commit()
+            return str(file.file_id)
 
-async def _delete_openai_file_quietly(
-    openai_client: openai.AsyncClient | openai.AsyncAzureOpenAI,
-    file_id: str,
-) -> None:
-    try:
-        await openai_client.files.delete(file_id)
-    except Exception:
-        logger.exception(
-            "Failed to delete uploaded lecture slide PDF file_id=%s", file_id
-        )
+    return await _await_with_run_lease_heartbeat(
+        run_id,
+        lease_token,
+        _resolve(),
+    )
 
 
 async def _generate_narration_text(
     run_id: int,
     lease_token: str,
     deck_id: int,
-    pdf_path: str,
+    file_id: str,
     responses_model: str,
     openai_client: openai.AsyncClient | openai.AsyncAzureOpenAI,
 ) -> GeneratedSlideNarrationSet | None:
@@ -1610,41 +1643,31 @@ async def _generate_narration_text(
         author_comments_guidance = _slide_author_comments_guidance_text(deck.pages)
         response_model = _generated_slide_narration_set_model(slide_count)
 
-    file_id = await _await_with_run_lease_heartbeat(
+    return await _await_with_run_lease_heartbeat(
         run_id,
         lease_token,
-        _upload_openai_input_pdf(openai_client, pdf_path),
+        _parse_responses_output(
+            openai_client,
+            model=responses_model,
+            instructions=prompt,
+            response_model=response_model,
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_file", "file_id": file_id},
+                        {
+                            "type": "input_text",
+                            "text": _build_narration_generation_user_message(
+                                slide_count,
+                                author_comments_guidance,
+                            ),
+                        },
+                    ],
+                }
+            ],
+        ),
     )
-    if file_id is None:
-        return None
-    try:
-        return await _await_with_run_lease_heartbeat(
-            run_id,
-            lease_token,
-            _parse_responses_output(
-                openai_client,
-                model=responses_model,
-                instructions=prompt,
-                response_model=response_model,
-                input_messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "input_file", "file_id": file_id},
-                            {
-                                "type": "input_text",
-                                "text": _build_narration_generation_user_message(
-                                    slide_count,
-                                    author_comments_guidance,
-                                ),
-                            },
-                        ],
-                    }
-                ],
-            ),
-        )
-    finally:
-        await _delete_openai_file_quietly(openai_client, file_id)
 
 
 def _slide_author_comments_guidance_text(
@@ -2459,7 +2482,7 @@ async def _generate_slide_manifest(
     run_id: int,
     lease_token: str,
     deck_id: int,
-    pdf_path: str,
+    file_id: str,
     transcript: list[schemas.LectureVideoManifestWordV3],
     responses_model: str,
     openai_client: openai.AsyncClient | openai.AsyncAzureOpenAI,
@@ -2490,31 +2513,21 @@ async def _generate_slide_manifest(
         transcript=transcript,
     )
 
-    file_id = await _await_with_run_lease_heartbeat(
+    return await _await_with_run_lease_heartbeat(
         run_id,
         lease_token,
-        _upload_openai_input_pdf(openai_client, pdf_path),
+        _generate_slide_manifest_with_optional_chunks(
+            openai_client=openai_client,
+            model=responses_model,
+            file_id=file_id,
+            generation_prompt=prompt,
+            page_ranges=page_ranges,
+            transcript=transcript,
+            total_duration_ms=total_duration_ms,
+            manual_questions=manual_questions,
+            question_requests=question_requests,
+        ),
     )
-    if file_id is None:
-        return None
-    try:
-        return await _await_with_run_lease_heartbeat(
-            run_id,
-            lease_token,
-            _generate_slide_manifest_with_optional_chunks(
-                openai_client=openai_client,
-                model=responses_model,
-                file_id=file_id,
-                generation_prompt=prompt,
-                page_ranges=page_ranges,
-                transcript=transcript,
-                total_duration_ms=total_duration_ms,
-                manual_questions=manual_questions,
-                question_requests=question_requests,
-            ),
-        )
-    finally:
-        await _delete_openai_file_quietly(openai_client, file_id)
 
 
 async def _generate_slide_manifest_with_optional_chunks(

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -1581,6 +1581,16 @@ async def _get_or_upload_openai_input_pdf(
     deck_id: int,
     pdf_path: str,
 ) -> str | None:
+    async def _openai_file_exists(
+        session: AsyncSession, class_id: int, file_id: str
+    ) -> bool:
+        openai_client = await get_openai_client_by_class_id(session, class_id)
+        try:
+            await openai_client.files.retrieve(file_id)
+        except openai.NotFoundError:
+            return False
+        return True
+
     async def _resolve() -> str | None:
         async with config.db.driver.async_session() as session:
             deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
@@ -1603,8 +1613,28 @@ async def _get_or_upload_openai_input_pdf(
                 file = await models.File.get_by_id(
                     session, source.openai_file_object_id
                 )
-                if file is not None and file.file_id:
-                    return str(file.file_id)
+                if file is None or not file.file_id:
+                    logger.warning(
+                        "Lecture slide source has stale OpenAI file object pointer. "
+                        "deck_id=%s source_id=%s file_object_id=%s has_file=%s",
+                        deck.id,
+                        source.id,
+                        source.openai_file_object_id,
+                        file is not None,
+                    )
+                else:
+                    file_id = str(file.file_id)
+                    if await _openai_file_exists(session, deck.class_id, file_id):
+                        return file_id
+                    logger.warning(
+                        "Cached lecture slide OpenAI file is missing upstream; "
+                        "re-uploading source PDF. deck_id=%s source_id=%s file_id=%s",
+                        deck.id,
+                        source.id,
+                        file_id,
+                    )
+                    source.openai_file_object_id = None
+                    session.add(source)
 
             source_bytes = await asyncio.to_thread(Path(pdf_path).read_bytes)
             file = await upload_lecture_slide_source_to_openai(

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -68,7 +68,7 @@ async def upload_lecture_slide_source_to_openai(
     source: models.LectureSlideSourceStoredObject,
     *,
     class_id: int,
-    uploader_id: int,
+    uploader_id: int | None,
     source_bytes: bytes | None = None,
 ) -> models.File:
     if source_bytes is None:

--- a/pingpong/lecture_slide_service.py
+++ b/pingpong/lecture_slide_service.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -96,8 +97,9 @@ async def upload_lecture_slide_source_to_openai(
         source.openai_file_object_id = file.id
         session.add(source)
         return file
-    except Exception:
-        await openai_client.files.delete(file_id)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            await openai_client.files.delete(file_id)
         raise
 
 

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -292,8 +292,58 @@ async def test_list_rendered_pdf_page_images_sorts_zero_padded_names(tmp_path):
     ]
 
 
+async def test_get_or_upload_openai_input_pdf_reuses_source_file(db, monkeypatch):
+    deck = await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        file = await models.File.create(
+            session,
+            {
+                "file_id": "file-existing-slide-source",
+                "private": True,
+                "name": "slides.pdf",
+                "content_type": "application/pdf",
+            },
+            class_id=deck.class_id,
+        )
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        source.openai_file_object_id = file.id
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=deck.id,
+            lecture_slide_deck_id_snapshot=deck.id,
+            class_id=deck.class_id,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TEXT,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([source, run])
+        await session.commit()
+        run_id = run.id
+
+    async def fail_upload(*_args, **_kwargs):
+        raise AssertionError("should not upload an already linked slide source")
+
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "upload_lecture_slide_source_to_openai",
+        fail_upload,
+    )
+
+    file_id = await lecture_slide_processing._get_or_upload_openai_input_pdf(
+        run_id,
+        "lease",
+        deck.id,
+        "/missing/slides.pdf",
+    )
+
+    assert file_id == "file-existing-slide-source"
+
+
 async def test_generate_narration_text_requires_exact_slide_count(
-    db, monkeypatch, tmp_path
+    db,
 ):
     await _create_class_and_deck(db, slide_count=2)
     async with db.async_session() as session:
@@ -345,24 +395,13 @@ async def test_generate_narration_text_requires_exact_slide_count(
                 )
             )
 
-    class FakeFiles:
-        async def delete(self, file_id):
-            captured["deleted_file_id"] = file_id
-
-    fake_client = SimpleNamespace(responses=FakeResponses(), files=FakeFiles())
-    monkeypatch.setattr(
-        lecture_slide_processing,
-        "_upload_openai_input_pdf",
-        lambda _client, _path: _async_value("file-pdf"),
-    )
-    pdf_path = tmp_path / "slides.pdf"
-    pdf_path.write_bytes(b"%PDF-1.4")
+    fake_client = SimpleNamespace(responses=FakeResponses())
 
     narration_set = await lecture_slide_processing._generate_narration_text(
         run_id,
         "lease",
         1,
-        str(pdf_path),
+        "file-pdf",
         "assistant-chat-model",
         fake_client,
     )
@@ -383,11 +422,10 @@ async def test_generate_narration_text_requires_exact_slide_count(
     assert "Emphasize the setup before introducing the result." in payload
     assert "Mention this is a common exam misconception." in payload
     assert "Narration prompt" not in payload
-    assert captured["deleted_file_id"] == "file-pdf"
 
 
 async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_text(
-    db, monkeypatch, tmp_path
+    db,
 ):
     await _create_class_and_deck(db)
     async with db.async_session() as session:
@@ -440,29 +478,18 @@ async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_tex
                 )
             )
 
-    class FakeFiles:
-        async def delete(self, file_id):
-            captured["deleted_file_id"] = file_id
-
-    fake_client = SimpleNamespace(responses=FakeResponses(), files=FakeFiles())
-    monkeypatch.setattr(
-        lecture_slide_processing,
-        "_upload_openai_input_pdf",
-        lambda _client, _path: _async_value("file-pdf"),
-    )
+    fake_client = SimpleNamespace(responses=FakeResponses())
     transcript = [
         schemas.LectureVideoManifestWordV3(
             id="w1", word="transcript-token", start_offset_ms=0, end_offset_ms=500
         )
     ]
-    pdf_path = tmp_path / "slides.pdf"
-    pdf_path.write_bytes(b"%PDF-1.4")
 
     manifest = await lecture_slide_processing._generate_slide_manifest(
         run_id,
         "lease",
         1,
-        str(pdf_path),
+        "file-pdf",
         transcript,
         "assistant-chat-model",
         fake_client,
@@ -487,7 +514,6 @@ async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_tex
     assert "stop_offset_ms" not in instructions
     assert "continue_offset_ms" not in instructions
     assert captured["text_format"] is lecture_slide_processing.GeneratedSlideManifest
-    assert captured["deleted_file_id"] == "file-pdf"
     payload = json.dumps(captured["input"])
     assert "file-pdf" in payload
     assert "transcript-token" in payload
@@ -500,7 +526,7 @@ async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_tex
 
 
 async def test_generate_slide_manifest_rejects_multiple_correct_options(
-    db, monkeypatch, tmp_path
+    db,
 ):
     await _create_class_and_deck(db)
     async with db.async_session() as session:
@@ -546,30 +572,18 @@ async def test_generate_slide_manifest_rejects_multiple_correct_options(
                 )
             )
 
-    class FakeFiles:
-        async def delete(self, _file_id):
-            return None
-
-    fake_client = SimpleNamespace(responses=FakeResponses(), files=FakeFiles())
-    monkeypatch.setattr(
-        lecture_slide_processing,
-        "_upload_openai_input_pdf",
-        lambda _client, _path: _async_value("file-pdf"),
-    )
+    fake_client = SimpleNamespace(responses=FakeResponses())
     transcript = [
         schemas.LectureVideoManifestWordV3(
             id="w1", word="token", start_offset_ms=0, end_offset_ms=1000
         )
     ]
-    pdf_path = tmp_path / "slides.pdf"
-    pdf_path.write_bytes(b"%PDF-1.4")
-
     with pytest.raises(ValueError, match="exactly one correct"):
         await lecture_slide_processing._generate_slide_manifest(
             run_id,
             "lease",
             1,
-            str(pdf_path),
+            "file-pdf",
             transcript,
             "assistant-chat-model",
             fake_client,

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -1,8 +1,12 @@
+import asyncio
 import json
+import logging
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
+import openai
 import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -45,6 +49,16 @@ def _minimal_pdf(text: str) -> bytes:
         f"startxref\n{xref_offset}\n%%EOF\n".encode("ascii")
     )
     return bytes(output)
+
+
+def _openai_not_found_error(file_id: str) -> openai.NotFoundError:
+    request = httpx.Request("GET", f"https://api.openai.com/v1/files/{file_id}")
+    response = httpx.Response(404, request=request)
+    return openai.NotFoundError(
+        f"No file found with id '{file_id}'.",
+        response=response,
+        body={"error": {"message": "not found"}},
+    )
 
 
 def _deck(
@@ -294,6 +308,7 @@ async def test_list_rendered_pdf_page_images_sorts_zero_padded_names(tmp_path):
 
 async def test_get_or_upload_openai_input_pdf_reuses_source_file(db, monkeypatch):
     deck = await _create_class_and_deck(db)
+    retrieved_file_ids: list[str] = []
     async with db.async_session() as session:
         file = await models.File.create(
             session,
@@ -326,10 +341,20 @@ async def test_get_or_upload_openai_input_pdf_reuses_source_file(db, monkeypatch
     async def fail_upload(*_args, **_kwargs):
         raise AssertionError("should not upload an already linked slide source")
 
+    class FakeFiles:
+        async def retrieve(self, file_id):
+            retrieved_file_ids.append(file_id)
+            return SimpleNamespace(id=file_id)
+
     monkeypatch.setattr(
         lecture_slide_processing,
         "upload_lecture_slide_source_to_openai",
         fail_upload,
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "get_openai_client_by_class_id",
+        lambda _session, _class_id: _async_value(SimpleNamespace(files=FakeFiles())),
     )
 
     file_id = await lecture_slide_processing._get_or_upload_openai_input_pdf(
@@ -340,6 +365,211 @@ async def test_get_or_upload_openai_input_pdf_reuses_source_file(db, monkeypatch
     )
 
     assert file_id == "file-existing-slide-source"
+    assert retrieved_file_ids == ["file-existing-slide-source"]
+
+
+async def test_get_or_upload_openai_input_pdf_uploads_when_source_has_no_file(
+    db, monkeypatch, tmp_path
+):
+    deck = await _create_class_and_deck(db)
+    pdf_path = tmp_path / "slides.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    captured: dict[str, object] = {}
+    async with db.async_session() as session:
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=deck.id,
+            lecture_slide_deck_id_snapshot=deck.id,
+            class_id=deck.class_id,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TEXT,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add(run)
+        await session.commit()
+        run_id = run.id
+
+    async def fake_upload(
+        session,
+        source,
+        *,
+        class_id,
+        uploader_id,
+        source_bytes,
+    ):
+        captured["class_id"] = class_id
+        captured["uploader_id"] = uploader_id
+        captured["source_bytes"] = source_bytes
+        file = await models.File.create(
+            session,
+            {
+                "file_id": "file-uploaded-slide-source",
+                "private": True,
+                "uploader_id": uploader_id,
+                "name": source.original_filename,
+                "content_type": source.content_type,
+            },
+            class_id=class_id,
+        )
+        source.openai_file_object_id = file.id
+        session.add(source)
+        captured["file_object_id"] = file.id
+        return file
+
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "upload_lecture_slide_source_to_openai",
+        fake_upload,
+    )
+
+    file_id = await lecture_slide_processing._get_or_upload_openai_input_pdf(
+        run_id,
+        "lease",
+        deck.id,
+        str(pdf_path),
+    )
+
+    assert file_id == "file-uploaded-slide-source"
+    assert captured["class_id"] == deck.class_id
+    assert captured["uploader_id"] is None
+    assert captured["source_bytes"] == b"%PDF-1.4"
+    async with db.async_session() as session:
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        assert source.openai_file_object_id == captured["file_object_id"]
+
+
+async def test_get_or_upload_openai_input_pdf_reuploads_stale_openai_file(
+    db, monkeypatch, tmp_path, caplog
+):
+    deck = await _create_class_and_deck(db)
+    pdf_path = tmp_path / "slides.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    async with db.async_session() as session:
+        old_file = await models.File.create(
+            session,
+            {
+                "file_id": "file-stale-slide-source",
+                "private": True,
+                "name": "slides.pdf",
+                "content_type": "application/pdf",
+            },
+            class_id=deck.class_id,
+        )
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        source.openai_file_object_id = old_file.id
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=deck.id,
+            lecture_slide_deck_id_snapshot=deck.id,
+            class_id=deck.class_id,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TEXT,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([source, run])
+        await session.commit()
+        run_id = run.id
+
+    class FakeFiles:
+        async def retrieve(self, file_id):
+            raise _openai_not_found_error(file_id)
+
+    async def fake_upload(
+        session,
+        source,
+        *,
+        class_id,
+        uploader_id,
+        source_bytes,
+    ):
+        file = await models.File.create(
+            session,
+            {
+                "file_id": "file-new-slide-source",
+                "private": True,
+                "uploader_id": uploader_id,
+                "name": source.original_filename,
+                "content_type": source.content_type,
+            },
+            class_id=class_id,
+        )
+        source.openai_file_object_id = file.id
+        session.add(source)
+        return file
+
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "get_openai_client_by_class_id",
+        lambda _session, _class_id: _async_value(SimpleNamespace(files=FakeFiles())),
+    )
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "upload_lecture_slide_source_to_openai",
+        fake_upload,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        file_id = await lecture_slide_processing._get_or_upload_openai_input_pdf(
+            run_id,
+            "lease",
+            deck.id,
+            str(pdf_path),
+        )
+
+    assert file_id == "file-new-slide-source"
+    assert "missing upstream" in caplog.text
+    async with db.async_session() as session:
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        assert source.openai_file_object_id != old_file.id
+
+
+async def test_upload_lecture_slide_source_to_openai_cleans_up_on_cancellation(
+    db, monkeypatch
+):
+    deck = await _create_class_and_deck(db)
+    deleted_file_ids: list[str] = []
+
+    class FakeFiles:
+        async def create(self, **_kwargs):
+            return SimpleNamespace(id="file-cancelled-upload")
+
+        async def delete(self, file_id):
+            deleted_file_ids.append(file_id)
+
+    async def fail_file_create(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        lecture_slide_service,
+        "get_openai_client_by_class_id",
+        lambda _session, _class_id: _async_value(SimpleNamespace(files=FakeFiles())),
+    )
+    monkeypatch.setattr(lecture_slide_service.models.File, "create", fail_file_create)
+
+    async with db.async_session() as session:
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        with pytest.raises(asyncio.CancelledError):
+            await lecture_slide_service.upload_lecture_slide_source_to_openai(
+                session,
+                source,
+                class_id=deck.class_id,
+                uploader_id=None,
+                source_bytes=b"%PDF-1.4",
+            )
+
+    assert deleted_file_ids == ["file-cancelled-upload"]
 
 
 async def test_generate_narration_text_requires_exact_slide_count(

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -441,6 +441,72 @@ async def test_get_or_upload_openai_input_pdf_uploads_when_source_has_no_file(
         assert source.openai_file_object_id == captured["file_object_id"]
 
 
+async def test_get_or_upload_openai_input_pdf_warns_on_dangling_source_file(
+    db, monkeypatch, tmp_path, caplog
+):
+    deck = await _create_class_and_deck(db)
+    pdf_path = tmp_path / "slides.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    async with db.async_session() as session:
+        source = await session.get(
+            models.LectureSlideSourceStoredObject, deck.source_stored_object_id
+        )
+        assert source is not None
+        source.openai_file_object_id = 999
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=deck.id,
+            lecture_slide_deck_id_snapshot=deck.id,
+            class_id=deck.class_id,
+            stage=schemas.LectureSlideProcessingStage.NARRATION_TEXT,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([source, run])
+        await session.commit()
+        run_id = run.id
+
+    async def fake_upload(
+        session,
+        source,
+        *,
+        class_id,
+        uploader_id,
+        source_bytes,
+    ):
+        file = await models.File.create(
+            session,
+            {
+                "file_id": "file-recovered-slide-source",
+                "private": True,
+                "uploader_id": uploader_id,
+                "name": source.original_filename,
+                "content_type": source.content_type,
+            },
+            class_id=class_id,
+        )
+        source.openai_file_object_id = file.id
+        session.add(source)
+        return file
+
+    monkeypatch.setattr(
+        lecture_slide_processing,
+        "upload_lecture_slide_source_to_openai",
+        fake_upload,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        file_id = await lecture_slide_processing._get_or_upload_openai_input_pdf(
+            run_id,
+            "lease",
+            deck.id,
+            str(pdf_path),
+        )
+
+    assert file_id == "file-recovered-slide-source"
+    assert "stale OpenAI file object pointer" in caplog.text
+
+
 async def test_get_or_upload_openai_input_pdf_reuploads_stale_openai_file(
     db, monkeypatch, tmp_path, caplog
 ):


### PR DESCRIPTION
## Lecture Slides (Preview)

> [!NOTE]
> This release adds new capabilities for Lecture Slides, which remain under active development and are not yet officially supported in Groups. APIs, features, and UI/UX may change before final release.
>
> Lecture Slides mode is currently visible only to institutional admins when creating an assistant.

### Updates & Improvements
* Lecture Slide narration and manifest generation now reuse the stored OpenAI copy of the uploaded slide deck instead of uploading a temporary PDF for each generation step.