### PR TITLE
feat(slide): pre-process slides

### DIFF
--- a/pingpong/lecture_slide_chat.py
+++ b/pingpong/lecture_slide_chat.py
@@ -30,6 +30,7 @@ class LectureSlideChatTurnPreparation:
     user_output_index: int
     user_assistant_messages_only: bool = True
     include_developer_messages: bool = True
+    user_message_metadata: dict[str, Any] | None = None
 
 
 def _words_from_transcript_data(
@@ -327,7 +328,6 @@ async def _build_initial_lecture_file_message(
                 part_index=0,
                 type=schemas.MessagePartType.INPUT_FILE,
                 input_file_object_id=input_file.id,
-                input_file=input_file,
             ),
             models.MessagePart(
                 part_index=1,

--- a/pingpong/lecture_slide_chat.py
+++ b/pingpong/lecture_slide_chat.py
@@ -21,6 +21,7 @@ LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE = (
 )
 
 _V3_TRANSCRIPT_ADAPTER = TypeAdapter(list[schemas.LectureVideoManifestWordV3])
+_V5_CONTEXT_ADAPTER = TypeAdapter(schemas.LectureSlideContextV5)
 
 
 @dataclass
@@ -55,6 +56,14 @@ def lecture_slide_chat_context_from_model(
     return transcript or None
 
 
+def lecture_slide_context_v5_from_model(
+    deck: models.LectureSlideDeck,
+) -> schemas.LectureSlideContextV5 | None:
+    if deck.context_version != 5 or deck.context_data is None:
+        return None
+    return _V5_CONTEXT_ADAPTER.validate_python(deck.context_data)
+
+
 def transcript_from_model(
     deck: models.LectureSlideDeck,
 ) -> list[schemas.LectureVideoManifestWordV3] | None:
@@ -64,7 +73,7 @@ def transcript_from_model(
 def lecture_slide_chat_available(deck: models.LectureSlideDeck | None) -> bool:
     if deck is None:
         return False
-    return deck.context_version == 4 and deck.lecture_slide_chat_available
+    return deck.context_version in {4, 5} and deck.lecture_slide_chat_available
 
 
 def _get_current_question(
@@ -430,6 +439,210 @@ def _build_context_text(
     return "\n".join(lines)
 
 
+def _select_summary_checkpoint_v5(
+    checkpoints: list[schemas.LectureSlideContextSummaryCheckpointV5],
+    furthest_offset_ms: int,
+) -> schemas.LectureSlideContextSummaryCheckpointV5 | None:
+    selected = None
+    for checkpoint in checkpoints:
+        if checkpoint.end_offset_ms <= furthest_offset_ms:
+            selected = checkpoint
+        else:
+            break
+    return selected
+
+
+def _select_moment_context_v5(
+    moments: list[schemas.LectureSlideContextMomentV5],
+    playback_position_ms: int,
+) -> schemas.LectureSlideContextMomentV5 | None:
+    containing = [
+        moment
+        for moment in moments
+        if moment.start_offset_ms <= playback_position_ms <= moment.end_offset_ms
+    ]
+    if containing:
+        return min(
+            containing,
+            key=lambda moment: abs(moment.center_offset_ms - playback_position_ms),
+        )
+    if not moments:
+        return None
+    return min(
+        moments,
+        key=lambda moment: abs(moment.center_offset_ms - playback_position_ms),
+    )
+
+
+def _slide_at_offset(
+    deck: models.LectureSlideDeck,
+    offset_ms: int,
+) -> models.LectureSlidePage | None:
+    timed_pages = [
+        page
+        for page in sorted(deck.pages, key=lambda item: item.position)
+        if page.start_offset_ms is not None and page.end_offset_ms is not None
+    ]
+    for page in timed_pages:
+        if page.start_offset_ms <= offset_ms <= page.end_offset_ms:
+            return page
+    past_pages = [page for page in timed_pages if page.end_offset_ms <= offset_ms]
+    if past_pages:
+        return past_pages[-1]
+    return timed_pages[0] if timed_pages else None
+
+
+def _slide_context_by_position(
+    context: schemas.LectureSlideContextV5,
+) -> dict[int, schemas.LectureSlideContextSlideV5]:
+    return {slide.slide_position: slide for slide in context.slides}
+
+
+def _format_slide_number(slide_position: int | None) -> str:
+    if slide_position is None:
+        return "Unknown"
+    return f"Slide {slide_position + 1}"
+
+
+def _format_moment_context_v5(
+    moment: schemas.LectureSlideContextMomentV5,
+) -> str:
+    return (
+        f"Before this moment:\n{moment.before}\n\n"
+        f"At this moment:\n{moment.at}\n\n"
+        f"After this moment:\n{moment.after}"
+    )
+
+
+def _format_current_slide_context_v5(
+    slide: schemas.LectureSlideContextSlideV5 | None,
+) -> str | None:
+    if slide is None:
+        return None
+    title = slide.title.strip()
+    header = _format_slide_number(slide.slide_position)
+    if title:
+        header = f"{header}: {title}"
+    lines = [header]
+    if slide.visible_text:
+        lines.extend(["", "Visible text:", slide.visible_text])
+    if slide.visual_context:
+        lines.extend(["", "Visual context:", slide.visual_context])
+    if slide.narration_summary:
+        lines.extend(["", "Narration summary:", slide.narration_summary])
+    if slide.key_points:
+        lines.extend(["", "Key points:"])
+        lines.extend(f"- {point}" for point in slide.key_points)
+    if slide.diagrams:
+        lines.extend(["", "Diagrams:"])
+        lines.extend(f"- {diagram}" for diagram in slide.diagrams)
+    if slide.equations_or_symbols:
+        lines.extend(["", "Equations or symbols:"])
+        lines.extend(f"- {symbol}" for symbol in slide.equations_or_symbols)
+    return "\n".join(lines)
+
+
+def _build_context_text_v5(
+    thread: models.Thread,
+    state: models.LectureSlideThreadState,
+    context: schemas.LectureSlideContextV5,
+    *,
+    playback_position_ms: int,
+    answered_knowledge_checks: str | None,
+) -> str:
+    deck = thread.lecture_slide_deck
+    current_question = _get_current_question(thread, state)
+    furthest_offset_ms = max(state.furthest_offset_ms, playback_position_ms, 0)
+    summary_checkpoint = _select_summary_checkpoint_v5(
+        context.summary_checkpoints,
+        furthest_offset_ms,
+    )
+    moment_context = _select_moment_context_v5(
+        context.moment_contexts,
+        playback_position_ms,
+    )
+    current_slide_position = None
+    furthest_slide_position = None
+    if deck is not None:
+        current_slide = _slide_at_offset(deck, playback_position_ms)
+        furthest_slide = _slide_at_offset(deck, furthest_offset_ms)
+        current_slide_position = (
+            current_slide.position if current_slide is not None else None
+        )
+        furthest_slide_position = (
+            furthest_slide.position if furthest_slide is not None else None
+        )
+    if current_slide_position is None and moment_context is not None:
+        current_slide_position = moment_context.slide_position
+    if furthest_slide_position is None and summary_checkpoint is not None:
+        furthest_slide_position = summary_checkpoint.end_slide_position
+
+    slides_by_position = _slide_context_by_position(context)
+    current_slide_context = (
+        slides_by_position.get(current_slide_position)
+        if current_slide_position is not None
+        else None
+    )
+
+    current_knowledge_check = None
+    if (
+        state.state == schemas.InteractiveLessonSessionState.AWAITING_ANSWER
+        and current_question is not None
+    ):
+        current_knowledge_check = _format_knowledge_check_prompt(current_question)
+
+    upcoming_knowledge_check = None
+    if current_knowledge_check is None:
+        if (
+            state.state
+            == schemas.InteractiveLessonSessionState.AWAITING_POST_ANSWER_RESUME
+            and current_question is not None
+        ):
+            upcoming_question = _get_next_question(thread, current_question)
+        else:
+            upcoming_question = _get_next_future_question(thread, playback_position_ms)
+        upcoming_knowledge_check = _format_upcoming_knowledge_check(upcoming_question)
+
+    lines = [
+        "## Lecture Context",
+        "",
+        f"Status: {_lecture_context_status(state, current_question)}",
+        f"Current offset: {playback_position_ms}ms",
+        f"Furthest watched offset: {furthest_offset_ms}ms",
+        f"Current slide: {_format_slide_number(current_slide_position)}",
+        f"Furthest reached slide: {_format_slide_number(furthest_slide_position)}",
+    ]
+    _append_context_section(
+        lines,
+        "Lecture Summary So Far",
+        (
+            f"Through {summary_checkpoint.end_offset_ms}ms / "
+            f"{_format_slide_number(summary_checkpoint.end_slide_position)}:\n"
+            f"{summary_checkpoint.summary}"
+            if summary_checkpoint is not None
+            else None
+        ),
+    )
+    _append_context_section(
+        lines,
+        "Current Moment Context",
+        _format_moment_context_v5(moment_context)
+        if moment_context is not None
+        else None,
+    )
+    _append_context_section(
+        lines,
+        "Current Slide",
+        _format_current_slide_context_v5(current_slide_context),
+    )
+    _append_context_section(lines, "Current Knowledge Check", current_knowledge_check)
+    _append_context_section(lines, "Upcoming Knowledge Check", upcoming_knowledge_check)
+    _append_context_section(
+        lines, "Knowledge Checks Answered", answered_knowledge_checks
+    )
+    return "\n".join(lines)
+
+
 async def prepare_lecture_chat_turn(
     *,
     request: Any,
@@ -451,10 +664,19 @@ async def prepare_lecture_chat_turn(
         )
 
     deck = slide_thread.lecture_slide_deck
-    try:
-        transcript = (
-            lecture_slide_chat_context_from_model(deck) if deck is not None else None
+    if not lecture_slide_chat_available(deck):
+        raise HTTPException(
+            status_code=409,
+            detail=LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE,
         )
+    transcript = None
+    context_v5 = None
+    try:
+        if deck is not None and deck.context_version == 5:
+            context_v5 = lecture_slide_context_v5_from_model(deck)
+            transcript = transcript_from_model(deck)
+        elif deck is not None:
+            transcript = lecture_slide_chat_context_from_model(deck)
     except (ValidationError, ValueError) as exc:
         logger.warning(
             "Stored lecture slide chat context is invalid. lecture_slide_deck_id=%s",
@@ -465,7 +687,9 @@ async def prepare_lecture_chat_turn(
             status_code=409,
             detail=LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE,
         ) from exc
-    if transcript is None:
+    if transcript is None or (
+        deck is not None and deck.context_version == 5 and context_v5 is None
+    ):
         raise HTTPException(
             status_code=409,
             detail=LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE,
@@ -486,7 +710,11 @@ async def prepare_lecture_chat_turn(
         since_created=previous_context_created,
     )
     prepended_messages = []
-    if not await _thread_has_messages(request.state["db"], slide_thread.id):
+    if (
+        deck is not None
+        and deck.context_version == 4
+        and not await _thread_has_messages(request.state["db"], slide_thread.id)
+    ):
         developer_context_message = _build_lecture_developer_context_message(
             slide_thread=slide_thread,
             output_index=0,
@@ -502,12 +730,21 @@ async def prepare_lecture_chat_turn(
         if initial_file_message is not None:
             prepended_messages.append(initial_file_message)
 
-    context_text = _build_context_text(
-        slide_thread,
-        slide_state,
-        playback_position_ms=playback_position_ms,
-        answered_knowledge_checks=answered_knowledge_checks,
-    )
+    if context_v5 is not None:
+        context_text = _build_context_text_v5(
+            slide_thread,
+            slide_state,
+            context_v5,
+            playback_position_ms=playback_position_ms,
+            answered_knowledge_checks=answered_knowledge_checks,
+        )
+    else:
+        context_text = _build_context_text(
+            slide_thread,
+            slide_state,
+            playback_position_ms=playback_position_ms,
+            answered_knowledge_checks=answered_knowledge_checks,
+        )
     if context_text.strip():
         prepended_messages.append(
             models.Message(

--- a/pingpong/lecture_slide_chat.py
+++ b/pingpong/lecture_slide_chat.py
@@ -687,9 +687,11 @@ async def prepare_lecture_chat_turn(
             status_code=409,
             detail=LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE,
         ) from exc
-    if transcript is None or (
-        deck is not None and deck.context_version == 5 and context_v5 is None
-    ):
+    if deck is not None and deck.context_version == 5:
+        context_available = context_v5 is not None
+    else:
+        context_available = transcript is not None
+    if not context_available:
         raise HTTPException(
             status_code=409,
             detail=LECTURE_SLIDE_CHAT_UNAVAILABLE_NOTE,
@@ -770,5 +772,5 @@ async def prepare_lecture_chat_turn(
         prepended_messages=prepended_messages,
         user_output_index=prev_output_sequence + 1 + len(prepended_messages),
         user_assistant_messages_only=True,
-        include_developer_messages=True,
+        include_developer_messages=context_v5 is None,
     )

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -24,7 +24,7 @@ from openai.types import Reasoning
 import uuid_utils as uuid
 from openai.types.audio import TranscriptionWord
 from openai.types.responses.response_input_param import ResponseInputParam
-from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model
 from pydub import AudioSegment
 from pypdf import PdfReader
 from sqlalchemy import and_, delete, func, or_, select, update
@@ -270,6 +270,14 @@ class GeneratedSlideQuestion(BaseModel):
 class GeneratedSlideManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    deck_summary: str = ""
+    slides: list[schemas.LectureSlideContextSlideV5] = Field(default_factory=list)
+    summary_checkpoints: list[schemas.LectureSlideContextSummaryCheckpointV5] = Field(
+        default_factory=list
+    )
+    moment_contexts: list[schemas.LectureSlideContextMomentV5] = Field(
+        default_factory=list
+    )
     questions: list[GeneratedSlideQuestion] = Field(default_factory=list)
 
 
@@ -367,7 +375,25 @@ GENERATION GUIDANCE SPECIFIC TO THIS LESSON:
 
 YOUR TASK:
 Create a JSON object with these top-level fields:
+- deck_summary: a compact one-paragraph summary of the full slide lesson.
+- slides: compact per-slide chat context objects.
+- summary_checkpoints: cumulative summaries through increasing timeline offsets.
+- moment_contexts: local before/at/after context windows around important moments.
 - questions: optional multiple-choice comprehension checks placed after selected slides.
+
+SLIDE CHAT CONTEXT:
+- Include one slides entry for each slide in the supplied generation window.
+- slide_position is the zero-based slide number.
+- title should match the slide title when visible; otherwise use a short descriptive title.
+- start_offset_ms and end_offset_ms must come from the timing source row when available.
+- visible_text should compactly capture important readable text on the slide.
+- visual_context should describe diagrams, layout, images, charts, code, symbols, or other visual information needed to answer questions about the slide.
+- narration_summary should summarize what the narration says for this slide.
+- key_points should contain concise concept bullets grounded in the PDF and transcript.
+- diagrams and equations_or_symbols should list notable visual diagrams or equations/symbols, or be empty arrays.
+- For summary_checkpoints, each summary is cumulative from the start of the lesson through end_offset_ms, and end_slide_position is the zero-based slide reached by that offset.
+- For moment_contexts, create useful local windows with start_offset_ms <= center_offset_ms <= end_offset_ms and a zero-based slide_position.
+- If a generation window is provided, create slides, summary_checkpoints, and moment_contexts only for that requested generation window, not the surrounding context overlap.
 
 QUESTIONS:
 - Not every slide needs a question. Add questions only after slides with a clear, useful concept check.
@@ -2423,6 +2449,59 @@ def _filter_slide_questions_for_window(
     return filtered
 
 
+def _filter_slide_context_for_window(
+    manifest: GeneratedSlideManifest,
+    *,
+    page_ranges: list[SlidePageRange],
+    start_offset_ms: int,
+    end_offset_ms: int,
+) -> GeneratedSlideManifest:
+    window_slide_positions = {
+        int(page_range["slide_position"])
+        for page_range in page_ranges
+        if page_range["start_offset_ms"] is not None
+        and page_range["end_offset_ms"] is not None
+        and (
+            (start_offset_ms == 0 and page_range["end_offset_ms"] >= start_offset_ms)
+            or page_range["end_offset_ms"] > start_offset_ms
+        )
+        and page_range["start_offset_ms"] <= end_offset_ms
+    }
+    return manifest.model_copy(
+        update={
+            "slides": [
+                slide
+                for slide in manifest.slides
+                if slide.slide_position in window_slide_positions
+            ],
+            "summary_checkpoints": [
+                checkpoint
+                for checkpoint in manifest.summary_checkpoints
+                if (
+                    (
+                        start_offset_ms == 0
+                        and checkpoint.end_offset_ms >= start_offset_ms
+                    )
+                    or checkpoint.end_offset_ms > start_offset_ms
+                )
+                and checkpoint.end_offset_ms <= end_offset_ms
+            ],
+            "moment_contexts": [
+                moment
+                for moment in manifest.moment_contexts
+                if (
+                    (
+                        start_offset_ms == 0
+                        and moment.center_offset_ms >= start_offset_ms
+                    )
+                    or moment.center_offset_ms > start_offset_ms
+                )
+                and moment.center_offset_ms <= end_offset_ms
+            ],
+        }
+    )
+
+
 def _slide_question_pause_offsets(
     question: GeneratedSlideQuestion,
     *,
@@ -2473,6 +2552,31 @@ def _validate_generated_slide_manifest(
             )
         valid_questions.append(question)
     return manifest.model_copy(update={"questions": valid_questions})
+
+
+def _validated_slide_context_v5(
+    manifest: GeneratedSlideManifest,
+) -> schemas.LectureSlideContextV5 | None:
+    if (
+        not manifest.deck_summary.strip()
+        or not manifest.slides
+        or not manifest.summary_checkpoints
+        or not manifest.moment_contexts
+    ):
+        return None
+    return schemas.LectureSlideContextV5.model_validate(
+        {
+            "version": 5,
+            "deck_summary": manifest.deck_summary,
+            "slides": [slide.model_dump() for slide in manifest.slides],
+            "summary_checkpoints": [
+                checkpoint.model_dump() for checkpoint in manifest.summary_checkpoints
+            ],
+            "moment_contexts": [
+                moment.model_dump() for moment in manifest.moment_contexts
+            ],
+        }
+    )
 
 
 def _is_context_limit_error(exc: Exception) -> bool:
@@ -2807,6 +2911,12 @@ async def _generate_slide_manifest_for_window(
                 )
             }
         )
+        manifest = _filter_slide_context_for_window(
+            manifest,
+            page_ranges=page_ranges,
+            start_offset_ms=chunk.generation_start_ms,
+            end_offset_ms=chunk.generation_end_ms,
+        )
     return _validate_generated_slide_manifest(
         manifest,
         page_ranges=page_ranges,
@@ -2817,10 +2927,43 @@ async def _generate_slide_manifest_for_window(
 def _merge_slide_chunk_manifests(
     chunk_manifests: list[GeneratedSlideManifest],
 ) -> GeneratedSlideManifest:
+    slides = sorted(
+        {
+            slide.slide_position: slide
+            for manifest in chunk_manifests
+            for slide in manifest.slides
+        }.values(),
+        key=lambda item: item.slide_position,
+    )
+    summary_checkpoints = sorted(
+        {
+            checkpoint.end_offset_ms: checkpoint
+            for manifest in chunk_manifests
+            for checkpoint in manifest.summary_checkpoints
+        }.values(),
+        key=lambda item: item.end_offset_ms,
+    )
+    moment_contexts = sorted(
+        {
+            moment.center_offset_ms: moment
+            for manifest in chunk_manifests
+            for moment in manifest.moment_contexts
+        }.values(),
+        key=lambda item: item.center_offset_ms,
+    )
+    deck_summary = "\n\n".join(
+        manifest.deck_summary.strip()
+        for manifest in chunk_manifests
+        if manifest.deck_summary.strip()
+    )
     return GeneratedSlideManifest(
+        deck_summary=deck_summary,
+        slides=slides,
+        summary_checkpoints=summary_checkpoints,
+        moment_contexts=moment_contexts,
         questions=[
             question for manifest in chunk_manifests for question in manifest.questions
-        ]
+        ],
     )
 
 
@@ -2910,11 +3053,27 @@ async def _persist_slide_manifest(
             ],
         )
 
-        context_data = dict(deck.context_data or {})
-        context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
-        deck.context_data = context_data
-        deck.context_version = 4
-        deck.lecture_slide_chat_available = bool(transcript)
+        try:
+            context_v5 = _validated_slide_context_v5(manifest)
+        except (ValidationError, ValueError):
+            logger.warning(
+                "Generated lecture slide v5 context is invalid. "
+                "lecture_slide_deck_id=%s",
+                deck.id,
+                exc_info=True,
+            )
+            context_v5 = None
+
+        if transcript and context_v5 is not None:
+            deck.context_data = context_v5.model_dump()
+            deck.context_version = 5
+            deck.lecture_slide_chat_available = True
+        else:
+            context_data = dict(deck.context_data or {})
+            context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
+            deck.context_data = context_data
+            deck.context_version = 5
+            deck.lecture_slide_chat_available = False
         deck.transcript_data = transcript_data_from_words(transcript)
         await session.commit()
 

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -1055,7 +1055,7 @@ async def process_claimed_run(assignment: RunAssignment) -> None:
 async def _deck_has_slide_manifest(deck_id: int) -> bool:
     async with config.db.driver.async_session() as session:
         deck = await models.LectureSlideDeck.get_by_id(session, deck_id)
-        if deck is None or deck.context_version != 4:
+        if deck is None or deck.context_version not in {4, 5}:
             return False
         question_count = await session.scalar(
             select(func.count(models.LectureSlideQuestion.id)).where(
@@ -2422,6 +2422,15 @@ def _split_slide_manifest_generation_chunk(
     ]
 
 
+def _offset_is_in_window(
+    offset_ms: int, start_offset_ms: int, end_offset_ms: int
+) -> bool:
+    return (
+        (start_offset_ms == 0 and offset_ms >= start_offset_ms)
+        or offset_ms > start_offset_ms
+    ) and offset_ms <= end_offset_ms
+
+
 def _filter_slide_questions_for_window(
     questions: list[GeneratedSlideQuestion],
     *,
@@ -2441,10 +2450,7 @@ def _filter_slide_questions_for_window(
         if pause_offsets is None:
             continue
         stop_offset_ms = pause_offsets["stop_offset_ms"]
-        if (
-            (start_offset_ms == 0 and stop_offset_ms >= start_offset_ms)
-            or stop_offset_ms > start_offset_ms
-        ) and stop_offset_ms <= end_offset_ms:
+        if _offset_is_in_window(stop_offset_ms, start_offset_ms, end_offset_ms):
             filtered.append(question)
     return filtered
 
@@ -2461,9 +2467,8 @@ def _filter_slide_context_for_window(
         for page_range in page_ranges
         if page_range["start_offset_ms"] is not None
         and page_range["end_offset_ms"] is not None
-        and (
-            (start_offset_ms == 0 and page_range["end_offset_ms"] >= start_offset_ms)
-            or page_range["end_offset_ms"] > start_offset_ms
+        and _offset_is_in_window(
+            page_range["end_offset_ms"], start_offset_ms, end_offset_ms
         )
         and page_range["start_offset_ms"] <= end_offset_ms
     }
@@ -2477,26 +2482,16 @@ def _filter_slide_context_for_window(
             "summary_checkpoints": [
                 checkpoint
                 for checkpoint in manifest.summary_checkpoints
-                if (
-                    (
-                        start_offset_ms == 0
-                        and checkpoint.end_offset_ms >= start_offset_ms
-                    )
-                    or checkpoint.end_offset_ms > start_offset_ms
+                if _offset_is_in_window(
+                    checkpoint.end_offset_ms, start_offset_ms, end_offset_ms
                 )
-                and checkpoint.end_offset_ms <= end_offset_ms
             ],
             "moment_contexts": [
                 moment
                 for moment in manifest.moment_contexts
-                if (
-                    (
-                        start_offset_ms == 0
-                        and moment.center_offset_ms >= start_offset_ms
-                    )
-                    or moment.center_offset_ms > start_offset_ms
+                if _offset_is_in_window(
+                    moment.center_offset_ms, start_offset_ms, end_offset_ms
                 )
-                and moment.center_offset_ms <= end_offset_ms
             ],
         }
     )
@@ -2577,6 +2572,14 @@ def _validated_slide_context_v5(
             ],
         }
     )
+
+
+def _validated_existing_slide_context_v5(
+    deck: models.LectureSlideDeck,
+) -> schemas.LectureSlideContextV5 | None:
+    if deck.context_version != 5 or deck.context_data is None:
+        return None
+    return schemas.LectureSlideContextV5.model_validate(deck.context_data)
 
 
 def _is_context_limit_error(exc: Exception) -> bool:
@@ -2927,6 +2930,11 @@ async def _generate_slide_manifest_for_window(
 def _merge_slide_chunk_manifests(
     chunk_manifests: list[GeneratedSlideManifest],
 ) -> GeneratedSlideManifest:
+    def append_unique_summary(parts: list[str], summary: str) -> None:
+        summary = summary.strip()
+        if summary and summary not in parts:
+            parts.append(summary)
+
     slides = sorted(
         {
             slide.slide_position: slide
@@ -2935,7 +2943,7 @@ def _merge_slide_chunk_manifests(
         }.values(),
         key=lambda item: item.slide_position,
     )
-    summary_checkpoints = sorted(
+    sorted_summary_checkpoints = sorted(
         {
             checkpoint.end_offset_ms: checkpoint
             for manifest in chunk_manifests
@@ -2943,6 +2951,15 @@ def _merge_slide_chunk_manifests(
         }.values(),
         key=lambda item: item.end_offset_ms,
     )
+    cumulative_summary_parts: list[str] = []
+    summary_checkpoints = []
+    for checkpoint in sorted_summary_checkpoints:
+        append_unique_summary(cumulative_summary_parts, checkpoint.summary)
+        summary_checkpoints.append(
+            checkpoint.model_copy(
+                update={"summary": " ".join(cumulative_summary_parts)}
+            )
+        )
     moment_contexts = sorted(
         {
             moment.center_offset_ms: moment
@@ -2951,10 +2968,14 @@ def _merge_slide_chunk_manifests(
         }.values(),
         key=lambda item: item.center_offset_ms,
     )
-    deck_summary = "\n\n".join(
-        manifest.deck_summary.strip()
-        for manifest in chunk_manifests
-        if manifest.deck_summary.strip()
+    deck_summary = (
+        summary_checkpoints[-1].summary
+        if summary_checkpoints
+        else " ".join(
+            manifest.deck_summary.strip()
+            for manifest in chunk_manifests
+            if manifest.deck_summary.strip()
+        )
     )
     return GeneratedSlideManifest(
         deck_summary=deck_summary,
@@ -3064,16 +3085,31 @@ async def _persist_slide_manifest(
             )
             context_v5 = None
 
-        if transcript and context_v5 is not None:
+        existing_context_v5 = None
+        if context_v5 is None:
+            try:
+                existing_context_v5 = _validated_existing_slide_context_v5(deck)
+            except (ValidationError, ValueError):
+                existing_context_v5 = None
+
+        if context_v5 is not None:
             deck.context_data = context_v5.model_dump()
+            deck.context_version = 5
+            deck.lecture_slide_chat_available = True
+        elif existing_context_v5 is not None:
+            deck.context_data = existing_context_v5.model_dump()
             deck.context_version = 5
             deck.lecture_slide_chat_available = True
         else:
             context_data = dict(deck.context_data or {})
             context_data.pop(schemas.LECTURE_SLIDE_MANUAL_QUESTIONS_CONTEXT_KEY, None)
             deck.context_data = context_data
-            deck.context_version = 5
-            deck.lecture_slide_chat_available = False
+            if transcript:
+                deck.context_version = 4
+                deck.lecture_slide_chat_available = True
+            else:
+                deck.context_version = None
+                deck.lecture_slide_chat_available = False
         deck.transcript_data = transcript_data_from_words(transcript)
         await session.commit()
 

--- a/pingpong/lecture_slide_runtime.py
+++ b/pingpong/lecture_slide_runtime.py
@@ -73,7 +73,7 @@ class LectureSlideAdapter:
 
     def lesson_chat_available(self, asset: object) -> bool:
         deck = cast(models.LectureSlideDeck, asset)
-        return deck.context_version == 4 and deck.lecture_slide_chat_available
+        return deck.context_version in {4, 5} and deck.lecture_slide_chat_available
 
     def initial_state_fields(self) -> dict[str, Any]:
         return {"last_chat_context_end_ms": 0}

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -937,6 +937,126 @@ class LectureVideoManifestMomentContextV4(BaseModel):
         return self
 
 
+class LectureSlideContextSlideV5(BaseModel):
+    slide_position: int = Field(..., ge=0)
+    title: str = ""
+    start_offset_ms: int | None = Field(None, ge=0)
+    end_offset_ms: int | None = Field(None, ge=0)
+    visible_text: str = ""
+    visual_context: str = ""
+    narration_summary: str = ""
+    key_points: list[str] = Field(default_factory=list)
+    diagrams: list[str] = Field(default_factory=list)
+    equations_or_symbols: list[str] = Field(default_factory=list)
+
+    @field_validator(
+        "title",
+        "visible_text",
+        "visual_context",
+        "narration_summary",
+        mode="after",
+    )
+    @classmethod
+    def strip_text_field(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("key_points", "diagrams", "equations_or_symbols", mode="after")
+    @classmethod
+    def strip_text_list(cls, value: list[str]) -> list[str]:
+        return [item.strip() for item in value if item.strip()]
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "LectureSlideContextSlideV5":
+        if (
+            self.start_offset_ms is not None
+            and self.end_offset_ms is not None
+            and self.end_offset_ms < self.start_offset_ms
+        ):
+            raise ValueError(
+                "end_offset_ms must be greater than or equal to start_offset_ms"
+            )
+        return self
+
+
+class LectureSlideContextSummaryCheckpointV5(BaseModel):
+    end_offset_ms: int = Field(..., ge=0)
+    end_slide_position: int = Field(..., ge=0)
+    summary: str = Field(..., min_length=1)
+
+    @field_validator("summary")
+    @classmethod
+    def strip_summary(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("summary must not be empty")
+        return value
+
+
+class LectureSlideContextMomentV5(BaseModel):
+    start_offset_ms: int = Field(..., ge=0)
+    center_offset_ms: int = Field(..., ge=0)
+    end_offset_ms: int = Field(..., ge=0)
+    slide_position: int = Field(..., ge=0)
+    before: str = Field(..., min_length=1)
+    at: str = Field(..., min_length=1)
+    after: str = Field(..., min_length=1)
+
+    @field_validator("before", "at", "after")
+    @classmethod
+    def strip_text(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("context text must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "LectureSlideContextMomentV5":
+        if not self.start_offset_ms <= self.center_offset_ms <= self.end_offset_ms:
+            raise ValueError(
+                "start_offset_ms <= center_offset_ms <= end_offset_ms is required"
+            )
+        return self
+
+
+class LectureSlideContextV5(BaseModel):
+    version: Literal[5] = 5
+    deck_summary: str = Field(..., min_length=1)
+    slides: list[LectureSlideContextSlideV5] = Field(..., min_length=1)
+    summary_checkpoints: list[LectureSlideContextSummaryCheckpointV5] = Field(
+        ..., min_length=1
+    )
+    moment_contexts: list[LectureSlideContextMomentV5] = Field(..., min_length=1)
+
+    @field_validator("deck_summary")
+    @classmethod
+    def strip_deck_summary(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("deck_summary must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def normalize_context_arrays(self) -> "LectureSlideContextV5":
+        self.slides = sorted(
+            {slide.slide_position: slide for slide in self.slides}.values(),
+            key=lambda item: item.slide_position,
+        )
+        self.summary_checkpoints = sorted(
+            {
+                checkpoint.end_offset_ms: checkpoint
+                for checkpoint in self.summary_checkpoints
+            }.values(),
+            key=lambda item: item.end_offset_ms,
+        )
+        self.moment_contexts = sorted(
+            {
+                moment.center_offset_ms: moment for moment in self.moment_contexts
+            }.values(),
+            key=lambda item: item.center_offset_ms,
+        )
+        return self
+
+
 def normalize_lecture_video_manifest_v4_context_arrays(
     summary_checkpoints: list[LectureVideoManifestSummaryCheckpointV4],
     moment_contexts: list[LectureVideoManifestMomentContextV4],

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -142,6 +142,84 @@ def _generated_slide_context_kwargs() -> dict:
     }
 
 
+async def test_offset_is_in_window_keeps_zero_boundary_only_for_first_window():
+    assert lecture_slide_processing._offset_is_in_window(0, 0, 1000)
+    assert not lecture_slide_processing._offset_is_in_window(0, 1, 1000)
+    assert lecture_slide_processing._offset_is_in_window(500, 1, 1000)
+    assert not lecture_slide_processing._offset_is_in_window(1001, 1, 1000)
+
+
+async def test_merge_slide_chunk_manifests_carries_cumulative_summaries_forward():
+    first_manifest = lecture_slide_processing.GeneratedSlideManifest(
+        deck_summary="First chunk summary.",
+        slides=[
+            schemas.LectureSlideContextSlideV5(
+                slide_position=0,
+                title="First",
+                narration_summary="First slide.",
+            )
+        ],
+        summary_checkpoints=[
+            schemas.LectureSlideContextSummaryCheckpointV5(
+                end_offset_ms=1000,
+                end_slide_position=0,
+                summary="First chunk summary.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureSlideContextMomentV5(
+                start_offset_ms=0,
+                center_offset_ms=500,
+                end_offset_ms=1000,
+                slide_position=0,
+                before="Before first.",
+                at="At first.",
+                after="After first.",
+            )
+        ],
+    )
+    second_manifest = lecture_slide_processing.GeneratedSlideManifest(
+        deck_summary="Second chunk summary.",
+        slides=[
+            schemas.LectureSlideContextSlideV5(
+                slide_position=1,
+                title="Second",
+                narration_summary="Second slide.",
+            )
+        ],
+        summary_checkpoints=[
+            schemas.LectureSlideContextSummaryCheckpointV5(
+                end_offset_ms=2000,
+                end_slide_position=1,
+                summary="Second chunk summary.",
+            )
+        ],
+        moment_contexts=[
+            schemas.LectureSlideContextMomentV5(
+                start_offset_ms=1000,
+                center_offset_ms=1500,
+                end_offset_ms=2000,
+                slide_position=1,
+                before="Before second.",
+                at="At second.",
+                after="After second.",
+            )
+        ],
+    )
+
+    merged = lecture_slide_processing._merge_slide_chunk_manifests(
+        [first_manifest, second_manifest]
+    )
+
+    assert merged.deck_summary == "First chunk summary. Second chunk summary."
+    assert [slide.slide_position for slide in merged.slides] == [0, 1]
+    assert [checkpoint.summary for checkpoint in merged.summary_checkpoints] == [
+        "First chunk summary.",
+        "First chunk summary. Second chunk summary.",
+    ]
+    assert [moment.center_offset_ms for moment in merged.moment_contexts] == [500, 1500]
+
+
 async def _create_class_and_deck(
     db, *, deck_id: int = 1, slide_count: int = 1
 ) -> models.LectureSlideDeck:
@@ -173,6 +251,36 @@ async def test_queue_lecture_slide_processing_run_reuses_active_run(db):
         assert deck.status == schemas.LectureSlideDeckStatus.PROCESSING
         assert first.stage == schemas.LectureSlideProcessingStage.SLIDE_ASSET_EXTRACTION
         assert first.attempt_number == 1
+
+
+async def test_deck_has_slide_manifest_accepts_v5_context_version(db):
+    await _create_class_and_deck(db)
+    async with db.async_session() as session:
+        deck = await session.get(models.LectureSlideDeck, 1)
+        assert deck is not None
+        deck.context_version = 5
+        question = models.LectureSlideQuestion(
+            lecture_slide_deck_id=1,
+            position=0,
+            slide_position=0,
+            slide_offset_ms=0,
+            stop_offset_ms=1000,
+            question_type=schemas.LectureSlideQuestionType.SINGLE_SELECT,
+            question_text="Question?",
+            intro_text="",
+            options=[
+                models.LectureSlideQuestionOption(
+                    position=0,
+                    option_text="Option",
+                    post_answer_text="",
+                    continue_offset_ms=1000,
+                )
+            ],
+        )
+        session.add(question)
+        await session.commit()
+
+    assert await lecture_slide_processing._deck_has_slide_manifest(1)
 
 
 async def test_claim_next_processing_run_recovers_expired_lease(db):
@@ -1083,6 +1191,108 @@ async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatc
             for question in deck.questions
             for option in question.options
         ] == [500, 500, 1200, 1200]
+
+
+async def test_persist_slide_manifest_preserves_existing_v5_context_on_failure(db):
+    await _create_class_and_deck(db, slide_count=1)
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        deck.context_version = 5
+        deck.context_data = schemas.LectureSlideContextV5.model_validate(
+            {
+                "version": 5,
+                **_generated_slide_context_kwargs(),
+            }
+        ).model_dump()
+        deck.lecture_slide_chat_available = True
+        page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=0,
+            start_offset_ms=0,
+            end_offset_ms=500,
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.MANIFEST_GENERATION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([page, run])
+        await session.commit()
+        run_id = run.id
+
+    await lecture_slide_processing._persist_slide_manifest(
+        run_id,
+        "lease",
+        1,
+        lecture_slide_processing.GeneratedSlideManifest(questions=[]),
+        [],
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.context_version == 5
+        assert deck.context_data is not None
+        assert deck.context_data["version"] == 5
+        assert deck.context_data["deck_summary"] == "A compact lesson summary."
+        assert deck.lecture_slide_chat_available is True
+
+
+async def test_persist_slide_manifest_falls_back_to_v4_when_v5_context_missing(db):
+    await _create_class_and_deck(db, slide_count=1)
+    async with db.async_session() as session:
+        page = models.LectureSlidePage(
+            lecture_slide_deck_id=1,
+            position=0,
+            start_offset_ms=0,
+            end_offset_ms=500,
+        )
+        run = models.LectureSlideProcessingRun(
+            lecture_slide_deck_id=1,
+            lecture_slide_deck_id_snapshot=1,
+            class_id=1,
+            stage=schemas.LectureSlideProcessingStage.MANIFEST_GENERATION,
+            attempt_number=1,
+            status=schemas.LectureSlideProcessingRunStatus.RUNNING,
+            lease_token="lease",
+        )
+        session.add_all([page, run])
+        await session.commit()
+        run_id = run.id
+    transcript = [
+        schemas.LectureVideoManifestWordV3(
+            id="slide-0-word-0",
+            word="hello",
+            start_offset_ms=0,
+            end_offset_ms=100,
+        )
+    ]
+
+    await lecture_slide_processing._persist_slide_manifest(
+        run_id,
+        "lease",
+        1,
+        lecture_slide_processing.GeneratedSlideManifest(questions=[]),
+        transcript,
+    )
+
+    async with db.async_session() as session:
+        deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
+            session, 1
+        )
+        assert deck is not None
+        assert deck.context_version == 4
+        assert deck.context_data == {}
+        assert deck.lecture_slide_chat_available is True
 
 
 async def test_persist_slide_manifest_includes_manual_questions_from_context(db):

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -87,6 +87,61 @@ def _deck(
     )
 
 
+def _generated_slide_context_kwargs() -> dict:
+    return {
+        "deck_summary": "A compact lesson summary.",
+        "slides": [
+            schemas.LectureSlideContextSlideV5(
+                slide_position=0,
+                title="First",
+                start_offset_ms=0,
+                end_offset_ms=500,
+                visible_text="First slide",
+                visual_context="A simple opening slide.",
+                narration_summary="The narration introduces the topic.",
+                key_points=["The first point matters."],
+                diagrams=[],
+                equations_or_symbols=[],
+            ),
+            schemas.LectureSlideContextSlideV5(
+                slide_position=1,
+                title="Second",
+                start_offset_ms=500,
+                end_offset_ms=1200,
+                visible_text="Second slide",
+                visual_context="A follow-up example.",
+                narration_summary="The narration applies the topic.",
+                key_points=["The example applies the point."],
+                diagrams=[],
+                equations_or_symbols=[],
+            ),
+        ],
+        "summary_checkpoints": [
+            schemas.LectureSlideContextSummaryCheckpointV5(
+                end_offset_ms=500,
+                end_slide_position=0,
+                summary="The topic has been introduced.",
+            ),
+            schemas.LectureSlideContextSummaryCheckpointV5(
+                end_offset_ms=1200,
+                end_slide_position=1,
+                summary="The topic has been introduced and applied.",
+            ),
+        ],
+        "moment_contexts": [
+            schemas.LectureSlideContextMomentV5(
+                start_offset_ms=0,
+                center_offset_ms=500,
+                end_offset_ms=1000,
+                slide_position=0,
+                before="The lesson is beginning.",
+                at="The first point is introduced.",
+                after="The lesson moves to the example.",
+            )
+        ],
+    }
+
+
 async def _create_class_and_deck(
     db, *, deck_id: int = 1, slide_count: int = 1
 ) -> models.LectureSlideDeck:
@@ -800,8 +855,12 @@ async def test_generate_slide_manifest_uses_pdf_and_transcript_not_extracted_tex
     assert "Not every slide needs a question" in instructions
     assert "A question appears between slides" in instructions
     assert "set slide_position to the zero-based slide after which" in instructions
-    assert "summary_checkpoints" not in instructions
-    assert "moment_contexts" not in instructions
+    assert "SLIDE CHAT CONTEXT:" in instructions
+    assert "deck_summary" in instructions
+    assert "summary_checkpoints" in instructions
+    assert "moment_contexts" in instructions
+    assert "visible_text" in instructions
+    assert "visual_context" in instructions
     assert (
         "Each question's options array uses option_text, post_answer_text, and correct"
         in instructions
@@ -933,6 +992,7 @@ async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatc
         run_id = run.id
 
     manifest = lecture_slide_processing.GeneratedSlideManifest(
+        **_generated_slide_context_kwargs(),
         questions=[
             lecture_slide_processing.GeneratedSlideQuestion(
                 slide_position=0,
@@ -986,8 +1046,12 @@ async def test_persist_slide_manifest_replaces_existing_questions(db, monkeypatc
             session, 1
         )
         assert deck is not None
-        assert deck.context_version == 4
-        assert deck.context_data == {}
+        assert deck.context_version == 5
+        assert deck.context_data is not None
+        assert deck.context_data["version"] == 5
+        assert deck.context_data["deck_summary"] == "A compact lesson summary."
+        assert deck.context_data["slides"][0]["title"] == "First"
+        assert deck.lecture_slide_chat_available is True
         assert deck.transcript_data is not None
         assert len(deck.questions) == 2
         assert deck.questions[0].question_text == "New question?"

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -913,6 +913,7 @@ async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
         )
         session.add(input_file)
         await session.flush()
+        input_file_id = input_file.id
         assert deck.source_stored_object is not None
         deck.source_stored_object.openai_file_object_id = input_file.id
         page = models.LectureSlidePage(
@@ -961,8 +962,7 @@ async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
     assert file_message.is_hidden is True
     assert file_message.role == schemas.MessageRole.USER
     assert file_message.content[0].type == schemas.MessagePartType.INPUT_FILE
-    assert file_message.content[0].input_file is not None
-    assert file_message.content[0].input_file.file_id == "pdf-file-id"
+    assert file_message.content[0].input_file_object_id == input_file_id
     assert "visual source of truth" in file_note
     assert context_message.is_hidden is True
     assert "## Lecture Context" in context_text

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -190,6 +190,57 @@ def _slide_transcript_data() -> dict:
     }
 
 
+def _slide_context_data_v5() -> dict:
+    return {
+        "version": 5,
+        "deck_summary": "A short lesson about using examples to explain an idea.",
+        "slides": [
+            {
+                "slide_position": 0,
+                "title": "Core idea",
+                "start_offset_ms": 0,
+                "end_offset_ms": 30_000,
+                "visible_text": "Core idea",
+                "visual_context": "A title slide with a simple definition.",
+                "narration_summary": "The narration introduces the core idea.",
+                "key_points": ["The idea needs a concrete example."],
+                "diagrams": [],
+                "equations_or_symbols": [],
+            },
+            {
+                "slide_position": 1,
+                "title": "Example",
+                "start_offset_ms": 30_000,
+                "end_offset_ms": 60_000,
+                "visible_text": "Example",
+                "visual_context": "A worked example is shown in a callout.",
+                "narration_summary": "The narration walks through the example.",
+                "key_points": ["Examples make the concept testable."],
+                "diagrams": ["A callout box connects the term to the example."],
+                "equations_or_symbols": ["x -> y"],
+            },
+        ],
+        "summary_checkpoints": [
+            {
+                "end_offset_ms": 39_000,
+                "end_slide_position": 1,
+                "summary": "The lesson has introduced the idea and started the example.",
+            }
+        ],
+        "moment_contexts": [
+            {
+                "start_offset_ms": 36_000,
+                "center_offset_ms": 42_000,
+                "end_offset_ms": 48_000,
+                "slide_position": 1,
+                "before": "The learner has just moved from the definition to the example.",
+                "at": "The example is being connected to the visible callout.",
+                "after": "The narration will finish the example and prepare to continue.",
+            }
+        ],
+    }
+
+
 @with_institution(11, "Test Institution")
 async def test_initialize_thread_state_and_acquire_control_for_lecture_slides(
     db, institution
@@ -819,6 +870,24 @@ async def test_lecture_slide_session_uses_stored_chat_available_flag(db, institu
 
 
 @with_institution(11, "Test Institution")
+async def test_lecture_slide_session_accepts_v5_chat_context(db, institution):
+    async with db.async_session() as session:
+        _, deck, _, thread, _ = await _create_slide_runtime_fixture(
+            session, institution
+        )
+        deck.context_version = 5
+        deck.lecture_slide_chat_available = True
+        lesson_session = await lecture_slide_runtime.get_thread_session(
+            session,
+            thread.id,
+            request_actor_user_id=123,
+        )
+
+    assert lesson_session is not None
+    assert lesson_session.lesson_chat_available is True
+
+
+@with_institution(11, "Test Institution")
 async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
     db, institution
 ):
@@ -904,6 +973,87 @@ async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
     assert "### Upcoming Knowledge Check" in context_text
     assert "### Current Slide" not in context_text
     assert "Extracted text:" not in context_text
+
+
+@with_institution(11, "Test Institution")
+async def test_prepare_lecture_slide_chat_turn_uses_v5_compact_context(db, institution):
+    async with db.async_session() as session:
+        (
+            class_,
+            deck,
+            assistant,
+            thread,
+            questions,
+        ) = await _create_slide_runtime_fixture(session, institution)
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        assistant.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        deck.transcript_data = _slide_transcript_data()
+        deck.context_data = _slide_context_data_v5()
+        deck.context_version = 5
+        deck.lecture_slide_chat_available = True
+        deck.slide_count = 2
+        pages = [
+            models.LectureSlidePage(
+                lecture_slide_deck=deck,
+                position=0,
+                start_offset_ms=0,
+                end_offset_ms=30_000,
+            ),
+            models.LectureSlidePage(
+                lecture_slide_deck=deck,
+                position=1,
+                start_offset_ms=30_000,
+                end_offset_ms=60_000,
+            ),
+        ]
+        state = models.LectureSlideThreadState(
+            thread=thread,
+            state=schemas.InteractiveLessonSessionState.PLAYING,
+            current_question=questions[0],
+            last_known_offset_ms=42_000,
+            furthest_offset_ms=52_000,
+            version=1,
+        )
+        session.add_all([*pages, state])
+        await session.flush()
+
+        prep = await lecture_slide_chat.prepare_lecture_chat_turn(
+            request=_server_request(session),
+            class_id=str(class_.id),
+            thread=thread,
+            user_id=123,
+            prev_output_sequence=7,
+            lecture_video_playback_position_ms=42_000,
+        )
+        context_message = prep.prepended_messages[0]
+        context_text = context_message.content[0].text
+
+    assert prep.user_output_index == 9
+    assert [message.role for message in prep.prepended_messages] == [
+        schemas.MessageRole.DEVELOPER,
+    ]
+    assert context_message.is_hidden is True
+    assert context_text.startswith("## Lecture Context")
+    assert "## Lecture Slide Lesson Context" not in context_text
+    assert "Current offset: 42000ms" in context_text
+    assert "Furthest watched offset: 52000ms" in context_text
+    assert "Current slide: Slide 2" in context_text
+    assert "Furthest reached slide: Slide 2" in context_text
+    assert "### Lecture Summary So Far" in context_text
+    assert "Through 39000ms / Slide 2:" in context_text
+    assert "### Current Moment Context" in context_text
+    assert "Before this moment:" in context_text
+    assert "At this moment:" in context_text
+    assert "After this moment:" in context_text
+    assert "### Current Slide" in context_text
+    assert "Slide 2: Example" in context_text
+    assert "Visible text:\nExample" in context_text
+    assert "Visual context:\nA worked example is shown in a callout." in context_text
+    assert "Key points:\n- Examples make the concept testable." in context_text
+    assert (
+        "Diagrams:\n- A callout box connects the term to the example." in context_text
+    )
+    assert "Equations or symbols:\n- x -> y" in context_text
 
 
 @with_institution(11, "Test Institution")

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -951,6 +951,7 @@ async def test_prepare_lecture_slide_chat_turn_uses_video_context_shape(
 
     assert prep.user_output_index == 11
     assert prep.user_assistant_messages_only is True
+    assert prep.include_developer_messages is True
     assert lesson_context_message.is_hidden is True
     assert lesson_context_message.role == schemas.MessageRole.DEVELOPER
     assert "## Lecture Slide Narrations" in lesson_context_text
@@ -1029,9 +1030,11 @@ async def test_prepare_lecture_slide_chat_turn_uses_v5_compact_context(db, insti
         context_text = context_message.content[0].text
 
     assert prep.user_output_index == 9
+    assert prep.include_developer_messages is False
     assert [message.role for message in prep.prepended_messages] == [
         schemas.MessageRole.DEVELOPER,
     ]
+    assert context_message.output_index == 8
     assert context_message.is_hidden is True
     assert context_text.startswith("## Lecture Context")
     assert "## Lecture Slide Lesson Context" not in context_text
@@ -1054,6 +1057,67 @@ async def test_prepare_lecture_slide_chat_turn_uses_v5_compact_context(db, insti
         "Diagrams:\n- A callout box connects the term to the example." in context_text
     )
     assert "Equations or symbols:\n- x -> y" in context_text
+
+
+@with_institution(11, "Test Institution")
+async def test_prepare_lecture_slide_chat_turn_accepts_v5_context_without_transcript(
+    db, institution
+):
+    async with db.async_session() as session:
+        (
+            class_,
+            deck,
+            assistant,
+            thread,
+            questions,
+        ) = await _create_slide_runtime_fixture(session, institution)
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        assistant.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        deck.transcript_data = None
+        deck.context_data = _slide_context_data_v5()
+        deck.context_version = 5
+        deck.lecture_slide_chat_available = True
+        pages = [
+            models.LectureSlidePage(
+                lecture_slide_deck=deck,
+                position=0,
+                start_offset_ms=0,
+                end_offset_ms=30_000,
+            ),
+            models.LectureSlidePage(
+                lecture_slide_deck=deck,
+                position=1,
+                start_offset_ms=30_000,
+                end_offset_ms=60_000,
+            ),
+        ]
+        state = models.LectureSlideThreadState(
+            thread=thread,
+            state=schemas.InteractiveLessonSessionState.PLAYING,
+            current_question=questions[0],
+            last_known_offset_ms=42_000,
+            furthest_offset_ms=52_000,
+            version=1,
+        )
+        session.add_all([*pages, state])
+        await session.flush()
+
+        prep = await lecture_slide_chat.prepare_lecture_chat_turn(
+            request=_server_request(session),
+            class_id=str(class_.id),
+            thread=thread,
+            user_id=123,
+            prev_output_sequence=7,
+            lecture_video_playback_position_ms=42_000,
+        )
+
+    assert prep.user_output_index == 9
+    assert prep.include_developer_messages is False
+    assert [message.role for message in prep.prepended_messages] == [
+        schemas.MessageRole.DEVELOPER,
+    ]
+    assert prep.prepended_messages[0].output_index == 8
+    assert "### Current Slide" in prep.prepended_messages[0].content[0].text
 
 
 @with_institution(11, "Test Institution")
@@ -1105,6 +1169,7 @@ async def test_prepare_lecture_slide_chat_turn_skips_initial_file_message_withou
         )
 
     assert prep.user_output_index == 2
+    assert prep.include_developer_messages is True
     assert [message.role for message in prep.prepended_messages] == [
         schemas.MessageRole.DEVELOPER,
         schemas.MessageRole.DEVELOPER,
@@ -1240,6 +1305,7 @@ async def test_prepare_lecture_slide_chat_turn_adds_dynamic_context_without_recr
         context_text = context_message.content[0].text
 
     assert prep.user_output_index == 22
+    assert prep.include_developer_messages is True
     assert [message.role for message in prep.prepended_messages] == [
         schemas.MessageRole.DEVELOPER,
     ]


### PR DESCRIPTION
## Lecture Slides (Under Development)
### Updates & Improvements
* Lecture Slides chat now uses a new compact slide context generated from the PDF and narration transcript, including the current slide, visible slide text, visual context, narration summary, key points, diagrams, equations, and symbols.
* Chat context now includes the learner’s current slide, furthest reached slide, cumulative lecture summary so far, and local before/at/after context around the current playback moment.
* Existing Lecture Slides decks using the previous v4 chat context remain fully supported.