### PR TITLE
feat(ui): compact the code interpreter ui

### DIFF
--- a/web/pingpong/src/lib/actions/scroll.ts
+++ b/web/pingpong/src/lib/actions/scroll.ts
@@ -12,6 +12,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	const programmaticScrollEpsilon = 2;
 	const programmaticScrollTimeoutMs = 1500;
 	const bottomSettleWindowMs = 2500;
+	const userExpansionSuppressMs = 15000;
 	let lastScrollTop = el.scrollTop;
 	let userPausedAutoScroll = false;
 	let isProgrammaticScroll = false;
@@ -25,6 +26,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	let currentThreadId = params.threadId;
 	let isStreaming = params.streaming;
 	let preserveBottomUntil = Date.now() + bottomSettleWindowMs;
+	let suppressGrowthAnchorUntil = 0;
 
 	const clearProgrammaticScrollTimeout = () => {
 		if (programmaticScrollTimeout !== null) {
@@ -51,6 +53,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	const getBottomScrollTop = () => Math.max(0, el.scrollHeight - el.clientHeight);
 	const wasNearKnownBottom = () => lastKnownScrollHeight - lastScrollTop - el.clientHeight < 80;
 	const isSettlingAtBottom = () => Date.now() < preserveBottomUntil;
+	const isGrowthAnchorSuppressed = () => Date.now() < suppressGrowthAnchorUntil;
 	const shouldPreserveBottomAnchor = () =>
 		!userPausedAutoScroll && (isProgrammaticScroll || wasNearKnownBottom() || isSettlingAtBottom());
 
@@ -184,6 +187,11 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 
 	const reanchorAfterGrowth = () => {
 		const scrollHeightIncreased = el.scrollHeight > lastKnownScrollHeight;
+		if (scrollHeightIncreased && isGrowthAnchorSuppressed()) {
+			lastKnownScrollHeight = el.scrollHeight;
+			lastScrollTop = el.scrollTop;
+			return false;
+		}
 		if (!scrollHeightIncreased || !shouldPreserveBottomAnchor()) {
 			return false;
 		}
@@ -212,12 +220,23 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 			completeProgrammaticScroll();
 		}
 	};
+	const onUserContentExpansion = () => {
+		suppressGrowthAnchorUntil = Date.now() + userExpansionSuppressMs;
+		preserveBottomUntil = 0;
+		clearProgrammaticScrollTimeout();
+		cancelSettledScroll();
+		isProgrammaticScroll = false;
+		targetScrollTop = null;
+		lastScrollTop = el.scrollTop;
+		lastKnownScrollHeight = el.scrollHeight;
+	};
 
 	el.addEventListener('scroll', onScroll, { passive: true });
 	if (scrollEndSupported) {
 		el.addEventListener('scrollend', onScrollEnd);
 	}
 	el.addEventListener('load', onDescendantLoad, true);
+	el.addEventListener('pp:user-content-expansion', onUserContentExpansion);
 	mutationObserver.observe(el, {
 		childList: true,
 		subtree: true,
@@ -276,6 +295,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 			mutationObserver.disconnect();
 			el.removeEventListener('load', onDescendantLoad, true);
 			el.removeEventListener('scroll', onScroll);
+			el.removeEventListener('pp:user-content-expansion', onUserContentExpansion);
 			if (scrollEndSupported) {
 				el.removeEventListener('scrollend', onScrollEnd);
 			}

--- a/web/pingpong/src/lib/actions/scroll.ts
+++ b/web/pingpong/src/lib/actions/scroll.ts
@@ -11,6 +11,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	const scrollEndSupported = 'onscrollend' in el;
 	const programmaticScrollEpsilon = 2;
 	const programmaticScrollTimeoutMs = 1500;
+	const bottomSettleWindowMs = 2500;
 	let lastScrollTop = el.scrollTop;
 	let userPausedAutoScroll = false;
 	let isProgrammaticScroll = false;
@@ -23,6 +24,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	let lastTailContentKey: string | null = params.tailContentKey ?? null;
 	let currentThreadId = params.threadId;
 	let isStreaming = params.streaming;
+	let preserveBottomUntil = Date.now() + bottomSettleWindowMs;
 
 	const clearProgrammaticScrollTimeout = () => {
 		if (programmaticScrollTimeout !== null) {
@@ -47,6 +49,10 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	};
 
 	const getBottomScrollTop = () => Math.max(0, el.scrollHeight - el.clientHeight);
+	const wasNearKnownBottom = () => lastKnownScrollHeight - lastScrollTop - el.clientHeight < 80;
+	const isSettlingAtBottom = () => Date.now() < preserveBottomUntil;
+	const shouldPreserveBottomAnchor = () =>
+		!userPausedAutoScroll && (isProgrammaticScroll || wasNearKnownBottom() || isSettlingAtBottom());
 
 	const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
 		clearProgrammaticScrollTimeout();
@@ -68,7 +74,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 	const reanchorAfterShrink = () => {
 		const scrollHeightDecreased = el.scrollHeight < lastKnownScrollHeight;
 		// Use the previous scroll metrics to preserve whether the user was anchored before a shrink.
-		const wasNearBottom = lastKnownScrollHeight - lastScrollTop - el.clientHeight < 80;
+		const wasNearBottom = wasNearKnownBottom();
 		if (!isStreaming || !scrollHeightDecreased || !wasNearBottom) {
 			return false;
 		}
@@ -117,10 +123,11 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 			}
 
 			const scrollHeightChanged = el.scrollHeight !== lastKnownScrollHeight;
-			scrollToBottom();
+			scrollToBottom(force ? 'auto' : 'smooth');
 			lastKnownScrollHeight = el.scrollHeight;
 			settlePassesRemaining -= 1;
 			if (scrollHeightChanged) {
+				preserveBottomUntil = Date.now() + bottomSettleWindowMs;
 				settlePassesRemaining = Math.max(settlePassesRemaining, 2);
 			}
 			if (settlePassesRemaining > 0) {
@@ -148,6 +155,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 				el.scrollTop < targetScrollTop - programmaticScrollEpsilon
 			) {
 				userPausedAutoScroll = true;
+				preserveBottomUntil = 0;
 				clearProgrammaticScrollTimeout();
 				isProgrammaticScroll = false;
 				targetScrollTop = null;
@@ -162,6 +170,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 
 		if (isScrollingUp) {
 			userPausedAutoScroll = true;
+			preserveBottomUntil = 0;
 		}
 		if (isStreaming) {
 			const isScrollingDown = el.scrollTop > lastScrollTop;
@@ -173,13 +182,29 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 		lastScrollTop = el.scrollTop;
 	};
 
+	const reanchorAfterGrowth = () => {
+		const scrollHeightIncreased = el.scrollHeight > lastKnownScrollHeight;
+		if (!scrollHeightIncreased || !shouldPreserveBottomAnchor()) {
+			return false;
+		}
+		preserveBottomUntil = Date.now() + bottomSettleWindowMs;
+		scheduleScrollToBottom(4, true);
+		return true;
+	};
+
 	const mutationObserver = new MutationObserver(() => {
 		if (reanchorAfterShrink()) {
+			return;
+		}
+		if (reanchorAfterGrowth()) {
 			return;
 		}
 		if (isStreaming) scheduleScrollToBottom(4);
 	});
 	const onDescendantLoad = () => {
+		if (reanchorAfterGrowth()) {
+			return;
+		}
 		if (isStreaming) scheduleScrollToBottom(4);
 	};
 	const onScrollEnd = () => {
@@ -208,6 +233,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 			if (nextParams.threadId !== currentThreadId) {
 				currentThreadId = nextParams.threadId;
 				userPausedAutoScroll = false;
+				preserveBottomUntil = Date.now() + bottomSettleWindowMs;
 				lastMessageId = null;
 				lastTailContentKey = nextParams.tailContentKey ?? null;
 				lastScrollTop = 0;
@@ -230,6 +256,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 
 			if (isStreaming && !wasStreaming) {
 				userPausedAutoScroll = false;
+				preserveBottomUntil = Date.now() + bottomSettleWindowMs;
 			}
 
 			requestAnimationFrame(() => {
@@ -238,6 +265,7 @@ export const scroll = (el: HTMLDivElement, params: ScrollParams) => {
 					userPausedAutoScroll = false;
 				}
 				if (!userPausedAutoScroll && (hasNewTailMessage || hasTailContentChange || isStreaming)) {
+					preserveBottomUntil = Date.now() + bottomSettleWindowMs;
 					scheduleScrollToBottom();
 				}
 			});

--- a/web/pingpong/src/lib/components/CodeInterpreterCallItem.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterCallItem.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import {
+		ChevronDownOutline,
+		CodeOutline,
+		ImageSolid,
+		TerminalOutline
+	} from 'flowbite-svelte-icons';
+
+	export let label: string;
+	export let icon: 'code' | 'image' | 'logs' = 'code';
+	export let forceOpen = false;
+
+	let open = false;
+	let previousOpen: boolean | null = null;
+	$: {
+		if (forceOpen) {
+			if (previousOpen === null) {
+				previousOpen = open;
+			}
+			open = true;
+		} else if (previousOpen !== null) {
+			open = previousOpen;
+			previousOpen = null;
+		}
+	}
+
+	const toggle = () => (open = !open);
+</script>
+
+<div class="my-2">
+	<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
+		<span class="inline-flex text-gray-600">
+			{#if icon === 'logs'}
+				<TerminalOutline class="h-4 w-4" />
+			{:else if icon === 'image'}
+				<ImageSolid class="h-4 w-4" />
+			{:else}
+				<CodeOutline class="h-4 w-4" />
+			{/if}
+		</span>
+		<span class="text-sm font-medium text-gray-600">{label}{open ? '...' : ''}</span>
+		{#if open}
+			<ChevronDownOutline class="rotate-180 transform text-gray-600" />
+		{:else}
+			<ChevronDownOutline class="text-gray-600" />
+		{/if}
+	</button>
+
+	{#if open}
+		<div
+			class="mt-2 ml-2 border-l border-gray-200 pl-4 text-sm font-light text-gray-600"
+			transition:slide={{ duration: 250 }}
+		>
+			<div class="rounded border border-gray-200 bg-gray-50 px-4 py-3">
+				<slot />
+			</div>
+		</div>
+	{/if}
+</div>

--- a/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
@@ -1,0 +1,169 @@
+<script context="module" lang="ts">
+	import { writable, type Writable } from 'svelte/store';
+	import { SvelteMap } from 'svelte/reactivity';
+
+	type GroupState = {
+		open: boolean;
+		loading: boolean;
+		requested: string[];
+	};
+
+	const groupStores = new SvelteMap<string, Writable<GroupState>>();
+
+	const getGroupStore = (key: string) => {
+		let store = groupStores.get(key);
+		if (!store) {
+			store = writable({ open: false, loading: false, requested: [] });
+			groupStores.set(key, store);
+		}
+		return store;
+	};
+</script>
+
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import { ChevronDownOutline, CodeOutline } from 'flowbite-svelte-icons';
+	import { Spinner } from 'flowbite-svelte';
+	import type * as api from '$lib/api';
+	import CodeInterpreterCallItem from './CodeInterpreterCallItem.svelte';
+
+	// Stable identity for this analysis block across placeholder/result replacement.
+	export let stateKey: string;
+	// The consecutive code-interpreter content items that make up a single analysis.
+	export let items: api.Content[] = [];
+	// Streaming while the assistant is still producing the analysis, done once persisted.
+	export let streaming = false;
+	// Force the group (and the steps inside it) open, e.g. for the print view.
+	export let forceOpen = false;
+	// Resolves a code-interpreter image file id to a displayable URL.
+	export let imageUrl: (fileId: string) => string;
+	// Fetches the result for a placeholder step. Resolves once the result is loaded.
+	export let onFetch: (run_id: string, step_id: string) => Promise<unknown>;
+
+	let groupState = getGroupStore(stateKey);
+	$: groupState = getGroupStore(stateKey);
+	$: open = forceOpen || $groupState.open;
+
+	$: placeholders = items.filter(
+		(item): item is api.CodeInterpreterCallPlaceholder =>
+			item.type === 'code_interpreter_call_placeholder'
+	);
+	$: hasPlaceholders = placeholders.length > 0;
+
+	// Loading state for the in-flight fetch, surfaced next to the "Ran analysis" label.
+	// Enforce a minimum visible duration so a near-instant (e.g. cached) response doesn't
+	// flash the spinner and vanish, which reads as a jarring flicker.
+	const MIN_LOADING_MS = 450;
+	const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+	const requestResults = async () => {
+		if ($groupState.loading) {
+			return;
+		}
+		const pending = placeholders.filter(
+			(placeholder) =>
+				!$groupState.requested.includes(`${placeholder.run_id}:${placeholder.step_id}`)
+		);
+		if (pending.length === 0) {
+			return;
+		}
+		const pendingKeys = pending.map(
+			(placeholder) => `${placeholder.run_id}:${placeholder.step_id}`
+		);
+		groupState.update((state) => ({
+			...state,
+			loading: true,
+			requested: Array.from(new Set([...state.requested, ...pendingKeys]))
+		}));
+		try {
+			await Promise.all([
+				delay(MIN_LOADING_MS),
+				...pending.map((placeholder) => onFetch(placeholder.run_id, placeholder.step_id))
+			]);
+			// Reveal the results once they've loaded.
+			groupState.update((state) => ({ ...state, open: true }));
+		} catch {
+			// The parent surfaces the error; allow the user to retry the fetch.
+			groupState.update((state) => ({
+				...state,
+				requested: state.requested.filter((key) => !pendingKeys.includes(key))
+			}));
+		} finally {
+			groupState.update((state) => ({ ...state, loading: false }));
+		}
+	};
+
+	const toggle = () => {
+		// While results are still placeholders, a click kicks off the fetch and the
+		// accordion opens itself once they arrive — rather than opening onto a spinner.
+		if (hasPlaceholders) {
+			requestResults();
+			return;
+		}
+		groupState.update((state) => ({ ...state, open: !state.open }));
+	};
+
+	// Eagerly fetch results when forced open (e.g. the print view) so they're visible.
+	$: if (forceOpen && hasPlaceholders) {
+		requestResults();
+	}
+</script>
+
+<div class="my-2">
+	<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
+		<span class="inline-flex text-gray-600">
+			<CodeOutline class="h-4 w-4" />
+		</span>
+		{#if streaming}
+			<span class="shimmer text-sm font-medium">Analyzing...</span>
+		{:else}
+			<span class="text-sm font-medium text-gray-600">Ran analysis</span>
+		{/if}
+		{#if $groupState.loading}
+			<Spinner color="gray" size="4" />
+		{/if}
+		<ChevronDownOutline class="text-gray-600 {open ? 'rotate-180 transform' : ''}" />
+	</button>
+
+	{#if open}
+		<div class="mt-2 ml-2 border-l border-gray-200 pl-4" transition:slide={{ duration: 250 }}>
+			{#each items as item, i (i)}
+				{#if item.type === 'code'}
+					<CodeInterpreterCallItem label="Ran Code Interpreter code" icon="code" {forceOpen}>
+						<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.code}</pre>
+					</CodeInterpreterCallItem>
+				{:else if item.type === 'code_output_logs'}
+					<CodeInterpreterCallItem label="Returned Code Interpreter logs" icon="logs" {forceOpen}>
+						<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.logs}</pre>
+					</CodeInterpreterCallItem>
+				{:else if item.type === 'code_output_image_file'}
+					<CodeInterpreterCallItem label="Generated output image" icon="image" {forceOpen}>
+						<img
+							class="img-attachment m-auto"
+							src={imageUrl(item.image_file.file_id)}
+							alt="Attachment generated by the assistant"
+						/>
+					</CodeInterpreterCallItem>
+				{:else if item.type === 'code_output_image_url'}
+					<CodeInterpreterCallItem label="Generated output image" icon="image" {forceOpen}>
+						<img
+							class="img-attachment m-auto"
+							src={item.url}
+							alt="Attachment generated by the assistant"
+						/>
+					</CodeInterpreterCallItem>
+				{/if}
+			{/each}
+
+			{#if hasPlaceholders && !$groupState.loading}
+				<button
+					type="button"
+					class="my-2 text-sm font-medium text-gray-500 underline hover:text-gray-700"
+					onclick={requestResults}
+				>
+					Load results
+				</button>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
@@ -5,6 +5,7 @@
 	type GroupState = {
 		open: boolean;
 		loading: boolean;
+		fetching: boolean;
 		requested: string[];
 	};
 
@@ -13,7 +14,7 @@
 	const getGroupStore = (key: string) => {
 		let store = groupStores.get(key);
 		if (!store) {
-			store = writable({ open: false, loading: false, requested: [] });
+			store = writable({ open: false, loading: false, fetching: false, requested: [] });
 			groupStores.set(key, store);
 		}
 		return store;
@@ -21,6 +22,7 @@
 </script>
 
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { ChevronDownOutline, CodeOutline } from 'flowbite-svelte-icons';
 	import { Spinner } from 'flowbite-svelte';
@@ -41,8 +43,38 @@
 	export let onFetch: (run_id: string, step_id: string) => Promise<unknown>;
 
 	let groupState = getGroupStore(stateKey);
+	let previousStateKey: string | null = null;
+	let previousOpen: boolean | null = null;
+	let loadingDelayTimeout: ReturnType<typeof setTimeout> | null = null;
+	let destroyed = false;
+
+	const clearLoadingDelay = () => {
+		if (loadingDelayTimeout) {
+			clearTimeout(loadingDelayTimeout);
+			loadingDelayTimeout = null;
+		}
+	};
+
+	$: {
+		if (previousStateKey && previousStateKey !== stateKey) {
+			groupStores.delete(previousStateKey);
+			previousOpen = null;
+		}
+		previousStateKey = stateKey;
+	}
 	$: groupState = getGroupStore(stateKey);
 	$: open = forceOpen || $groupState.open;
+	$: {
+		if (forceOpen) {
+			if (previousOpen === null) {
+				previousOpen = $groupState.open;
+			}
+		} else if (previousOpen !== null) {
+			const restoredOpen = previousOpen;
+			groupState.update((state) => ({ ...state, open: restoredOpen }));
+			previousOpen = null;
+		}
+	}
 
 	$: placeholders = items.filter(
 		(item): item is api.CodeInterpreterCallPlaceholder =>
@@ -50,14 +82,32 @@
 	);
 	$: hasPlaceholders = placeholders.length > 0;
 
-	// Loading state for the in-flight fetch, surfaced next to the "Ran analysis" label.
-	// Enforce a minimum visible duration so a near-instant (e.g. cached) response doesn't
-	// flash the spinner and vanish, which reads as a jarring flicker.
-	const MIN_LOADING_MS = 450;
+	// Delay the spinner for quick cached responses; once visible, keep it long enough to read.
+	const LOADING_INDICATOR_DELAY_MS = 150;
+	const MIN_VISIBLE_LOADING_MS = 300;
 	const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+	const contentKey = (item: api.Content, i: number) => {
+		if (item.type === 'code_interpreter_call_placeholder') {
+			return `${item.type}:${item.run_id}:${item.step_id}`;
+		}
+		if (item.type === 'code_output_image_file') {
+			return `${item.type}:${item.image_file.file_id}:${item.source_message_id ?? i}`;
+		}
+		if (item.type === 'code_output_image_url') {
+			return `${item.type}:${item.url}:${item.source_message_id ?? i}`;
+		}
+		if (item.type === 'code') {
+			return `${item.type}:${item.source_message_id ?? ''}:${item.code}`;
+		}
+		if (item.type === 'code_output_logs') {
+			return `${item.type}:${item.source_message_id ?? ''}:${item.logs}`;
+		}
+		return `${item.type}:${item.source_message_id ?? i}`;
+	};
+
 	const requestResults = async () => {
-		if ($groupState.loading) {
+		if ($groupState.fetching) {
 			return;
 		}
 		const pending = placeholders.filter(
@@ -70,18 +120,26 @@
 		const pendingKeys = pending.map(
 			(placeholder) => `${placeholder.run_id}:${placeholder.step_id}`
 		);
+		const revealAfterLoad = !forceOpen;
 		groupState.update((state) => ({
 			...state,
-			loading: true,
+			fetching: true,
 			requested: Array.from(new Set([...state.requested, ...pendingKeys]))
 		}));
+		let loadingShownAt: number | null = null;
+		loadingDelayTimeout = setTimeout(() => {
+			loadingShownAt = Date.now();
+			groupState.update((state) => ({ ...state, loading: true }));
+			loadingDelayTimeout = null;
+		}, LOADING_INDICATOR_DELAY_MS);
 		try {
-			await Promise.all([
-				delay(MIN_LOADING_MS),
-				...pending.map((placeholder) => onFetch(placeholder.run_id, placeholder.step_id))
-			]);
-			// Reveal the results once they've loaded.
-			groupState.update((state) => ({ ...state, open: true }));
+			await Promise.all(
+				pending.map((placeholder) => onFetch(placeholder.run_id, placeholder.step_id))
+			);
+			if (revealAfterLoad) {
+				// Reveal the results once they've loaded for a user-triggered load.
+				groupState.update((state) => ({ ...state, open: true }));
+			}
 		} catch {
 			// The parent surfaces the error; allow the user to retry the fetch.
 			groupState.update((state) => ({
@@ -89,7 +147,14 @@
 				requested: state.requested.filter((key) => !pendingKeys.includes(key))
 			}));
 		} finally {
-			groupState.update((state) => ({ ...state, loading: false }));
+			clearLoadingDelay();
+			if (loadingShownAt !== null) {
+				const elapsed = Date.now() - loadingShownAt;
+				await delay(Math.max(0, MIN_VISIBLE_LOADING_MS - elapsed));
+			}
+			if (!destroyed) {
+				groupState.update((state) => ({ ...state, fetching: false, loading: false }));
+			}
 		}
 	};
 
@@ -107,6 +172,12 @@
 	$: if (forceOpen && hasPlaceholders) {
 		requestResults();
 	}
+
+	onDestroy(() => {
+		destroyed = true;
+		clearLoadingDelay();
+		groupStores.delete(stateKey);
+	});
 </script>
 
 <div class="my-2">
@@ -127,7 +198,7 @@
 
 	{#if open}
 		<div class="mt-2 ml-2 border-l border-gray-200 pl-4" transition:slide={{ duration: 250 }}>
-			{#each items as item, i (i)}
+			{#each items as item, i (contentKey(item, i))}
 				{#if item.type === 'code'}
 					<CodeInterpreterCallItem label="Ran Code Interpreter code" icon="code" {forceOpen}>
 						<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.code}</pre>

--- a/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
@@ -158,7 +158,10 @@
 		}
 	};
 
-	const toggle = () => {
+	const toggle = (event: MouseEvent) => {
+		event.currentTarget?.dispatchEvent(
+			new CustomEvent('pp:user-content-expansion', { bubbles: true })
+		);
 		// While results are still placeholders, a click kicks off the fetch and the
 		// accordion opens itself once they arrive — rather than opening onto a spinner.
 		if (hasPlaceholders) {
@@ -171,6 +174,15 @@
 	// Eagerly fetch results when forced open (e.g. the print view) so they're visible.
 	$: if (forceOpen && hasPlaceholders) {
 		requestResults();
+	}
+
+	$: if (!hasPlaceholders && ($groupState.loading || $groupState.fetching)) {
+		groupState.update((state) => ({
+			...state,
+			open: true,
+			loading: false,
+			fetching: false
+		}));
 	}
 
 	onDestroy(() => {

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -51,7 +51,7 @@
 		LinkOutline
 	} from 'flowbite-svelte-icons';
 
-	import { parseTextContent } from '$lib/content';
+	import { groupMessageContent, parseTextContent } from '$lib/content';
 	import { ThreadManager, type Message } from '$lib/stores/thread';
 	import AttachmentDeletedPlaceholder from '$lib/components/AttachmentDeletedPlaceholder.svelte';
 	import FilePlaceholder from '$lib/components/FilePlaceholder.svelte';
@@ -561,97 +561,6 @@
 		}).format(new Date(timestamp * 1000));
 	};
 
-	type MCPContent = api.MCPServerCallItem | api.MCPListToolsCallItem;
-	type ContentBlock =
-		| { type: 'content'; key: string; content: api.Content }
-		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] }
-		| { type: 'ci_group'; key: string; items: api.Content[]; isLast: boolean };
-
-	const isMCPContent = (content: api.Content): content is MCPContent => {
-		return content.type === 'mcp_server_call' || content.type === 'mcp_list_tools_call';
-	};
-
-	// Code-interpreter steps that should be collected under a single "Ran analysis" block.
-	const isCodeInterpreterContent = (content: api.Content) => {
-		return (
-			content.type === 'code' ||
-			content.type === 'code_output_logs' ||
-			content.type === 'code_output_image_file' ||
-			content.type === 'code_output_image_url' ||
-			content.type === 'code_interpreter_call_placeholder'
-		);
-	};
-
-	const getMCPServerKey = (content: MCPContent) => {
-		return content.server_label || content.server_name || 'mcp';
-	};
-
-	const groupMessageContent = (contents: api.Content[]): ContentBlock[] => {
-		const blocks: ContentBlock[] = [];
-		let index = 0;
-		// Ordinal of each code-interpreter analysis within this message. Keyed by ordinal
-		// rather than array position so the block keeps a stable identity when its
-		// placeholder is swapped for the fetched result items (which reorders/resizes
-		// the content array) — otherwise the component would be recreated and its open
-		// accordion would snap shut.
-		let ciGroupOrdinal = 0;
-
-		while (index < contents.length) {
-			const content = contents[index];
-
-			if (isCodeInterpreterContent(content)) {
-				const items: api.Content[] = [content];
-				let cursor = index + 1;
-				while (cursor < contents.length && isCodeInterpreterContent(contents[cursor])) {
-					items.push(contents[cursor]);
-					cursor += 1;
-				}
-				blocks.push({ type: 'ci_group', key: `ci-group-${ciGroupOrdinal}`, items, isLast: false });
-				ciGroupOrdinal += 1;
-				index = cursor;
-				continue;
-			}
-
-			if (!isMCPContent(content)) {
-				blocks.push({ type: 'content', key: `content-${index}`, content });
-				index += 1;
-				continue;
-			}
-
-			const serverKey = getMCPServerKey(content);
-			const items: MCPContent[] = [content];
-			let cursor = index + 1;
-			while (cursor < contents.length) {
-				const next = contents[cursor];
-				if (!isMCPContent(next) || getMCPServerKey(next) !== serverKey) {
-					break;
-				}
-				items.push(next);
-				cursor += 1;
-			}
-
-			if (items.length > 1) {
-				const label = items[0].server_name || items[0].server_label || 'MCP server';
-				blocks.push({
-					type: 'mcp_group',
-					key: `mcp-group-${serverKey}-${index}`,
-					serverLabel: label,
-					items
-				});
-			} else {
-				blocks.push({ type: 'content', key: `content-${index}`, content });
-			}
-
-			index = cursor;
-		}
-
-		const lastBlock = blocks[blocks.length - 1];
-		if (lastBlock?.type === 'ci_group') {
-			lastBlock.isLast = true;
-		}
-		return blocks;
-	};
-
 	let currentMessageAttachments: api.ServerFile[] = [];
 	// Get the name of the participant in the chat thread.
 	const getName = (message: api.OpenAIMessage) => {
@@ -745,6 +654,26 @@
 			// Re-throw so the analysis block resets its loading state and re-enables retry.
 			throw e;
 		}
+	};
+
+	const loadCodeInterpreterResultsForPrint = async () => {
+		const placeholders = get(messages)
+			.flatMap((message) => message.data.content)
+			.filter(
+				(content): content is api.CodeInterpreterCallPlaceholder =>
+					content.type === 'code_interpreter_call_placeholder'
+			);
+		const uniquePlaceholders = new Map(
+			placeholders.map((placeholder) => [
+				`${placeholder.run_id}:${placeholder.step_id}`,
+				placeholder
+			])
+		);
+		await Promise.all(
+			Array.from(uniquePlaceholders.values()).map((placeholder) =>
+				fetchCodeInterpreterResult(placeholder.run_id, placeholder.step_id)
+			)
+		);
 	};
 
 	const getThreadImageUrl = (fileId: string) =>
@@ -1090,6 +1019,7 @@
 		printingThread = true;
 		try {
 			await loadEntireThreadForPrint();
+			await loadCodeInterpreterResultsForPrint();
 			await tick();
 
 			if (typeof window === 'undefined') {

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -669,7 +669,7 @@
 				placeholder
 			])
 		);
-		await Promise.all(
+		await Promise.allSettled(
 			Array.from(uniquePlaceholders.values()).map((placeholder) =>
 				fetchCodeInterpreterResult(placeholder.run_id, placeholder.step_id)
 			)

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -16,11 +16,8 @@
 	import { computeLatestIncidentTimestamps, filterLatestIncidentUpdates } from '$lib/statusUpdates';
 	import { blur } from 'svelte/transition';
 	import {
-		Accordion,
-		AccordionItem,
 		Avatar,
 		Button,
-		Card,
 		Dropdown,
 		DropdownDivider,
 		DropdownItem,
@@ -39,8 +36,6 @@
 	import ChatDropOverlay from '$lib/components/ChatDropOverlay.svelte';
 	import {
 		RefreshOutline,
-		CodeOutline,
-		ImageSolid,
 		CogOutline,
 		EyeOutline,
 		EyeSlashOutline,
@@ -53,8 +48,7 @@
 		ServerOutline,
 		MicrophoneSlashOutline,
 		UsersSolid,
-		LinkOutline,
-		TerminalOutline
+		LinkOutline
 	} from 'flowbite-svelte-icons';
 
 	import { parseTextContent } from '$lib/content';
@@ -78,6 +72,7 @@
 	import FileCitation from './FileCitation.svelte';
 	import StatusErrors from './StatusErrors.svelte';
 	import FileSearchCallItem from './FileSearchCallItem.svelte';
+	import CodeInterpreterGroup from './CodeInterpreterGroup.svelte';
 	import MCPListToolsCallItem from './MCPListToolsCallItem.svelte';
 	import MCPServerCallItem from './MCPServerCallItem.svelte';
 	import ReasoningCallItem from './ReasoningCallItem.svelte';
@@ -338,6 +333,11 @@
 	}
 	$: loading = threadMgr.loading;
 	$: canFetchMore = threadMgr.canFetchMore;
+
+	// The latest assistant message is the one actively streaming while a run is in flight.
+	$: latestMessageId = $messages.length ? $messages[$messages.length - 1].data.id : null;
+	const isStreamingMessage = (message: Message) =>
+		message.streamedInSession && message.data.id === latestMessageId && ($submitting || $waiting);
 	$: supportsFileSearch = data.availableTools.includes('file_search') || false;
 	$: supportsCodeInterpreter = data.availableTools.includes('code_interpreter') || false;
 	$: supportsWebSearch = data.availableTools.includes('web_search') || false;
@@ -564,10 +564,22 @@
 	type MCPContent = api.MCPServerCallItem | api.MCPListToolsCallItem;
 	type ContentBlock =
 		| { type: 'content'; key: string; content: api.Content }
-		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] };
+		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] }
+		| { type: 'ci_group'; key: string; items: api.Content[]; isLast: boolean };
 
 	const isMCPContent = (content: api.Content): content is MCPContent => {
 		return content.type === 'mcp_server_call' || content.type === 'mcp_list_tools_call';
+	};
+
+	// Code-interpreter steps that should be collected under a single "Ran analysis" block.
+	const isCodeInterpreterContent = (content: api.Content) => {
+		return (
+			content.type === 'code' ||
+			content.type === 'code_output_logs' ||
+			content.type === 'code_output_image_file' ||
+			content.type === 'code_output_image_url' ||
+			content.type === 'code_interpreter_call_placeholder'
+		);
 	};
 
 	const getMCPServerKey = (content: MCPContent) => {
@@ -577,9 +589,29 @@
 	const groupMessageContent = (contents: api.Content[]): ContentBlock[] => {
 		const blocks: ContentBlock[] = [];
 		let index = 0;
+		// Ordinal of each code-interpreter analysis within this message. Keyed by ordinal
+		// rather than array position so the block keeps a stable identity when its
+		// placeholder is swapped for the fetched result items (which reorders/resizes
+		// the content array) — otherwise the component would be recreated and its open
+		// accordion would snap shut.
+		let ciGroupOrdinal = 0;
 
 		while (index < contents.length) {
 			const content = contents[index];
+
+			if (isCodeInterpreterContent(content)) {
+				const items: api.Content[] = [content];
+				let cursor = index + 1;
+				while (cursor < contents.length && isCodeInterpreterContent(contents[cursor])) {
+					items.push(contents[cursor]);
+					cursor += 1;
+				}
+				blocks.push({ type: 'ci_group', key: `ci-group-${ciGroupOrdinal}`, items, isLast: false });
+				ciGroupOrdinal += 1;
+				index = cursor;
+				continue;
+			}
+
 			if (!isMCPContent(content)) {
 				blocks.push({ type: 'content', key: `content-${index}`, content });
 				index += 1;
@@ -613,6 +645,10 @@
 			index = cursor;
 		}
 
+		const lastBlock = blocks[blocks.length - 1];
+		if (lastBlock?.type === 'ci_group') {
+			lastBlock.isLast = true;
+		}
 		return blocks;
 	};
 
@@ -698,18 +734,16 @@
 		}
 	};
 
-	// Fetch a singular code interpreter step result
-	const fetchCodeInterpreterResult = async (content: api.Content) => {
-		if (content.type !== 'code_interpreter_call_placeholder') {
-			sadToast('Invalid code interpreter request.');
-			return;
-		}
+	// Fetch a singular code interpreter step result, triggered when its analysis block is opened.
+	const fetchCodeInterpreterResult = async (run_id: string, step_id: string) => {
 		try {
-			await threadMgr.fetchCodeInterpreterResult(content.run_id, content.step_id);
+			await threadMgr.fetchCodeInterpreterResult(run_id, step_id);
 		} catch (e) {
 			sadToast(
 				`Failed to load code interpreter results. Error: ${errorMessage(e, "We're facing an unknown error. Check PingPong's status page for updates if this persists.")}`
 			);
+			// Re-throw so the analysis block resets its loading state and re-enables retry.
+			throw e;
 		}
 	};
 
@@ -1764,6 +1798,7 @@
 								participants={$participants}
 								mimeType={data.uploadInfo.mimeType}
 								{fetchMoreMessages}
+								{fetchCodeInterpreterResult}
 								onsubmit={handleLectureChatSubmit}
 								ondismisserror={handleLectureChatDismissError}
 								oncontinuewatching={handleLectureChatContinueWatching}
@@ -1870,6 +1905,7 @@
 							participants={$participants}
 							mimeType={data.uploadInfo.mimeType}
 							{fetchMoreMessages}
+							{fetchCodeInterpreterResult}
 							onsubmit={handleLectureSlideChatSubmit}
 							ondismisserror={handleLectureChatDismissError}
 							oncontinuewatching={handleLectureChatContinueWatching}
@@ -1970,6 +2006,15 @@
 										{/each}
 									</div>
 								</div>
+							{:else if block.type === 'ci_group'}
+								<CodeInterpreterGroup
+									stateKey={`${message.data.run_id ?? message.data.id}:${block.key}`}
+									items={block.items}
+									streaming={isStreamingMessage(message) && block.isLast}
+									forceOpen={printingThread}
+									imageUrl={(fileId) => getCodeInterpreterImageUrl(message.data, fileId)}
+									onFetch={fetchCodeInterpreterResult}
+								/>
 							{:else}
 								{@const content = block.content}
 								{#if content.type === 'text'}
@@ -2016,53 +2061,6 @@
 											{/each}
 										</div>
 									{/if}
-								{:else if content.type === 'code'}
-									{#if printingThread}
-										<div class="w-full leading-6">
-											<div class="mb-2 flex flex-row items-center space-x-2">
-												<div><CodeOutline size="lg" /></div>
-												<div>Code Interpreter Code</div>
-											</div>
-											<pre style="white-space: pre-wrap;" class="text-black">{content.code}</pre>
-										</div>
-									{:else}
-										<div class="w-full leading-6">
-											<Accordion flush>
-												<AccordionItem>
-													<span slot="header"
-														><div class="flex flex-row items-center space-x-2">
-															<div><CodeOutline size="lg" /></div>
-															<div>Code Interpreter Code</div>
-														</div></span
-													>
-													<pre
-														style="white-space: pre-wrap;"
-														class="text-black">{content.code}</pre>
-												</AccordionItem>
-											</Accordion>
-										</div>
-									{/if}
-								{:else if content.type === 'code_interpreter_call_placeholder'}
-									<Card padding="md" class="flex max-w-full flex-row items-center justify-between">
-										<div class="flex flex-row items-center space-x-2">
-											<div><CodeOutline size="lg" /></div>
-											<div>Code Interpreter</div>
-										</div>
-
-										<div class="flex flex-wrap items-center gap-2">
-											<Button
-												outline
-												disabled={$loading || $submitting || $waiting}
-												pill
-												size="xs"
-												color="alternative"
-												onclick={() => fetchCodeInterpreterResult(content)}
-												ontouchstart={() => fetchCodeInterpreterResult(content)}
-											>
-												Load Code Interpreter Results
-											</Button>
-										</div></Card
-									>
 								{:else if content.type === 'file_search_call'}
 									<FileSearchCallItem {content} forceOpen={printingThread} />
 								{:else if content.type === 'web_search_call'}
@@ -2077,105 +2075,6 @@
 									<MCPListToolsCallItem {content} forceOpen={printingThread} />
 								{:else if content.type === 'reasoning'}
 									<ReasoningCallItem {content} forceOpen={printingThread} />
-								{:else if content.type === 'code_output_image_file'}
-									{#if printingThread}
-										<div class="w-full leading-6">
-											<div class="mb-2 flex flex-row items-center space-x-2">
-												<div><ImageSolid size="lg" /></div>
-												<div>Output Image</div>
-											</div>
-											<div class="w-full leading-6">
-												<img
-													class="img-attachment m-auto"
-													src={getCodeInterpreterImageUrl(message.data, content.image_file.file_id)}
-													alt="Attachment generated by the assistant"
-												/>
-											</div>
-										</div>
-									{:else}
-										<Accordion flush>
-											<AccordionItem>
-												<span slot="header"
-													><div class="flex flex-row items-center space-x-2">
-														<div><ImageSolid size="lg" /></div>
-														<div>Output Image</div>
-													</div></span
-												>
-												<div class="w-full leading-6">
-													<img
-														class="img-attachment m-auto"
-														src={getCodeInterpreterImageUrl(
-															message.data,
-															content.image_file.file_id
-														)}
-														alt="Attachment generated by the assistant"
-													/>
-												</div>
-											</AccordionItem>
-										</Accordion>
-									{/if}
-								{:else if content.type === 'code_output_image_url'}
-									{#if printingThread}
-										<div class="w-full leading-6">
-											<div class="mb-2 flex flex-row items-center space-x-2">
-												<div><ImageSolid size="lg" /></div>
-												<div>Output Image</div>
-											</div>
-											<div class="w-full leading-6">
-												<img
-													class="img-attachment m-auto"
-													src={content.url}
-													alt="Attachment generated by the assistant"
-												/>
-											</div>
-										</div>
-									{:else}
-										<Accordion flush>
-											<AccordionItem>
-												<span slot="header"
-													><div class="flex flex-row items-center space-x-2">
-														<div><ImageSolid size="lg" /></div>
-														<div>Output Image</div>
-													</div></span
-												>
-												<div class="w-full leading-6">
-													<img
-														class="img-attachment m-auto"
-														src={content.url}
-														alt="Attachment generated by the assistant"
-													/>
-												</div>
-											</AccordionItem>
-										</Accordion>
-									{/if}
-								{:else if content.type === 'code_output_logs'}
-									{#if printingThread}
-										<div class="w-full leading-6">
-											<div class="mb-2 flex flex-row items-center space-x-2">
-												<div><TerminalOutline size="lg" /></div>
-												<div>Output Logs</div>
-											</div>
-											<div class="w-full leading-6">
-												<pre style="white-space: pre-wrap;" class="text-black">{content.logs}</pre>
-											</div>
-										</div>
-									{:else}
-										<Accordion flush>
-											<AccordionItem>
-												<span slot="header"
-													><div class="flex flex-row items-center space-x-2">
-														<div><TerminalOutline size="lg" /></div>
-														<div>Output Logs</div>
-													</div></span
-												>
-												<div class="w-full leading-6">
-													<pre
-														style="white-space: pre-wrap;"
-														class="text-black">{content.logs}</pre>
-												</div>
-											</AccordionItem>
-										</Accordion>
-									{/if}
 								{:else if content.type === 'image_file'}
 									{@const optimisticVisionFile =
 										!message.persisted && $version === 3

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoChatPanel.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoChatPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as api from '$lib/api';
-	import { parseTextContent } from '$lib/content';
+	import { groupMessageContent, parseTextContent } from '$lib/content';
 	import { Button, Tooltip, Avatar } from 'flowbite-svelte';
 	import {
 		RefreshOutline,
@@ -107,97 +107,6 @@
 		'Give me a real-world example.',
 		"Quiz me on what's been covered so far."
 	];
-
-	type MCPContent = api.MCPServerCallItem | api.MCPListToolsCallItem;
-	type ContentBlock =
-		| { type: 'content'; key: string; content: api.Content }
-		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] }
-		| { type: 'ci_group'; key: string; items: api.Content[]; isLast: boolean };
-
-	const isMCPContent = (content: api.Content): content is MCPContent => {
-		return content.type === 'mcp_server_call' || content.type === 'mcp_list_tools_call';
-	};
-
-	// Code-interpreter steps that should be collected under a single "Ran analysis" block.
-	const isCodeInterpreterContent = (content: api.Content) => {
-		return (
-			content.type === 'code' ||
-			content.type === 'code_output_logs' ||
-			content.type === 'code_output_image_file' ||
-			content.type === 'code_output_image_url' ||
-			content.type === 'code_interpreter_call_placeholder'
-		);
-	};
-
-	const getMCPServerKey = (content: MCPContent) => {
-		return content.server_label || content.server_name || 'mcp';
-	};
-
-	const groupMessageContent = (contents: api.Content[]): ContentBlock[] => {
-		const blocks: ContentBlock[] = [];
-		let index = 0;
-		// Ordinal of each code-interpreter analysis within this message. Keyed by ordinal
-		// rather than array position so the block keeps a stable identity when its
-		// placeholder is swapped for the fetched result items (which reorders/resizes
-		// the content array) — otherwise the component would be recreated and its open
-		// accordion would snap shut.
-		let ciGroupOrdinal = 0;
-
-		while (index < contents.length) {
-			const content = contents[index];
-
-			if (isCodeInterpreterContent(content)) {
-				const items: api.Content[] = [content];
-				let cursor = index + 1;
-				while (cursor < contents.length && isCodeInterpreterContent(contents[cursor])) {
-					items.push(contents[cursor]);
-					cursor += 1;
-				}
-				blocks.push({ type: 'ci_group', key: `ci-group-${ciGroupOrdinal}`, items, isLast: false });
-				ciGroupOrdinal += 1;
-				index = cursor;
-				continue;
-			}
-
-			if (!isMCPContent(content)) {
-				blocks.push({ type: 'content', key: `content-${index}`, content });
-				index += 1;
-				continue;
-			}
-
-			const serverKey = getMCPServerKey(content);
-			const items: MCPContent[] = [content];
-			let cursor = index + 1;
-			while (cursor < contents.length) {
-				const next = contents[cursor];
-				if (!isMCPContent(next) || getMCPServerKey(next) !== serverKey) {
-					break;
-				}
-				items.push(next);
-				cursor += 1;
-			}
-
-			if (items.length > 1) {
-				const label = items[0].server_name || items[0].server_label || 'MCP server';
-				blocks.push({
-					type: 'mcp_group',
-					key: `mcp-group-${serverKey}-${index}`,
-					serverLabel: label,
-					items
-				});
-			} else {
-				blocks.push({ type: 'content', key: `content-${index}`, content });
-			}
-
-			index = cursor;
-		}
-
-		const lastBlock = blocks[blocks.length - 1];
-		if (lastBlock?.type === 'ci_group') {
-			lastBlock.isLast = true;
-		}
-		return blocks;
-	};
 
 	function isFileCitation(a: api.TextAnnotation): a is api.TextAnnotationFileCitation {
 		return a.type === 'file_citation' && a.text === 'responses_v3';

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoChatPanel.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoChatPanel.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import * as api from '$lib/api';
 	import { parseTextContent } from '$lib/content';
-	import { Button, Tooltip, Avatar, Accordion, AccordionItem } from 'flowbite-svelte';
+	import { Button, Tooltip, Avatar } from 'flowbite-svelte';
 	import {
 		RefreshOutline,
-		CodeOutline,
 		ServerOutline,
-		TerminalOutline,
 		MessageDotsOutline,
 		VolumeUpSolid,
 		VolumeMuteSolid,
@@ -19,6 +17,7 @@
 		type ChatInputHandle,
 		type ChatInputMessage
 	} from '$lib/components/ChatInput.svelte';
+	import CodeInterpreterGroup from '$lib/components/CodeInterpreterGroup.svelte';
 	import FileCitation from '$lib/components/FileCitation.svelte';
 	import FilePlaceholder from '$lib/components/FilePlaceholder.svelte';
 	import FileSearchCallItem from '$lib/components/FileSearchCallItem.svelte';
@@ -56,6 +55,7 @@
 		participants,
 		mimeType,
 		fetchMoreMessages,
+		fetchCodeInterpreterResult,
 		onsubmit,
 		ondismisserror,
 		ttsMuted = false,
@@ -88,6 +88,7 @@
 		participants: api.ThreadParticipants;
 		mimeType: api.MimeTypeLookupFn;
 		fetchMoreMessages: () => Promise<void>;
+		fetchCodeInterpreterResult: (run_id: string, step_id: string) => Promise<unknown>;
 		onsubmit?: (message: ChatInputMessage) => void;
 		ondismisserror?: () => void;
 		ttsMuted?: boolean;
@@ -110,10 +111,22 @@
 	type MCPContent = api.MCPServerCallItem | api.MCPListToolsCallItem;
 	type ContentBlock =
 		| { type: 'content'; key: string; content: api.Content }
-		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] };
+		| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] }
+		| { type: 'ci_group'; key: string; items: api.Content[]; isLast: boolean };
 
 	const isMCPContent = (content: api.Content): content is MCPContent => {
 		return content.type === 'mcp_server_call' || content.type === 'mcp_list_tools_call';
+	};
+
+	// Code-interpreter steps that should be collected under a single "Ran analysis" block.
+	const isCodeInterpreterContent = (content: api.Content) => {
+		return (
+			content.type === 'code' ||
+			content.type === 'code_output_logs' ||
+			content.type === 'code_output_image_file' ||
+			content.type === 'code_output_image_url' ||
+			content.type === 'code_interpreter_call_placeholder'
+		);
 	};
 
 	const getMCPServerKey = (content: MCPContent) => {
@@ -123,9 +136,29 @@
 	const groupMessageContent = (contents: api.Content[]): ContentBlock[] => {
 		const blocks: ContentBlock[] = [];
 		let index = 0;
+		// Ordinal of each code-interpreter analysis within this message. Keyed by ordinal
+		// rather than array position so the block keeps a stable identity when its
+		// placeholder is swapped for the fetched result items (which reorders/resizes
+		// the content array) — otherwise the component would be recreated and its open
+		// accordion would snap shut.
+		let ciGroupOrdinal = 0;
 
 		while (index < contents.length) {
 			const content = contents[index];
+
+			if (isCodeInterpreterContent(content)) {
+				const items: api.Content[] = [content];
+				let cursor = index + 1;
+				while (cursor < contents.length && isCodeInterpreterContent(contents[cursor])) {
+					items.push(contents[cursor]);
+					cursor += 1;
+				}
+				blocks.push({ type: 'ci_group', key: `ci-group-${ciGroupOrdinal}`, items, isLast: false });
+				ciGroupOrdinal += 1;
+				index = cursor;
+				continue;
+			}
+
 			if (!isMCPContent(content)) {
 				blocks.push({ type: 'content', key: `content-${index}`, content });
 				index += 1;
@@ -159,6 +192,10 @@
 			index = cursor;
 		}
 
+		const lastBlock = blocks[blocks.length - 1];
+		if (lastBlock?.type === 'ci_group') {
+			lastBlock.isLast = true;
+		}
 		return blocks;
 	};
 
@@ -520,6 +557,16 @@
 									{/each}
 								</div>
 							</div>
+						{:else if block.type === 'ci_group'}
+							<CodeInterpreterGroup
+								stateKey={`${message.data.run_id ?? message.data.id}:${block.key}`}
+								items={block.items}
+								streaming={isLatestStreamedAssistantResponse(message) &&
+									(submitting || waiting) &&
+									block.isLast}
+								imageUrl={(fileId) => getCodeInterpreterImageUrl(message.data, fileId)}
+								onFetch={fetchCodeInterpreterResult}
+							/>
 						{:else}
 							{@const content = block.content}
 							{#if content.type === 'text'}
@@ -563,18 +610,6 @@
 										{/each}
 									</div>
 								{/if}
-							{:else if content.type === 'code'}
-								<Accordion flush>
-									<AccordionItem>
-										<span slot="header">
-											<div class="flex flex-row items-center space-x-2">
-												<div><CodeOutline size="lg" /></div>
-												<div>Code Interpreter Code</div>
-											</div>
-										</span>
-										<pre style="white-space: pre-wrap;" class="text-black">{content.code}</pre>
-									</AccordionItem>
-								</Accordion>
 							{:else if content.type === 'file_search_call'}
 								<FileSearchCallItem {content} />
 							{:else if content.type === 'web_search_call'}
@@ -585,36 +620,6 @@
 								<MCPListToolsCallItem {content} />
 							{:else if content.type === 'reasoning'}
 								<ReasoningCallItem {content} />
-							{:else if content.type === 'code_output_image_file'}
-								<div class="w-full leading-6">
-									<img
-										class="img-attachment m-auto"
-										src={getCodeInterpreterImageUrl(message.data, content.image_file.file_id)}
-										alt="Attachment generated by the assistant"
-									/>
-								</div>
-							{:else if content.type === 'code_output_image_url'}
-								<div class="w-full leading-6">
-									<img
-										class="img-attachment m-auto"
-										src={content.url}
-										alt="Attachment generated by the assistant"
-									/>
-								</div>
-							{:else if content.type === 'code_output_logs'}
-								<Accordion flush>
-									<AccordionItem>
-										<span slot="header">
-											<div class="flex flex-row items-center space-x-2">
-												<div><TerminalOutline size="lg" /></div>
-												<div>Output Logs</div>
-											</div>
-										</span>
-										<div class="w-full leading-6">
-											<pre style="white-space: pre-wrap;" class="text-black">{content.logs}</pre>
-										</div>
-									</AccordionItem>
-								</Accordion>
 							{:else if content.type === 'image_file'}
 								<div class="w-full leading-6">
 									<img

--- a/web/pingpong/src/lib/content.ts
+++ b/web/pingpong/src/lib/content.ts
@@ -1,4 +1,11 @@
-import { join, type Text, type WebSearchSource } from '$lib/api';
+import {
+	join,
+	type Content,
+	type MCPListToolsCallItem,
+	type MCPServerCallItem,
+	type Text,
+	type WebSearchSource
+} from '$lib/api';
 
 type Replacement = {
 	start: number;
@@ -14,6 +21,95 @@ export type InlineWebSource = {
 export type ParsedTextContent = {
 	content: string;
 	inlineWebSources: InlineWebSource[];
+};
+
+export type MCPContent = MCPServerCallItem | MCPListToolsCallItem;
+export type ContentBlock =
+	| { type: 'content'; key: string; content: Content }
+	| { type: 'mcp_group'; key: string; serverLabel: string; items: MCPContent[] }
+	| { type: 'ci_group'; key: string; items: Content[]; isLast: boolean };
+
+export const isMCPContent = (content: Content): content is MCPContent => {
+	return content.type === 'mcp_server_call' || content.type === 'mcp_list_tools_call';
+};
+
+// Code-interpreter steps that should be collected under a single "Ran analysis" block.
+export const isCodeInterpreterContent = (content: Content) => {
+	return (
+		content.type === 'code' ||
+		content.type === 'code_output_logs' ||
+		content.type === 'code_output_image_file' ||
+		content.type === 'code_output_image_url' ||
+		content.type === 'code_interpreter_call_placeholder'
+	);
+};
+
+const getMCPServerKey = (content: MCPContent) => {
+	return content.server_label || content.server_name || 'mcp';
+};
+
+export const groupMessageContent = (contents: Content[]): ContentBlock[] => {
+	const blocks: ContentBlock[] = [];
+	let index = 0;
+	// Ordinal of each code-interpreter analysis within this message. Keyed by ordinal
+	// rather than array position so the block keeps a stable identity when its
+	// placeholder is swapped for the fetched result items.
+	let ciGroupOrdinal = 0;
+
+	while (index < contents.length) {
+		const content = contents[index];
+
+		if (isCodeInterpreterContent(content)) {
+			const items: Content[] = [content];
+			let cursor = index + 1;
+			while (cursor < contents.length && isCodeInterpreterContent(contents[cursor])) {
+				items.push(contents[cursor]);
+				cursor += 1;
+			}
+			blocks.push({ type: 'ci_group', key: `ci-group-${ciGroupOrdinal}`, items, isLast: false });
+			ciGroupOrdinal += 1;
+			index = cursor;
+			continue;
+		}
+
+		if (!isMCPContent(content)) {
+			blocks.push({ type: 'content', key: `content-${index}`, content });
+			index += 1;
+			continue;
+		}
+
+		const serverKey = getMCPServerKey(content);
+		const items: MCPContent[] = [content];
+		let cursor = index + 1;
+		while (cursor < contents.length) {
+			const next = contents[cursor];
+			if (!isMCPContent(next) || getMCPServerKey(next) !== serverKey) {
+				break;
+			}
+			items.push(next);
+			cursor += 1;
+		}
+
+		if (items.length > 1) {
+			const label = items[0].server_name || items[0].server_label || 'MCP server';
+			blocks.push({
+				type: 'mcp_group',
+				key: `mcp-group-${serverKey}-${index}`,
+				serverLabel: label,
+				items
+			});
+		} else {
+			blocks.push({ type: 'content', key: `content-${index}`, content });
+		}
+
+		index = cursor;
+	}
+
+	const lastBlock = blocks[blocks.length - 1];
+	if (lastBlock?.type === 'ci_group') {
+		lastBlock.isLast = true;
+	}
+	return blocks;
 };
 
 /**

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -645,7 +645,7 @@ export class ThreadManager {
 	}
 
 	async fetchCodeInterpreterResult(run_id: string, step_id: string) {
-		this.#data.update((d) => ({ ...d, error: null, waiting: true }));
+		this.#data.update((d) => ({ ...d, error: null }));
 		try {
 			const result = await api.getCIMessages(
 				this.#fetcher,
@@ -675,16 +675,14 @@ export class ThreadManager {
 									message.metadata.step_id === step_id
 								);
 							})
-					},
-					waiting: false
+					}
 				};
 			});
 			return result;
 		} catch (e) {
 			this.#data.update((d) => ({
 				...d,
-				error: { detail: errorMessage(e, 'Unknown error'), wasSent: true },
-				waiting: false
+				error: { detail: errorMessage(e, 'Unknown error'), wasSent: true }
 			}));
 			throw e;
 		}


### PR DESCRIPTION
## Assistants
### Updates & Improvements
* Code Interpreter activity now appears as a single compact analysis row instead of separate conversation blocks for code, logs, and generated images.
* While Code Interpreter is still running, PingPong shows a collapsed `Analyzing...` row. Once the assistant continues with the next response part, the row changes to `Ran analysis`.
* Opening an analysis reveals nested details for the executed code, returned logs, and generated output images, keeping artifacts available without taking over the conversation.
* Code Interpreter results now load directly from the compact analysis row and open automatically after loading, replacing the previous standalone “Load Code Interpreter Results” card.
* The compact Code Interpreter display is used consistently across regular assistant chats, Lecture Videos chat, and Lecture Slides chat.
* Printed thread exports now include loaded Code Interpreter results instead of leaving placeholder analysis rows unresolved.

### Resolved Issues
* Fixed: Loading Code Interpreter results may make the chat look like it is still waiting for the assistant’s response.
* Fixed: Code Interpreter analysis details may collapse or flicker when placeholder results are replaced with loaded output.
* Fixed: Chats may lose their bottom scroll position while streaming output, generated images, or loaded Code Interpreter results expand the latest message.