### PR TITLE
feat: control ci input/output visibility

### DIFF
--- a/alembic/versions/3e4f5a6b7c8d_add_code_interpreter_visibility_settings.py
+++ b/alembic/versions/3e4f5a6b7c8d_add_code_interpreter_visibility_settings.py
@@ -1,0 +1,47 @@
+"""Add Code Interpreter visibility settings
+
+Revision ID: 3e4f5a6b7c8d
+Revises: 7c1d9e2f3a4b
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3e4f5a6b7c8d"
+down_revision: Union[str, None] = "7c1d9e2f3a4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Resolves CodeQL's py/unused-global-variable
+    _ = revision, down_revision, branch_labels, depends_on
+    op.add_column(
+        "assistants",
+        sa.Column(
+            "hide_code_interpreter_code",
+            sa.Boolean(),
+            server_default="false",
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "assistants",
+        sa.Column(
+            "hide_code_interpreter_output",
+            sa.Boolean(),
+            server_default="false",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("assistants", "hide_code_interpreter_output")
+    op.drop_column("assistants", "hide_code_interpreter_code")

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -625,15 +625,14 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
     def _redacted_code_interpreter_output(
         self, output: dict[str, Any]
     ) -> dict[str, Any]:
-        match output.get("type"):
-            case "image":
-                return {**output, "image": {"file_id": ""}}
-            case "code_output_image_url":
-                return {**output, "url": ""}
-            case "code_output_logs" | "logs":
-                return {**output, "logs": ""}
-            case _:
-                return output
+        output_type = output.get("type")
+        if output_type == "image":
+            return {**output, "image": {"file_id": ""}}
+        if output_type == "code_output_image_url":
+            return {**output, "url": ""}
+        if output_type in {"code_output_logs", "logs"}:
+            return {**output, "logs": ""}
+        return output
 
     async def on_image_file_done(self, image_file: ImageFile) -> None:
         self.enqueue(

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -179,8 +179,6 @@ from pingpong.ai_error import get_details_from_api_error
 from pingpong.schemas import (
     CodeInterpreterMessage,
     DownloadExport,
-    ImageFile as SchemaImageFile,
-    MessageContentCodeOutputImageFile,
 )
 from pingpong.config import config
 from typing import Any, Dict, Literal, Union, overload
@@ -508,7 +506,13 @@ async def validate_api_key(
 
 
 async def get_ci_messages_from_step(
-    cli: openai.AsyncClient, thread_id: str, run_id: str, step_id: str
+    cli: openai.AsyncClient,
+    thread_id: str,
+    run_id: str,
+    step_id: str,
+    *,
+    show_code_interpreter_code: bool = True,
+    show_code_interpreter_output: bool = True,
 ) -> list[CodeInterpreterMessage]:
     """
     Get code interpreter messages from a thread run step.
@@ -527,17 +531,43 @@ async def get_ci_messages_from_step(
     messages: list[CodeInterpreterMessage] = []
     for tool_call in run_step.step_details.tool_calls:
         if tool_call.type == "code_interpreter":
+            content: list[dict[str, Any]] = []
+            if tool_call.code_interpreter.input:
+                content.append(
+                    {
+                        "code": tool_call.code_interpreter.input
+                        if show_code_interpreter_code
+                        else "",
+                        "type": "code",
+                    }
+                )
+            for output in tool_call.code_interpreter.outputs:
+                if output.type == "image":
+                    content.append(
+                        {
+                            "image_file": {
+                                "file_id": output.image.file_id
+                                if show_code_interpreter_output
+                                else ""
+                            },
+                            "type": "code_output_image_file",
+                        }
+                    )
+                elif output.type == "logs":
+                    content.append(
+                        {
+                            "logs": output.logs if show_code_interpreter_output else "",
+                            "type": "code_output_logs",
+                        }
+                    )
+            if not content:
+                content.append({"code": "", "type": "code"})
             new_message = CodeInterpreterMessage.model_validate(
                 {
                     "id": tool_call.id,
                     "assistant_id": run_step.assistant_id,
                     "created_at": run_step.created_at,
-                    "content": [
-                        {
-                            "code": tool_call.code_interpreter.input,
-                            "type": "code",
-                        }
-                    ],
+                    "content": content,
                     "file_search_file_ids": [],
                     "code_interpreter": [],
                     "metadata": {},
@@ -547,14 +577,6 @@ async def get_ci_messages_from_step(
                     "thread_id": run_step.thread_id,
                 }
             )
-            for output in tool_call.code_interpreter.outputs:
-                if output.type == "image":
-                    new_message.content.append(
-                        MessageContentCodeOutputImageFile(
-                            image_file=SchemaImageFile(file_id=output.image.file_id),
-                            type="code_output_image_file",
-                        )
-                    )
             messages.append(new_message)
     return messages
 
@@ -568,6 +590,8 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
         file_names: dict[str, str],
         user_auth: str | None = None,
         anonymous_user_auth: str | None = None,
+        show_code_interpreter_code: bool = True,
+        show_code_interpreter_output: bool = True,
         *args,
         **kwargs,
     ):
@@ -578,6 +602,8 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
         self.local_thread_id = local_thread_id
         self.file_names = file_names
         self.viewer_auth = anonymous_user_auth or user_auth
+        self.show_code_interpreter_code = show_code_interpreter_code
+        self.show_code_interpreter_output = show_code_interpreter_output
 
     def enqueue(self, data: Dict) -> None:
         self.__buffer.write(orjson.dumps(data))
@@ -595,6 +621,19 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
             data["run_id"] = run_step.run_id
             data["step_id"] = run_step.id
         return data
+
+    def _redacted_code_interpreter_output(
+        self, output: dict[str, Any]
+    ) -> dict[str, Any]:
+        match output.get("type"):
+            case "image":
+                return {**output, "image": {"file_id": ""}}
+            case "code_output_image_url":
+                return {**output, "url": ""}
+            case "code_output_logs" | "logs":
+                return {**output, "logs": ""}
+            case _:
+                return output
 
     async def on_image_file_done(self, image_file: ImageFile) -> None:
         self.enqueue(
@@ -640,18 +679,42 @@ class BufferedStreamHandler(openai.AsyncAssistantEventHandler):
         )
 
     async def on_tool_call_created(self, tool_call) -> None:
+        tool_call_data = (
+            tool_call if isinstance(tool_call, Dict) else tool_call.model_dump()
+        )
+        if tool_call_data.get("type") == "code_interpreter":
+            tool_call_data = dict(tool_call_data)
+            code_interpreter = dict(tool_call_data.get("code_interpreter") or {})
+            if not self.show_code_interpreter_code:
+                code_interpreter["input"] = ""
+            tool_call_data["code_interpreter"] = code_interpreter
         self.enqueue(
             {
                 "type": "tool_call_created",
-                "tool_call": tool_call
-                if isinstance(tool_call, Dict)
-                else tool_call.model_dump(),
+                "tool_call": tool_call_data,
             }
         )
 
     async def on_tool_call_delta(self, delta, snapshot) -> None:
         delta_data = self._with_current_run_step(delta.model_dump())
 
+        if delta_data.get("type") == "code_interpreter":
+            delta_data = dict(delta_data)
+            code_interpreter = dict(delta_data.get("code_interpreter") or {})
+            if not self.show_code_interpreter_code:
+                code_interpreter["input"] = None
+            if not self.show_code_interpreter_output and code_interpreter.get(
+                "outputs"
+            ):
+                code_interpreter["outputs"] = [
+                    self._redacted_code_interpreter_output(output)
+                    for output in code_interpreter["outputs"]
+                ]
+            delta_data["code_interpreter"] = code_interpreter
+            if not code_interpreter.get("input") and not code_interpreter.get(
+                "outputs"
+            ):
+                return
         self.enqueue(
             {
                 "type": "tool_call_delta",
@@ -1242,6 +1305,8 @@ class BufferedResponseStreamHandler:
         show_web_search_sources: bool | None = None,
         show_web_search_actions: bool | None = None,
         show_reasoning_summaries: bool | None = None,
+        show_code_interpreter_code: bool | None = None,
+        show_code_interpreter_output: bool | None = None,
         show_mcp_server_call_details: bool | None = None,
         *args,
         lecture_video_dual_text_mode: bool = False,
@@ -1305,6 +1370,16 @@ class BufferedResponseStreamHandler:
         )
         self.show_web_search_actions = (
             show_web_search_actions if show_web_search_actions is not None else True
+        )
+        self.show_code_interpreter_code = (
+            show_code_interpreter_code
+            if show_code_interpreter_code is not None
+            else True
+        )
+        self.show_code_interpreter_output = (
+            show_code_interpreter_output
+            if show_code_interpreter_output is not None
+            else True
         )
         self.show_mcp_server_call_details = (
             show_mcp_server_call_details
@@ -1989,7 +2064,12 @@ class BufferedResponseStreamHandler:
                     "index": tool_call_cache.output_index,
                     "output_index": tool_call_cache.output_index,
                     "type": "code_interpreter",
-                    "code_interpreter": {"input": data.code or "", "outputs": None},
+                    "code_interpreter": {
+                        "input": (data.code or "")
+                        if self.show_code_interpreter_code
+                        else "",
+                        "outputs": None,
+                    },
                     "status": data.status,
                     "run_id": str(self.run_id),
                 },
@@ -2042,17 +2122,18 @@ class BufferedResponseStreamHandler:
 
         await add_cached_tool_call_on_code_interpreter_tool_call_in_progress()
 
-        self.enqueue(
-            {
-                "type": "tool_call_delta",
-                "delta": {
-                    "index": data.output_index,
-                    "type": "code_interpreter",
-                    "id": data.item_id,
-                    "code_interpreter": {"input": data.delta, "outputs": None},
-                },
-            }
-        )
+        if self.show_code_interpreter_code:
+            self.enqueue(
+                {
+                    "type": "tool_call_delta",
+                    "delta": {
+                        "index": data.output_index,
+                        "type": "code_interpreter",
+                        "id": data.item_id,
+                        "code_interpreter": {"input": data.delta, "outputs": None},
+                    },
+                }
+            )
 
     async def on_code_interpreter_tool_call_interpreting(
         self, data: ResponseCodeInterpreterCallInterpretingEvent
@@ -2153,7 +2234,9 @@ class BufferedResponseStreamHandler:
                                         "outputs": [
                                             {
                                                 "type": "code_output_image_url",
-                                                "url": output.url,
+                                                "url": output.url
+                                                if self.show_code_interpreter_output
+                                                else "",
                                             }
                                         ],
                                     },
@@ -2181,7 +2264,9 @@ class BufferedResponseStreamHandler:
                                         "outputs": [
                                             {
                                                 "type": "code_output_logs",
-                                                "logs": output.logs,
+                                                "logs": output.logs
+                                                if self.show_code_interpreter_output
+                                                else "",
                                             }
                                         ],
                                     },
@@ -3733,6 +3818,8 @@ async def run_response(
     show_web_search_sources: bool | None = None,
     show_web_search_actions: bool | None = None,
     show_reasoning_summaries: bool | None = None,
+    show_code_interpreter_code: bool | None = None,
+    show_code_interpreter_output: bool | None = None,
     show_mcp_server_call_details: bool | None = None,
     user_auth: str | None = None,
     anonymous_link_auth: str | None = None,
@@ -4063,6 +4150,8 @@ async def run_response(
                     show_web_search_sources=show_web_search_sources,
                     show_web_search_actions=show_web_search_actions,
                     show_reasoning_summaries=show_reasoning_summaries,
+                    show_code_interpreter_code=show_code_interpreter_code,
+                    show_code_interpreter_output=show_code_interpreter_output,
                     show_mcp_server_call_details=show_mcp_server_call_details,
                     user_id=run.creator_id,
                     user_auth=user_auth,
@@ -4666,6 +4755,8 @@ async def run_thread(
     instructions: str | None = None,
     user_auth: str | None = None,
     anonymous_user_auth: str | None = None,
+    show_code_interpreter_code: bool = True,
+    show_code_interpreter_output: bool = True,
 ):
     try:
         if message:
@@ -4713,6 +4804,8 @@ async def run_thread(
             file_names=file_names,
             user_auth=user_auth,
             anonymous_user_auth=anonymous_user_auth,
+            show_code_interpreter_code=show_code_interpreter_code,
+            show_code_interpreter_output=show_code_interpreter_output,
         )
         async with cli.beta.threads.runs.stream(
             thread_id=thread_id,

--- a/pingpong/copy.py
+++ b/pingpong/copy.py
@@ -458,6 +458,8 @@ async def copy_assistant(
         hide_file_search_queries=assistant.hide_file_search_queries,
         hide_web_search_sources=assistant.hide_web_search_sources,
         hide_web_search_actions=assistant.hide_web_search_actions,
+        hide_code_interpreter_code=assistant.hide_code_interpreter_code,
+        hide_code_interpreter_output=assistant.hide_code_interpreter_output,
         hide_mcp_server_call_details=assistant.hide_mcp_server_call_details,
     )
 

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -5145,6 +5145,8 @@ class Assistant(Base):
     hide_file_search_queries = Column(Boolean, server_default="true")
     hide_web_search_sources = Column(Boolean, server_default="false")
     hide_web_search_actions = Column(Boolean, server_default="false")
+    hide_code_interpreter_code = Column(Boolean, server_default="false")
+    hide_code_interpreter_output = Column(Boolean, server_default="false")
     hide_mcp_server_call_details = Column(Boolean, server_default="true")
     mcp_server_tools = relationship(
         "MCPServerTool", secondary=mcp_server_tool_assistant_association

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1444,6 +1444,8 @@ class Assistant(BaseModel):
     hide_file_search_queries: bool | None = None
     hide_web_search_sources: bool | None = None
     hide_web_search_actions: bool | None = None
+    hide_code_interpreter_code: bool | None = None
+    hide_code_interpreter_output: bool | None = None
     hide_mcp_server_call_details: bool | None = None
     use_latex: bool | None
     use_image_descriptions: bool | None
@@ -1800,6 +1802,8 @@ class CreateAssistant(BaseModel):
     hide_file_search_queries: bool = True
     hide_web_search_sources: bool = False
     hide_web_search_actions: bool = False
+    hide_code_interpreter_code: bool = False
+    hide_code_interpreter_output: bool = False
     hide_mcp_server_call_details: bool = True
     deleted_private_files: list[int] = []
     create_classic_assistant: bool = False
@@ -1910,6 +1914,8 @@ class UpdateAssistant(BaseModel):
     hide_file_search_queries: bool | None = None
     hide_web_search_sources: bool | None = None
     hide_web_search_actions: bool | None = None
+    hide_code_interpreter_code: bool | None = None
+    hide_code_interpreter_output: bool | None = None
     hide_mcp_server_call_details: bool | None = None
     use_image_descriptions: bool | None = None
     convert_to_next_gen: bool | None = None

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -3999,6 +3999,44 @@ async def audio_stream(
     await browser_realtime_websocket(websocket, class_id, thread_id)
 
 
+def _code_interpreter_content_from_tool_call(
+    tool_call: models.ToolCall,
+    *,
+    show_code: bool,
+    show_output: bool,
+) -> list[schemas.CodeInterpreterMessageContent]:
+    tool_content: list[schemas.CodeInterpreterMessageContent] = []
+
+    if tool_call.code:
+        tool_content.append(
+            schemas.MessageContentCode(
+                code=tool_call.code if show_code else "",
+                type="code",
+            )
+        )
+
+    for output in tool_call.outputs:
+        if output.output_type == schemas.CodeInterpreterOutputType.IMAGE:
+            tool_content.append(
+                schemas.MessageContentCodeOutputImageURL(
+                    url=output.url if show_output else "",
+                    type="code_output_image_url",
+                )
+            )
+        elif output.output_type == schemas.CodeInterpreterOutputType.LOGS:
+            tool_content.append(
+                schemas.MessageContentCodeOutputLogs(
+                    logs=output.logs if show_output else "",
+                    type="code_output_logs",
+                )
+            )
+
+    if not tool_content:
+        tool_content.append(schemas.MessageContentCode(code="", type="code"))
+
+    return tool_content
+
+
 @v1.get(
     "/class/{class_id}/thread/{thread_id}",
     dependencies=[
@@ -4275,7 +4313,12 @@ async def get_thread(
         show_mcp_server_call_details = is_supervisor or (
             assistant and not assistant.hide_mcp_server_call_details
         )
-
+        show_code_interpreter_code = is_supervisor or (
+            assistant is not None and not assistant.hide_code_interpreter_code
+        )
+        show_code_interpreter_output = is_supervisor or (
+            assistant is not None and not assistant.hide_code_interpreter_output
+        )
         thread_messages: list[schemas.ThreadMessage] = []
         placeholder_ci_calls = []
         file_search_calls: list[schemas.FileSearchMessage] = []
@@ -4285,26 +4328,11 @@ async def get_thread(
         reasoning_messages: list[schemas.ReasoningMessage] = []
         for tool_call in tool_calls_v3:
             if tool_call.type == schemas.ToolCallType.CODE_INTERPRETER:
-                tool_content: list[schemas.CodeInterpreterMessageContent] = []
-
-                if tool_call.code:
-                    tool_content.append(
-                        schemas.MessageContentCode(code=tool_call.code, type="code")
-                    )
-
-                for output in tool_call.outputs:
-                    if output.output_type == schemas.CodeInterpreterOutputType.IMAGE:
-                        tool_content.append(
-                            schemas.MessageContentCodeOutputImageURL(
-                                url=output.url, type="code_output_image_url"
-                            )
-                        )
-                    elif output.output_type == schemas.CodeInterpreterOutputType.LOGS:
-                        tool_content.append(
-                            schemas.MessageContentCodeOutputLogs(
-                                logs=output.logs, type="code_output_logs"
-                            )
-                        )
+                tool_content = _code_interpreter_content_from_tool_call(
+                    tool_call,
+                    show_code=show_code_interpreter_code,
+                    show_output=show_code_interpreter_output,
+                )
 
                 placeholder_ci_calls.append(
                     schemas.CodeInterpreterMessage(
@@ -6133,9 +6161,33 @@ async def get_ci_messages(
     thread = await models.Thread.get_by_id(request.state["db"], int(thread_id))
     if not thread or thread.class_id != int(class_id):
         raise HTTPException(status_code=404, detail="Thread not found")
+    assistant, is_supervisor_check = await asyncio.gather(
+        models.Assistant.get_by_id(request.state["db"], thread.assistant_id),
+        request.state["authz"].check(
+            [
+                (
+                    f"user:{request.state['session'].user.id}",
+                    "supervisor",
+                    f"class:{class_id}",
+                ),
+            ]
+        ),
+    )
+    is_supervisor = is_supervisor_check[0]
+    show_code_interpreter_code = is_supervisor or (
+        assistant is not None and not assistant.hide_code_interpreter_code
+    )
+    show_code_interpreter_output = is_supervisor or (
+        assistant is not None and not assistant.hide_code_interpreter_output
+    )
     if thread.version <= 2:
         messages = await get_ci_messages_from_step(
-            openai_client, thread.thread_id, run_id, step_id
+            openai_client,
+            thread.thread_id,
+            run_id,
+            step_id,
+            show_code_interpreter_code=show_code_interpreter_code,
+            show_code_interpreter_output=show_code_interpreter_output,
         )
         ci_call = await models.CodeInterpreterCall.get_by_step_id(
             request.state["db"], thread.id, step_id
@@ -6588,6 +6640,12 @@ async def list_thread_messages(
         show_mcp_server_call_details = is_supervisor or (
             assistant and not assistant.hide_mcp_server_call_details
         )
+        show_code_interpreter_code = is_supervisor or (
+            assistant is not None and not assistant.hide_code_interpreter_code
+        )
+        show_code_interpreter_output = is_supervisor or (
+            assistant is not None and not assistant.hide_code_interpreter_output
+        )
 
         thread_messages: list[schemas.ThreadMessage] = []
         placeholder_ci_calls = []
@@ -6598,26 +6656,11 @@ async def list_thread_messages(
         mcp_messages: list[schemas.MCPMessage] = []
         for tool_call in tool_calls_v3:
             if tool_call.type == schemas.ToolCallType.CODE_INTERPRETER:
-                tool_content: list[schemas.CodeInterpreterMessageContent] = []
-
-                if tool_call.code:
-                    tool_content.append(
-                        schemas.MessageContentCode(code=tool_call.code, type="code")
-                    )
-
-                for output in tool_call.outputs:
-                    if output.output_type == schemas.CodeInterpreterOutputType.IMAGE:
-                        tool_content.append(
-                            schemas.MessageContentCodeOutputImageURL(
-                                url=output.url, type="code_output_image_url"
-                            )
-                        )
-                    elif output.output_type == schemas.CodeInterpreterOutputType.LOGS:
-                        tool_content.append(
-                            schemas.MessageContentCodeOutputLogs(
-                                logs=output.logs, type="code_output_logs"
-                            )
-                        )
+                tool_content = _code_interpreter_content_from_tool_call(
+                    tool_call,
+                    show_code=show_code_interpreter_code,
+                    show_output=show_code_interpreter_output,
+                )
 
                 placeholder_ci_calls.append(
                     schemas.CodeInterpreterMessage(
@@ -8530,6 +8573,10 @@ async def create_run(
                 or not asst.hide_web_search_sources,
                 show_web_search_actions=is_supervisor
                 or not asst.hide_web_search_actions,
+                show_code_interpreter_code=is_supervisor
+                or not asst.hide_code_interpreter_code,
+                show_code_interpreter_output=is_supervisor
+                or not asst.hide_code_interpreter_output,
                 show_mcp_server_call_details=is_supervisor
                 or not asst.hide_mcp_server_call_details,
                 lecture_video_dual_text_mode=_lecture_lesson_dual_text_enabled(thread),
@@ -8553,6 +8600,16 @@ async def create_run(
                 if thread.vector_store_id
                 else None
             )
+            is_supervisor_check = await request.state["authz"].check(
+                [
+                    (
+                        f"user:{request.state['session'].user.id}",
+                        "supervisor",
+                        f"class:{class_id}",
+                    )
+                ]
+            )
+            is_supervisor = is_supervisor_check[0]
 
             # One-time migration for threads that don't have instructions set
             if not thread.instructions:
@@ -8586,6 +8643,10 @@ async def create_run(
                 ),
                 user_auth=request.state["auth_user"],
                 anonymous_user_auth=request.state["anonymous_session_token_auth"],
+                show_code_interpreter_code=is_supervisor
+                or not asst.hide_code_interpreter_code,
+                show_code_interpreter_output=is_supervisor
+                or not asst.hide_code_interpreter_output,
             )
         except Exception as e:
             logger.exception("Error running thread")
@@ -8871,6 +8932,16 @@ async def send_message(
         )
 
         if thread.version <= 2:
+            is_supervisor_check = await request.state["authz"].check(
+                [
+                    (
+                        f"user:{request.state['session'].user.id}",
+                        "supervisor",
+                        f"class:{class_id}",
+                    )
+                ]
+            )
+            is_supervisor = is_supervisor_check[0]
             metadata: dict[str, str | int] = {
                 "user_id": str(request.state["session"].user.id),
             }
@@ -8897,6 +8968,12 @@ async def send_message(
                     thread.instructions,
                     data.timezone if data.timezone else thread.timezone,
                 ),
+                user_auth=request.state["auth_user"],
+                anonymous_user_auth=request.state["anonymous_session_token_auth"],
+                show_code_interpreter_code=is_supervisor
+                or not asst.hide_code_interpreter_code,
+                show_code_interpreter_output=is_supervisor
+                or not asst.hide_code_interpreter_output,
             )
         elif thread.version == 3:
             tasks_to_run = []
@@ -9142,6 +9219,10 @@ async def send_message(
                 show_file_search_document_names=show_file_search_document_names,
                 show_web_search_sources=show_web_search_sources,
                 show_web_search_actions=show_web_search_actions,
+                show_code_interpreter_code=is_supervisor
+                or not asst.hide_code_interpreter_code,
+                show_code_interpreter_output=is_supervisor
+                or not asst.hide_code_interpreter_output,
                 show_mcp_server_call_details=show_mcp_server_call_details,
                 user_auth=request.state["auth_user"],
                 anonymous_user_auth=request.state["anonymous_session_token_auth"],
@@ -12894,6 +12975,18 @@ async def update_assistant(
         and req.hide_mcp_server_call_details is not None
     ):
         asst.hide_mcp_server_call_details = req.hide_mcp_server_call_details
+
+    if (
+        "hide_code_interpreter_code" in req.model_fields_set
+        and req.hide_code_interpreter_code is not None
+    ):
+        asst.hide_code_interpreter_code = req.hide_code_interpreter_code
+
+    if (
+        "hide_code_interpreter_output" in req.model_fields_set
+        and req.hide_code_interpreter_output is not None
+    ):
+        asst.hide_code_interpreter_output = req.hide_code_interpreter_output
 
     if (
         "hide_web_search_sources" in req.model_fields_set

--- a/pingpong/test_thread_image_download.py
+++ b/pingpong/test_thread_image_download.py
@@ -376,7 +376,13 @@ async def test_get_ci_messages_v2_includes_ci_call_id_metadata(
         return openai_client
 
     async def fake_get_ci_messages_from_step(
-        _cli, _thread_id: str, _run_id: str, _step_id: str
+        _cli,
+        _thread_id: str,
+        _run_id: str,
+        _step_id: str,
+        *,
+        show_code_interpreter_code: bool = True,
+        show_code_interpreter_output: bool = True,
     ):
         return [
             schemas.CodeInterpreterMessage.model_validate(

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -2834,6 +2834,8 @@ export type Assistant = {
 	hide_file_search_queries: boolean | null;
 	hide_web_search_sources: boolean | null;
 	hide_web_search_actions: boolean | null;
+	hide_code_interpreter_code: boolean | null;
+	hide_code_interpreter_output: boolean | null;
 	hide_mcp_server_call_details: boolean | null;
 	endorsed: boolean | null;
 	lecture_video?: LectureVideoSummary | null;
@@ -3001,6 +3003,8 @@ export type CreateAssistantRequest = {
 	hide_file_search_queries?: boolean;
 	hide_web_search_sources?: boolean;
 	hide_web_search_actions?: boolean;
+	hide_code_interpreter_code?: boolean;
+	hide_code_interpreter_output?: boolean;
 	hide_mcp_server_call_details?: boolean;
 	mcp_servers?: MCPServerToolInput[];
 };
@@ -3072,6 +3076,8 @@ export type UpdateAssistantRequest = {
 	hide_file_search_queries?: boolean;
 	hide_web_search_sources?: boolean;
 	hide_web_search_actions?: boolean;
+	hide_code_interpreter_code?: boolean;
+	hide_code_interpreter_output?: boolean;
 	hide_mcp_server_call_details?: boolean;
 	mcp_servers?: MCPServerToolInput[];
 	convert_to_next_gen?: boolean;

--- a/web/pingpong/src/lib/components/CodeInterpreterCallItem.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterCallItem.svelte
@@ -10,6 +10,7 @@
 	export let label: string;
 	export let icon: 'code' | 'image' | 'logs' = 'code';
 	export let forceOpen = false;
+	export let hasContent = true;
 
 	let open = false;
 	let previousOpen: boolean | null = null;
@@ -25,29 +26,49 @@
 		}
 	}
 
-	const toggle = () => (open = !open);
+	const toggle = () => {
+		if (!hasContent) {
+			return;
+		}
+		open = !open;
+	};
 </script>
 
 <div class="my-2">
-	<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
-		<span class="inline-flex text-gray-600">
-			{#if icon === 'logs'}
-				<TerminalOutline class="h-4 w-4" />
-			{:else if icon === 'image'}
-				<ImageSolid class="h-4 w-4" />
+	{#if hasContent}
+		<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
+			<span class="inline-flex text-gray-600">
+				{#if icon === 'logs'}
+					<TerminalOutline class="h-4 w-4" />
+				{:else if icon === 'image'}
+					<ImageSolid class="h-4 w-4" />
+				{:else}
+					<CodeOutline class="h-4 w-4" />
+				{/if}
+			</span>
+			<span class="text-sm font-medium text-gray-600">{label}{open ? '...' : ''}</span>
+			{#if open}
+				<ChevronDownOutline class="rotate-180 transform text-gray-600" />
 			{:else}
-				<CodeOutline class="h-4 w-4" />
+				<ChevronDownOutline class="text-gray-600" />
 			{/if}
-		</span>
-		<span class="text-sm font-medium text-gray-600">{label}{open ? '...' : ''}</span>
-		{#if open}
-			<ChevronDownOutline class="rotate-180 transform text-gray-600" />
-		{:else}
-			<ChevronDownOutline class="text-gray-600" />
-		{/if}
-	</button>
+		</button>
+	{:else}
+		<div class="flex flex-row items-center gap-1">
+			<span class="inline-flex text-gray-600">
+				{#if icon === 'logs'}
+					<TerminalOutline class="h-4 w-4" />
+				{:else if icon === 'image'}
+					<ImageSolid class="h-4 w-4" />
+				{:else}
+					<CodeOutline class="h-4 w-4" />
+				{/if}
+			</span>
+			<span class="text-sm font-medium text-gray-600">{label}</span>
+		</div>
+	{/if}
 
-	{#if open}
+	{#if open && hasContent}
 		<div
 			class="mt-2 ml-2 border-l border-gray-200 pl-4 text-sm font-light text-gray-600"
 			transition:slide={{ duration: 250 }}

--- a/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
+++ b/web/pingpong/src/lib/components/CodeInterpreterGroup.svelte
@@ -81,6 +81,10 @@
 			item.type === 'code_interpreter_call_placeholder'
 	);
 	$: hasPlaceholders = placeholders.length > 0;
+	$: stepItems = items.filter((item) => item.type !== 'code_interpreter_call_placeholder');
+	$: hasSteps = stepItems.length > 0;
+	$: hasDropdown = hasPlaceholders || hasSteps;
+	$: title = streaming ? 'Analyzing...' : 'Ran analysis';
 
 	// Delay the spinner for quick cached responses; once visible, keep it long enough to read.
 	const LOADING_INDICATOR_DELAY_MS = 150;
@@ -104,6 +108,35 @@
 			return `${item.type}:${item.source_message_id ?? ''}:${item.logs}`;
 		}
 		return `${item.type}:${item.source_message_id ?? i}`;
+	};
+
+	const getItemLabel = (item: api.Content) => {
+		switch (item.type) {
+			case 'code':
+				return 'Ran Code Interpreter code';
+			case 'code_output_logs':
+				return 'Returned Code Interpreter logs';
+			case 'code_output_image_file':
+			case 'code_output_image_url':
+				return 'Generated image';
+			default:
+				return 'Ran analysis';
+		}
+	};
+
+	const hasVisibleContent = (item: api.Content) => {
+		switch (item.type) {
+			case 'code':
+				return item.code.trim().length > 0;
+			case 'code_output_logs':
+				return item.logs.trim().length > 0;
+			case 'code_output_image_file':
+				return item.image_file.file_id.trim().length > 0 && imageUrl(item) !== null;
+			case 'code_output_image_url':
+				return item.url.trim().length > 0;
+			default:
+				return false;
+		}
 	};
 
 	const requestResults = async () => {
@@ -168,6 +201,9 @@
 			requestResults();
 			return;
 		}
+		if (!hasSteps) {
+			return;
+		}
 		groupState.update((state) => ({ ...state, open: !state.open }));
 	};
 
@@ -193,63 +229,98 @@
 </script>
 
 <div class="my-2">
-	<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
-		<span class="inline-flex text-gray-600">
-			<CodeOutline class="h-4 w-4" />
-		</span>
-		{#if streaming}
-			<span class="shimmer text-sm font-medium">Analyzing...</span>
-		{:else}
-			<span class="text-sm font-medium text-gray-600">Ran analysis</span>
-		{/if}
-		{#if $groupState.loading}
-			<Spinner color="gray" size="4" />
-		{/if}
-		<ChevronDownOutline class="text-gray-600 {open ? 'rotate-180 transform' : ''}" />
-	</button>
+	{#if hasDropdown}
+		<button type="button" class="flex flex-row items-center gap-1" onclick={toggle}>
+			<span class="inline-flex text-gray-600">
+				<CodeOutline class="h-4 w-4" />
+			</span>
+			{#if streaming}
+				<span class="shimmer text-sm font-medium">{title}</span>
+			{:else}
+				<span class="text-sm font-medium text-gray-600">{title}</span>
+			{/if}
+			{#if $groupState.loading}
+				<Spinner color="gray" size="4" />
+			{/if}
+			<ChevronDownOutline class="text-gray-600 {open ? 'rotate-180 transform' : ''}" />
+		</button>
+	{:else}
+		<div class="flex flex-row items-center gap-1">
+			<span class="inline-flex text-gray-600">
+				<CodeOutline class="h-4 w-4" />
+			</span>
+			<span class="text-sm font-medium text-gray-600">{title}</span>
+		</div>
+	{/if}
 
-	{#if open}
+	{#if open && hasSteps}
 		<div class="mt-2 ml-2 border-l border-gray-200 pl-4" transition:slide={{ duration: 250 }}>
-			{#each items as item, i (contentKey(item, i))}
+			{#each stepItems as item, i (contentKey(item, i))}
 				{#if item.type === 'code'}
-					<CodeInterpreterCallItem label="Ran Code Interpreter code" icon="code" {forceOpen}>
-						<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.code}</pre>
-					</CodeInterpreterCallItem>
+					{#if hasVisibleContent(item)}
+						<CodeInterpreterCallItem label={getItemLabel(item)} icon="code" {forceOpen}>
+							<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.code}</pre>
+						</CodeInterpreterCallItem>
+					{:else}
+						<CodeInterpreterCallItem
+							label={getItemLabel(item)}
+							icon="code"
+							forceOpen={false}
+							hasContent={false}
+						/>
+					{/if}
 				{:else if item.type === 'code_output_logs'}
-					<CodeInterpreterCallItem label="Returned Code Interpreter logs" icon="logs" {forceOpen}>
-						<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.logs}</pre>
-					</CodeInterpreterCallItem>
+					{#if hasVisibleContent(item)}
+						<CodeInterpreterCallItem label={getItemLabel(item)} icon="logs" {forceOpen}>
+							<pre class="font-mono text-xs whitespace-pre-wrap text-gray-700">{item.logs}</pre>
+						</CodeInterpreterCallItem>
+					{:else}
+						<CodeInterpreterCallItem
+							label={getItemLabel(item)}
+							icon="logs"
+							forceOpen={false}
+							hasContent={false}
+						/>
+					{/if}
 				{:else if item.type === 'code_output_image_file'}
-					<CodeInterpreterCallItem label="Generated output image" icon="image" {forceOpen}>
-						{@const url = imageUrl(item)}
-						{#if url}
+					{#if hasVisibleContent(item)}
+						<CodeInterpreterCallItem label={getItemLabel(item)} icon="image" {forceOpen}>
+							{@const url = imageUrl(item)}
+							{#if url}
+								<img
+									class="img-attachment m-auto"
+									src={url}
+									alt="Attachment generated by the assistant"
+								/>
+							{/if}
+						</CodeInterpreterCallItem>
+					{:else}
+						<CodeInterpreterCallItem
+							label={getItemLabel(item)}
+							icon="image"
+							forceOpen={false}
+							hasContent={false}
+						/>
+					{/if}
+				{:else if item.type === 'code_output_image_url'}
+					{#if hasVisibleContent(item)}
+						<CodeInterpreterCallItem label={getItemLabel(item)} icon="image" {forceOpen}>
 							<img
 								class="img-attachment m-auto"
-								src={url}
+								src={item.url}
 								alt="Attachment generated by the assistant"
 							/>
-						{/if}
-					</CodeInterpreterCallItem>
-				{:else if item.type === 'code_output_image_url'}
-					<CodeInterpreterCallItem label="Generated output image" icon="image" {forceOpen}>
-						<img
-							class="img-attachment m-auto"
-							src={item.url}
-							alt="Attachment generated by the assistant"
+						</CodeInterpreterCallItem>
+					{:else}
+						<CodeInterpreterCallItem
+							label={getItemLabel(item)}
+							icon="image"
+							forceOpen={false}
+							hasContent={false}
 						/>
-					</CodeInterpreterCallItem>
+					{/if}
 				{/if}
 			{/each}
-
-			{#if hasPlaceholders && !$groupState.loading}
-				<button
-					type="button"
-					class="my-2 text-sm font-medium text-gray-500 underline hover:text-gray-700"
-					onclick={requestResults}
-				>
-					Load results
-				</button>
-			{/if}
 		</div>
 	{/if}
 </div>

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -432,6 +432,8 @@
 			const hideWebSearchSources = assistant.hide_web_search_sources === true;
 			const hideWebSearchActions = assistant.hide_web_search_actions === true;
 			const hideReasoningSummaries = assistant.hide_reasoning_summaries === true;
+			const hideCodeInterpreterCode = assistant.hide_code_interpreter_code === true;
+			const hideCodeInterpreterOutput = assistant.hide_code_interpreter_output === true;
 			const hideMCPServerCallDetails = assistant.hide_mcp_server_call_details === true;
 
 			if (supportsFileSearch) {
@@ -481,6 +483,28 @@
 							description: hideWebSearchActions
 								? 'Members can see that the assistant is searching the web without revealing specific details.'
 								: 'Members can see the specific web search actions such as queries, clicks, and extraction.'
+						}
+					]
+				});
+			}
+			if (supportsCodeInterpreter) {
+				nextBypassedSettingsSections.push({
+					id: 'code-interpreter',
+					title: 'Code Interpreter',
+					items: [
+						{
+							label: 'Code',
+							hidden: hideCodeInterpreterCode,
+							description: hideCodeInterpreterCode
+								? 'Members cannot see the code the assistant runs in Code Interpreter.'
+								: 'Members can see the code the assistant runs in Code Interpreter.'
+						},
+						{
+							label: 'Output',
+							hidden: hideCodeInterpreterOutput,
+							description: hideCodeInterpreterOutput
+								? 'Members cannot see logs or generated images returned by Code Interpreter.'
+								: 'Members can see logs and generated images returned by Code Interpreter.'
 						}
 					]
 				});

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -1483,6 +1483,8 @@ export class ThreadManager {
 						// Merge code into existing chunk
 						lastChunk.code += chunk.code_interpreter.input;
 					}
+				} else if (!chunk.code_interpreter.outputs && !lastChunk) {
+					lastMessage.content.push({ type: 'code', code: '' });
 				}
 
 				// Add outputs to the last message

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -2147,6 +2147,28 @@
 		hideFileSearchResultQuotes = true;
 	}
 
+	let hideCodeInterpreterCode = false;
+	let hasSetHideCodeInterpreterCode = false;
+	$: if (
+		assistant?.hide_code_interpreter_code !== undefined &&
+		assistant?.hide_code_interpreter_code !== null &&
+		!hasSetHideCodeInterpreterCode
+	) {
+		hideCodeInterpreterCode = assistant?.hide_code_interpreter_code;
+		hasSetHideCodeInterpreterCode = true;
+	}
+
+	let hideCodeInterpreterOutput = false;
+	let hasSetHideCodeInterpreterOutput = false;
+	$: if (
+		assistant?.hide_code_interpreter_output !== undefined &&
+		assistant?.hide_code_interpreter_output !== null &&
+		!hasSetHideCodeInterpreterOutput
+	) {
+		hideCodeInterpreterOutput = assistant?.hide_code_interpreter_output;
+		hasSetHideCodeInterpreterOutput = true;
+	}
+
 	let hasSetHideMCPServerCallDetails = false;
 	let hideMCPServerCallDetails = true;
 	$: if (
@@ -2893,6 +2915,8 @@
 			hide_file_search_queries: hideFileSearchQueries,
 			hide_web_search_sources: hideWebSearchActions ? true : hideWebSearchSources,
 			hide_web_search_actions: hideWebSearchActions,
+			hide_code_interpreter_code: hideCodeInterpreterCode,
+			hide_code_interpreter_output: hideCodeInterpreterOutput,
 			mcp_servers: mcpServersForRequest,
 			hide_mcp_server_call_details: hideMCPServerCallDetails,
 			convert_to_next_gen:
@@ -6526,6 +6550,70 @@
 										>This setting will only apply to Chat Mode models with File Search enabled.</b
 									></Helper
 								>
+							</div>
+
+							<hr />
+							<div class="col-span-2 mb-1">
+								<Checkbox
+									id="hide_code_interpreter_code"
+									name="hide_code_interpreter_code"
+									disabled={preventEdits}
+									bind:checked={hideCodeInterpreterCode}
+									><div class="flex flex-row gap-1">
+										<div>Hide Code Interpreter Code from Members</div>
+									</div></Checkbox
+								>
+								<Helper
+									>Control whether members can see the code the assistant runs in Code Interpreter.
+									Depending on your prompt, this code may reveal answers, solution logic, or
+									assessment details. When checked, members will not see Code Interpreter code.
+									Moderators can always review Code Interpreter code. <b
+										>This setting will only apply to Chat Mode models with Code Interpreter enabled.</b
+									></Helper
+								>
+							</div>
+
+							<div class="col-span-2 mb-1">
+								<Checkbox
+									id="hide_code_interpreter_output"
+									name="hide_code_interpreter_output"
+									disabled={preventEdits}
+									bind:checked={hideCodeInterpreterOutput}
+									><div class="flex flex-row gap-1">
+										<div>Hide Code Interpreter Output from Members</div>
+									</div></Checkbox
+								>
+								<Helper
+									>Control whether members can see output logs and generated images returned by Code
+									Interpreter. In some cases, this output may contain answers or verification
+									details for practice and quiz problems. When checked, members will not see Code
+									Interpreter output. However, note that assistants may still refer to the output in
+									their responses. Moderators can always review Code Interpreter output. <b
+										>This setting will only apply to Chat Mode models with Code Interpreter enabled.</b
+									></Helper
+								>
+							</div>
+
+							<div class="col-span-2 mb-1">
+								<div
+									class="rounded-lg border border-blue-400 bg-gradient-to-b from-blue-50 to-blue-100 p-3 text-blue-800"
+								>
+									<div class="flex flex-row items-center gap-x-3">
+										<LightbulbSolid size="md" class="shrink-0" />
+										<div class="flex flex-col text-xs">
+											<span class="font-bold"
+												>Assistant responses may show and allow members to download files and images
+												generated with Code Interpreter</span
+											>
+											<span
+												>When Code Interpreter is enabled, the assistant may show and allow members
+												to download files and images generated with Code Interpreter. Images
+												generated with Code Interpreter may also appear in assistant messages. You
+												may be able to control this behavior in your assistant's instructions.</span
+											>
+										</div>
+									</div>
+								</div>
 							</div>
 
 							<hr />


### PR DESCRIPTION
## Assistants
### New Features
- Introducing two new data controls for Next-Gen and Classic assistants:
    - **Hide Code Interpreter Code from Members** _(disabled by default)_: Control whether members can see the code the assistant runs in Code Interpreter. Depending on your prompt, this code may reveal answers, solution logic, or assessment details. When checked, members will not see Code Interpreter code. Moderators can always review Code Interpreter code. **This setting will only apply to Chat Mode models with Code Interpreter enabled.**
    - **Hide Code Interpreter Output from Members** _(disabled by default)_: Control whether members can see output logs and generated images returned by Code Interpreter. In some cases, this output may contain answers or verification details for practice and quiz problems. When checked, members will not see Code Interpreter output. However, note that assistants may still refer to the output in their responses. Moderators can always review Code Interpreter output. **This setting will only apply to Chat Mode models with Code Interpreter enabled.**
* Code Interpreter visibility settings apply consistently across streaming responses, saved thread history, and lazy-loaded Code Interpreter results in Classic Assistants.
* Moderators will see a warning when their permissions are bypassing Code Interpreter content visibility settings set in Assistant Settings.

### Notes
* The Code Interpreter tool call item remains visible as `Ran analysis` even when code or output details are hidden.
* **Assistant responses may show and allow members to download files and images generated with Code Interpreter.** When Code Interpreter is enabled, the assistant may show and allow members to download files and images generated with Code Interpreter. Images generated with Code Interpreter may also appear in assistant messages. You may be able to control this behavior in your assistant's instructions.
