### PR TITLE
fix(lessons): unblock TTS setup under autoplay restrictions

### DIFF
--- a/web/pingpong/src/lib/stores/thread.test.ts
+++ b/web/pingpong/src/lib/stores/thread.test.ts
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as api from '$lib/api';
 import type { BaseResponse, Fetcher, ThreadWithMeta } from '$lib/api';
@@ -7,7 +7,76 @@ import { parseTextContent } from '$lib/content';
 
 import { ThreadManager } from './thread';
 
+const ttsMocks = vi.hoisted(() => ({
+	unlockSharedAudioContext: vi.fn(),
+	getSharedAudioContext: vi.fn(() => null),
+	createPlayer: vi.fn()
+}));
+
+vi.mock('$lib/wavtools/index', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/wavtools/index')>();
+	return {
+		...actual,
+		unlockSharedAudioContext: ttsMocks.unlockSharedAudioContext,
+		getSharedAudioContext: ttsMocks.getSharedAudioContext,
+		WavStreamPlayer: function (options: unknown) {
+			return ttsMocks.createPlayer(options);
+		} as unknown as typeof import('$lib/wavtools/index').WavStreamPlayer
+	};
+});
+
 describe('ThreadManager', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		ttsMocks.unlockSharedAudioContext.mockClear();
+		ttsMocks.getSharedAudioContext.mockClear();
+		ttsMocks.createPlayer.mockReset();
+	});
+
+	const makeFakePlayer = (connect: () => Promise<true>) => ({
+		connect: vi.fn(connect),
+		setVolume: vi.fn(),
+		add16BitPCM: vi.fn(),
+		finish: vi.fn(),
+		interrupt: vi.fn().mockResolvedValue(null),
+		close: vi.fn().mockResolvedValue(undefined)
+	});
+
+	const makeChunks = (chunks: api.ThreadStreamChunk[]) => {
+		const stream = new ReadableStream<object>({
+			start(controller) {
+				controller.close();
+			}
+		});
+		return {
+			stream,
+			reader: stream.getReader(),
+			async *[Symbol.asyncIterator]() {
+				yield* chunks;
+			}
+		} as Awaited<ReturnType<typeof api.postMessage>>;
+	};
+
+	const makeAssistantMessage = (id: string): api.OpenAIMessage => ({
+		id,
+		role: 'assistant',
+		content: [],
+		created_at: Date.now() / 1000 + 5,
+		metadata: {},
+		assistant_id: 'asst_1',
+		object: 'thread.message',
+		run_id: 'run_tts_1',
+		attachments: []
+	});
+
+	const textDelta = (value: string): api.ThreadStreamChunk =>
+		({
+			type: 'message_delta',
+			delta: {
+				content: [{ index: 0, type: 'text', text: { value, annotations: [] } }],
+				role: null
+			}
+		}) as unknown as api.ThreadStreamChunk;
 	const makeThreadData = (
 		interactionMode: 'chat' | 'voice' | 'lecture_video' = 'voice'
 	): BaseResponse & ThreadWithMeta => ({
@@ -210,5 +279,106 @@ describe('ThreadManager', () => {
 			181,
 			expect.objectContaining({ generate_speech: false })
 		);
+	});
+
+	it('keeps streaming text when the TTS player never finishes connecting', async () => {
+		const player = makeFakePlayer(() => new Promise<true>(() => {}));
+		ttsMocks.createPlayer.mockReturnValue(player);
+		vi.spyOn(api, 'postMessage').mockResolvedValue(
+			makeChunks([
+				{
+					type: 'message_created',
+					role: 'assistant',
+					message: makeAssistantMessage('msg_tts_1')
+				} as unknown as api.ThreadStreamChunk,
+				{ type: 'audio_started' } as api.ThreadStreamChunk,
+				textDelta('Hello'),
+				{ type: 'audio_delta', audio: 'AAAA' } as api.ThreadStreamChunk,
+				textDelta(' world'),
+				{ type: 'audio_done' } as api.ThreadStreamChunk,
+				{ type: 'done' } as api.ThreadStreamChunk
+			])
+		);
+
+		const manager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		await manager.postMessage(123, 'Hi', vi.fn());
+
+		// The audio context was unlocked while the send gesture was live.
+		expect(ttsMocks.unlockSharedAudioContext).toHaveBeenCalledWith(24000);
+
+		// Text rendered fully even though connect() is still pending.
+		const assistantMessage = get(manager.messages).find((m) => m.data.id === 'msg_tts_1');
+		const textContent = assistantMessage?.data.content.find((c) => c.type === 'text');
+		if (textContent?.type !== 'text') {
+			throw new Error('Expected streamed text content.');
+		}
+		expect(textContent.text.value).toBe('Hello world');
+		expect(player.add16BitPCM).not.toHaveBeenCalled();
+	});
+
+	it('flushes audio buffered while the TTS player was connecting', async () => {
+		const player = makeFakePlayer(() => Promise.resolve(true as const));
+		ttsMocks.createPlayer.mockReturnValue(player);
+		vi.spyOn(api, 'postMessage').mockResolvedValue(
+			makeChunks([
+				{
+					type: 'message_created',
+					role: 'assistant',
+					message: makeAssistantMessage('msg_tts_2')
+				} as unknown as api.ThreadStreamChunk,
+				{ type: 'audio_started' } as api.ThreadStreamChunk,
+				{ type: 'audio_delta', audio: 'AAAA' } as api.ThreadStreamChunk,
+				{ type: 'audio_delta', audio: 'BBBB' } as api.ThreadStreamChunk,
+				{ type: 'audio_done' } as api.ThreadStreamChunk,
+				{ type: 'done' } as api.ThreadStreamChunk
+			])
+		);
+
+		const manager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		await manager.postMessage(123, 'Hi', vi.fn());
+
+		// Player setup is fire-and-forget, so wait for the flush to land.
+		await vi.waitFor(() => {
+			expect(player.add16BitPCM).toHaveBeenCalledTimes(2);
+			expect(player.finish).toHaveBeenCalledTimes(1);
+		});
+		expect(player.setVolume).toHaveBeenCalled();
+	});
+
+	it('does not unlock the audio context when voice is muted or outside lessons', async () => {
+		vi.spyOn(api, 'postMessage').mockResolvedValue(makeChunks([]));
+
+		const mutedManager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		mutedManager.setTtsMuted(true);
+		await mutedManager.postMessage(123, 'Hello', vi.fn());
+		expect(ttsMocks.unlockSharedAudioContext).not.toHaveBeenCalled();
+
+		const chatManager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('voice'),
+			'voice'
+		);
+		await chatManager.postMessage(123, 'Hello', vi.fn());
+		expect(ttsMocks.unlockSharedAudioContext).not.toHaveBeenCalled();
 	});
 });

--- a/web/pingpong/src/lib/stores/thread.test.ts
+++ b/web/pingpong/src/lib/stores/thread.test.ts
@@ -27,6 +27,7 @@ vi.mock('$lib/wavtools/index', async (importOriginal) => {
 
 describe('ThreadManager', () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 		ttsMocks.unlockSharedAudioContext.mockClear();
 		ttsMocks.getSharedAudioContext.mockClear();
@@ -282,6 +283,8 @@ describe('ThreadManager', () => {
 	});
 
 	it('keeps streaming text when the TTS player never finishes connecting', async () => {
+		vi.useFakeTimers();
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		const player = makeFakePlayer(() => new Promise<true>(() => {}));
 		ttsMocks.createPlayer.mockReturnValue(player);
 		vi.spyOn(api, 'postMessage').mockResolvedValue(
@@ -320,6 +323,9 @@ describe('ThreadManager', () => {
 		}
 		expect(textContent.text.value).toBe('Hello world');
 		expect(player.add16BitPCM).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(2100);
+		expect(warn).toHaveBeenCalledWith('TTS: AudioWorklet connect failed', expect.any(Error));
+		expect(player.close).toHaveBeenCalledTimes(1);
 	});
 
 	it('flushes audio buffered while the TTS player was connecting', async () => {
@@ -355,6 +361,133 @@ describe('ThreadManager', () => {
 			expect(player.finish).toHaveBeenCalledTimes(1);
 		});
 		expect(player.setVolume).toHaveBeenCalled();
+	});
+
+	it('disposes a player that finishes connecting after interruption', async () => {
+		let resolveConnect!: (value: true) => void;
+		const player = makeFakePlayer(
+			() =>
+				new Promise<true>((resolve) => {
+					resolveConnect = resolve;
+				})
+		);
+		ttsMocks.createPlayer.mockReturnValue(player);
+		vi.spyOn(api, 'postMessage').mockResolvedValue(
+			makeChunks([
+				{
+					type: 'message_created',
+					role: 'assistant',
+					message: makeAssistantMessage('msg_tts_interrupt')
+				} as unknown as api.ThreadStreamChunk,
+				{ type: 'audio_started' } as api.ThreadStreamChunk,
+				{ type: 'done' } as api.ThreadStreamChunk
+			])
+		);
+
+		const manager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		await manager.postMessage(123, 'Hi', vi.fn());
+		await manager.interruptTts();
+		resolveConnect(true);
+
+		await vi.waitFor(() => {
+			expect(player.close).toHaveBeenCalledTimes(1);
+		});
+		expect(player.add16BitPCM).not.toHaveBeenCalled();
+	});
+
+	it('clears pending audio when the stream reports an audio error', async () => {
+		let resolveConnect!: (value: true) => void;
+		const player = makeFakePlayer(
+			() =>
+				new Promise<true>((resolve) => {
+					resolveConnect = resolve;
+				})
+		);
+		ttsMocks.createPlayer.mockReturnValue(player);
+		vi.spyOn(api, 'postMessage').mockResolvedValue(
+			makeChunks([
+				{
+					type: 'message_created',
+					role: 'assistant',
+					message: makeAssistantMessage('msg_tts_error')
+				} as unknown as api.ThreadStreamChunk,
+				{ type: 'audio_started' } as api.ThreadStreamChunk,
+				{ type: 'audio_delta', audio: 'AAAA' } as api.ThreadStreamChunk,
+				{ type: 'audio_error' } as api.ThreadStreamChunk,
+				{ type: 'audio_done' } as api.ThreadStreamChunk,
+				{ type: 'done' } as api.ThreadStreamChunk
+			])
+		);
+
+		const manager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		await manager.postMessage(123, 'Hi', vi.fn());
+		resolveConnect(true);
+
+		await vi.waitFor(() => {
+			expect(player.close).toHaveBeenCalledTimes(1);
+		});
+		expect(player.add16BitPCM).not.toHaveBeenCalled();
+		expect(player.finish).not.toHaveBeenCalled();
+	});
+
+	it('ignores audio_done that arrives after TTS was interrupted', async () => {
+		const player = makeFakePlayer(() => Promise.resolve(true as const));
+		ttsMocks.createPlayer.mockReturnValue(player);
+		let continueStream!: () => void;
+		const streamCanFinish = new Promise<void>((resolve) => {
+			continueStream = resolve;
+		});
+		vi.spyOn(api, 'postMessage').mockResolvedValue({
+			stream: new ReadableStream<object>({
+				start(controller) {
+					controller.close();
+				}
+			}),
+			reader: new ReadableStream<object>().getReader(),
+			async *[Symbol.asyncIterator]() {
+				yield {
+					type: 'message_created',
+					role: 'assistant',
+					message: makeAssistantMessage('msg_tts_done_after_interrupt')
+				} as unknown as api.ThreadStreamChunk;
+				yield { type: 'audio_started' } as api.ThreadStreamChunk;
+				await streamCanFinish;
+				yield { type: 'audio_done' } as api.ThreadStreamChunk;
+				yield { type: 'done' } as api.ThreadStreamChunk;
+			}
+		} as Awaited<ReturnType<typeof api.postMessage>>);
+
+		const manager = new ThreadManager(
+			vi.fn() as unknown as Fetcher,
+			1,
+			181,
+			makeThreadData('lecture_video'),
+			'lecture_video'
+		);
+		const postPromise = manager.postMessage(123, 'Hi', vi.fn());
+
+		await vi.waitFor(() => {
+			expect(manager.getTtsPlayer()).toBe(player);
+		});
+		await manager.interruptTts();
+		continueStream();
+		await postPromise;
+
+		expect(player.interrupt).toHaveBeenCalledTimes(1);
+		expect(player.close).toHaveBeenCalledTimes(1);
+		expect(player.finish).not.toHaveBeenCalled();
 	});
 
 	it('does not unlock the audio context when voice is muted or outside lessons', async () => {

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -3,7 +3,33 @@ import type { Writable, Readable } from 'svelte/store';
 import * as api from '$lib/api';
 import type { ThreadWithMeta, Error as ApiError, BaseResponse } from '$lib/api';
 import { errorMessage } from '$lib/errors';
-import { WavStreamPlayer, base64ToArrayBuffer } from '$lib/wavtools/index';
+import {
+	WavStreamPlayer,
+	base64ToArrayBuffer,
+	getSharedAudioContext,
+	unlockSharedAudioContext
+} from '$lib/wavtools/index';
+
+/**
+ * Sample rate of the PCM16 audio chunks streamed by the TTS backend. The
+ * AudioContext used for playback must run at this rate.
+ */
+const TTS_SAMPLE_RATE = 24000;
+
+/**
+ * How long to wait for the TTS AudioContext to connect before giving up on
+ * audio for the response. Connecting can stall indefinitely when autoplay
+ * policies block the context, and the chunk stream must keep flowing.
+ */
+const TTS_CONNECT_TIMEOUT_MS = 2000;
+
+/**
+ * Audio chunks received while the TTS player is still connecting.
+ */
+type PendingTtsAudio = {
+	deltas: string[];
+	done: boolean;
+};
 
 /**
  * State for the thread manager.
@@ -225,6 +251,10 @@ export class ThreadManager {
 	#ttsVolume = 1;
 	#ttsMuted: Writable<boolean> = writable(false);
 	#ttsPlaying: Writable<boolean> = writable(false);
+	#ttsPendingAudio: PendingTtsAudio | null = null;
+	// Invalidates an in-flight TTS player setup when the response is
+	// interrupted or superseded before the player finishes connecting.
+	#ttsGeneration = 0;
 
 	/**
 	 * Whether TTS audio is currently playing/streaming.
@@ -801,6 +831,14 @@ export class ThreadManager {
 		const isLessonThread =
 			currentState?.data?.thread?.interaction_mode === 'lecture_video' ||
 			currentState?.data?.thread?.interaction_mode === 'lecture_slides';
+		if (isLessonThread && !get(this.#ttsMuted)) {
+			// Unlock the playback AudioContext synchronously while the user's
+			// send gesture is still live. Creating or resuming it later — when
+			// the audio_started chunk arrives off the network — is blocked by
+			// autoplay policies (Safari, embedded LTI iframes), which leaves
+			// resume() pending forever.
+			unlockSharedAudioContext(TTS_SAMPLE_RATE);
+		}
 		const optimisticOutputIndex =
 			threadVersion === 3 ? this.#getNextOutputIndex(currentState) : undefined;
 		const optimisticAssistantMsgId = isLessonThread
@@ -1120,7 +1158,10 @@ export class ThreadManager {
 				this.#completeReasoningStep(chunk);
 				break;
 			case 'audio_started':
-				await this.#handleTtsStarted();
+				// Deliberately not awaited: player setup can be slow (or hang
+				// entirely under autoplay policies) and must never block text
+				// deltas. Audio chunks are buffered until the player is ready.
+				this.#handleTtsStarted();
 				break;
 			case 'audio_delta':
 				this.#handleTtsDelta(chunk);
@@ -1148,10 +1189,20 @@ export class ThreadManager {
 		}
 	}
 
-	async #handleTtsStarted() {
+	#handleTtsStarted() {
+		const generation = ++this.#ttsGeneration;
+		const pending: PendingTtsAudio = { deltas: [], done: false };
+		this.#ttsPendingAudio = pending;
+		void this.#startTtsPlayer(generation, pending);
+	}
+
+	async #startTtsPlayer(generation: number, pending: PendingTtsAudio) {
+		let player: WavStreamPlayer | null = null;
+		let connectPromise: Promise<true> | null = null;
 		try {
-			const player = new WavStreamPlayer({
-				sampleRate: 24000,
+			player = new WavStreamPlayer({
+				sampleRate: TTS_SAMPLE_RATE,
+				context: getSharedAudioContext(TTS_SAMPLE_RATE) ?? undefined,
 				stopOnEmptyBuffer: false,
 				onPlaybackStopped: () => {
 					if (this.#ttsPlayer !== player) {
@@ -1163,34 +1214,88 @@ export class ThreadManager {
 					this.#disposeTtsPlayer(player).catch(() => {});
 				}
 			});
-			await player.connect();
+			connectPromise = player.connect();
+			await Promise.race([
+				connectPromise,
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() =>
+							reject(
+								new Error(`TTS: AudioContext connect timed out after ${TTS_CONNECT_TIMEOUT_MS}ms`)
+							),
+						TTS_CONNECT_TIMEOUT_MS
+					)
+				)
+			]);
+			if (generation !== this.#ttsGeneration) {
+				// Interrupted or superseded while connecting.
+				this.#disposeTtsPlayer(player).catch(() => {});
+				return;
+			}
 			player.setVolume(get(this.#ttsMuted) ? 0 : this.#ttsVolume);
 			this.#ttsPlayer = player;
 			this.#ttsTrackId = crypto.randomUUID();
 			this.#ttsPlaying.set(true);
+			// Flush audio that streamed in while the player was connecting.
+			this.#ttsPendingAudio = null;
+			for (const audio of pending.deltas) {
+				this.#writeTtsAudio(audio);
+			}
+			pending.deltas.length = 0;
+			if (pending.done) {
+				this.#handleTtsDone();
+			}
 		} catch (err) {
 			console.warn('TTS: AudioWorklet connect failed', err);
-			this.#ttsPlayer = null;
-			this.#ttsTrackId = null;
+			if (this.#ttsPendingAudio === pending) {
+				this.#ttsPendingAudio = null;
+			}
+			const failedPlayer = player;
+			if (failedPlayer && connectPromise) {
+				// connect() may still settle after the timeout; only then is it
+				// safe to tear the player down.
+				connectPromise
+					.catch(() => {})
+					.finally(() => {
+						this.#disposeTtsPlayer(failedPlayer).catch(() => {});
+					});
+			} else if (failedPlayer) {
+				this.#disposeTtsPlayer(failedPlayer).catch(() => {});
+			}
 		}
 	}
 
-	#handleTtsDelta(chunk: api.ThreadStreamAudioDeltaChunk) {
+	#writeTtsAudio(audio: string) {
 		if (!this.#ttsPlayer || !this.#ttsTrackId) return;
 		try {
-			this.#ttsPlayer.add16BitPCM(base64ToArrayBuffer(chunk.audio), this.#ttsTrackId);
+			this.#ttsPlayer.add16BitPCM(base64ToArrayBuffer(audio), this.#ttsTrackId);
 		} catch (err) {
 			console.warn('TTS: add16BitPCM failed', err);
 		}
 	}
 
+	#handleTtsDelta(chunk: api.ThreadStreamAudioDeltaChunk) {
+		if (this.#ttsPlayer && this.#ttsTrackId) {
+			this.#writeTtsAudio(chunk.audio);
+		} else if (this.#ttsPendingAudio) {
+			this.#ttsPendingAudio.deltas.push(chunk.audio);
+		}
+	}
+
 	#handleTtsDone() {
+		if (this.#ttsPendingAudio) {
+			// Player still connecting; finish once buffered audio is flushed.
+			this.#ttsPendingAudio.done = true;
+			return;
+		}
 		// Keep the speaker control visible until buffered audio fully drains.
 		this.#ttsPlayer?.finish();
 		this.#ttsTrackId = null;
 	}
 
 	#handleTtsError() {
+		this.#ttsGeneration += 1;
+		this.#ttsPendingAudio = null;
 		const player = this.#ttsPlayer;
 		this.#ttsPlayer = null;
 		this.#ttsTrackId = null;
@@ -1205,6 +1310,8 @@ export class ThreadManager {
 	 * Interrupt any active TTS playback.
 	 */
 	async interruptTts() {
+		this.#ttsGeneration += 1;
+		this.#ttsPendingAudio = null;
 		const player = this.#ttsPlayer;
 		if (player) {
 			this.#ttsPlayer = null;

--- a/web/pingpong/src/lib/stores/thread.ts
+++ b/web/pingpong/src/lib/stores/thread.ts
@@ -22,6 +22,7 @@ const TTS_SAMPLE_RATE = 24000;
  * policies block the context, and the chunk stream must keep flowing.
  */
 const TTS_CONNECT_TIMEOUT_MS = 2000;
+const MAX_PENDING_TTS_AUDIO_CHARS = 256 * 1024;
 
 /**
  * Audio chunks received while the TTS player is still connecting.
@@ -29,6 +30,8 @@ const TTS_CONNECT_TIMEOUT_MS = 2000;
 type PendingTtsAudio = {
 	deltas: string[];
 	done: boolean;
+	bufferedChars: number;
+	dropped: boolean;
 };
 
 /**
@@ -1191,7 +1194,14 @@ export class ThreadManager {
 
 	#handleTtsStarted() {
 		const generation = ++this.#ttsGeneration;
-		const pending: PendingTtsAudio = { deltas: [], done: false };
+		const stalePlayer = this.#ttsPlayer;
+		if (stalePlayer) {
+			this.#ttsPlayer = null;
+			this.#ttsTrackId = null;
+			this.#ttsPlaying.set(false);
+			this.#disposeTtsPlayer(stalePlayer).catch(() => {});
+		}
+		const pending: PendingTtsAudio = { deltas: [], done: false, bufferedChars: 0, dropped: false };
 		this.#ttsPendingAudio = pending;
 		void this.#startTtsPlayer(generation, pending);
 	}
@@ -1199,6 +1209,7 @@ export class ThreadManager {
 	async #startTtsPlayer(generation: number, pending: PendingTtsAudio) {
 		let player: WavStreamPlayer | null = null;
 		let connectPromise: Promise<true> | null = null;
+		let timeoutId: ReturnType<typeof setTimeout> | null = null;
 		try {
 			player = new WavStreamPlayer({
 				sampleRate: TTS_SAMPLE_RATE,
@@ -1215,18 +1226,25 @@ export class ThreadManager {
 				}
 			});
 			connectPromise = player.connect();
-			await Promise.race([
-				connectPromise,
-				new Promise<never>((_, reject) =>
-					setTimeout(
-						() =>
-							reject(
-								new Error(`TTS: AudioContext connect timed out after ${TTS_CONNECT_TIMEOUT_MS}ms`)
-							),
-						TTS_CONNECT_TIMEOUT_MS
-					)
-				)
-			]);
+			try {
+				await Promise.race([
+					connectPromise,
+					new Promise<never>((_, reject) => {
+						timeoutId = setTimeout(
+							() =>
+								reject(
+									new Error(`TTS: AudioContext connect timed out after ${TTS_CONNECT_TIMEOUT_MS}ms`)
+								),
+							TTS_CONNECT_TIMEOUT_MS
+						);
+					})
+				]);
+			} finally {
+				if (timeoutId) {
+					clearTimeout(timeoutId);
+					timeoutId = null;
+				}
+			}
 			if (generation !== this.#ttsGeneration) {
 				// Interrupted or superseded while connecting.
 				this.#disposeTtsPlayer(player).catch(() => {});
@@ -1251,16 +1269,9 @@ export class ThreadManager {
 				this.#ttsPendingAudio = null;
 			}
 			const failedPlayer = player;
-			if (failedPlayer && connectPromise) {
-				// connect() may still settle after the timeout; only then is it
-				// safe to tear the player down.
-				connectPromise
-					.catch(() => {})
-					.finally(() => {
-						this.#disposeTtsPlayer(failedPlayer).catch(() => {});
-					});
-			} else if (failedPlayer) {
+			if (failedPlayer) {
 				this.#disposeTtsPlayer(failedPlayer).catch(() => {});
+				connectPromise?.catch(() => {});
 			}
 		}
 	}
@@ -1278,6 +1289,14 @@ export class ThreadManager {
 		if (this.#ttsPlayer && this.#ttsTrackId) {
 			this.#writeTtsAudio(chunk.audio);
 		} else if (this.#ttsPendingAudio) {
+			if (this.#ttsPendingAudio.bufferedChars + chunk.audio.length > MAX_PENDING_TTS_AUDIO_CHARS) {
+				if (!this.#ttsPendingAudio.dropped) {
+					this.#ttsPendingAudio.dropped = true;
+					console.warn('TTS: dropping buffered audio while player is still connecting');
+				}
+				return;
+			}
+			this.#ttsPendingAudio.bufferedChars += chunk.audio.length;
 			this.#ttsPendingAudio.deltas.push(chunk.audio);
 		}
 	}

--- a/web/pingpong/src/lib/wavtools/index.ts
+++ b/web/pingpong/src/lib/wavtools/index.ts
@@ -32,6 +32,7 @@ import { AudioAnalysis } from './lib/analysis/audio_analysis';
 import { WavStreamPlayer } from './lib/wav_stream_player';
 import { WavRecorder } from './lib/wav_recorder';
 import { AUDIO_WORKLET_UNSUPPORTED_MESSAGE } from './lib/audio_support';
+import { getSharedAudioContext, unlockSharedAudioContext } from './lib/shared_audio_context';
 import { base64ToArrayBuffer } from './utils';
 
 export {
@@ -40,5 +41,7 @@ export {
 	WavStreamPlayer,
 	WavRecorder,
 	AUDIO_WORKLET_UNSUPPORTED_MESSAGE,
+	getSharedAudioContext,
+	unlockSharedAudioContext,
 	base64ToArrayBuffer
 };

--- a/web/pingpong/src/lib/wavtools/lib/fake_audio_context_test_util.ts
+++ b/web/pingpong/src/lib/wavtools/lib/fake_audio_context_test_util.ts
@@ -1,0 +1,62 @@
+import { vi } from 'vitest';
+
+/**
+ * Test-only stand-in for AudioContext, shaped to satisfy
+ * isAudioWorkletSupported() (audioWorklet must live on the prototype) and the
+ * calls WavStreamPlayer.connect()/close() make.
+ */
+export class FakeAudioContext {
+	state: AudioContextState = 'suspended';
+	sampleRate: number;
+	destination = {};
+	resume = vi.fn(() => {
+		this.state = 'running';
+		return Promise.resolve();
+	});
+	close = vi.fn(() => {
+		this.state = 'closed';
+		return Promise.resolve();
+	});
+	createAnalyser = vi.fn(() => ({
+		fftSize: 0,
+		smoothingTimeConstant: 0,
+		connect: vi.fn(),
+		disconnect: vi.fn()
+	}));
+	createGain = vi.fn(() => ({
+		gain: { value: 1 },
+		connect: vi.fn(),
+		disconnect: vi.fn()
+	}));
+	#audioWorklet = {
+		addModule: vi.fn(() => Promise.resolve())
+	};
+
+	constructor(options?: { sampleRate?: number }) {
+		this.sampleRate = options?.sampleRate ?? 44100;
+	}
+
+	// Class getter so 'audioWorklet' in AudioContext.prototype is true.
+	get audioWorklet() {
+		return this.#audioWorklet;
+	}
+}
+
+/**
+ * Install window/AudioContext/AudioWorkletNode globals so the wavtools audio
+ * support check passes. Returns the list of contexts constructed. Callers
+ * must run vi.unstubAllGlobals() afterwards.
+ */
+export function stubWebAudioGlobals(): FakeAudioContext[] {
+	const instances: FakeAudioContext[] = [];
+	class TrackingAudioContext extends FakeAudioContext {
+		constructor(options?: { sampleRate?: number }) {
+			super(options);
+			instances.push(this);
+		}
+	}
+	vi.stubGlobal('window', globalThis);
+	vi.stubGlobal('AudioContext', TrackingAudioContext);
+	vi.stubGlobal('AudioWorkletNode', class {});
+	return instances;
+}

--- a/web/pingpong/src/lib/wavtools/lib/shared_audio_context.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/shared_audio_context.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FakeAudioContext, stubWebAudioGlobals } from './fake_audio_context_test_util';
+
+// The module keeps per-sample-rate contexts in module state, so each test
+// imports a fresh copy.
+const loadModule = async () => await import('./shared_audio_context');
+
+describe('shared_audio_context', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('returns null when Web Audio is unavailable', async () => {
+		const { unlockSharedAudioContext, getSharedAudioContext } = await loadModule();
+
+		expect(unlockSharedAudioContext(24000)).toBeNull();
+		expect(getSharedAudioContext(24000)).toBeNull();
+	});
+
+	it('creates one context per sample rate, resumes it, and reuses it', async () => {
+		const instances = stubWebAudioGlobals();
+		const { unlockSharedAudioContext } = await loadModule();
+
+		const first = unlockSharedAudioContext(24000) as unknown as FakeAudioContext;
+		const second = unlockSharedAudioContext(24000) as unknown as FakeAudioContext;
+
+		expect(first).not.toBeNull();
+		expect(second).toBe(first);
+		expect(instances).toHaveLength(1);
+		expect(first.sampleRate).toBe(24000);
+		// Resumed while suspended, and only once: the second unlock sees the
+		// context already running.
+		expect(first.resume).toHaveBeenCalledTimes(1);
+		// The worklet module loads at most once per context.
+		expect(first.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+	});
+
+	it('replaces a context once it has been closed', async () => {
+		const instances = stubWebAudioGlobals();
+		const { unlockSharedAudioContext } = await loadModule();
+
+		const first = unlockSharedAudioContext(24000) as unknown as FakeAudioContext;
+		await first.close();
+		const second = unlockSharedAudioContext(24000) as unknown as FakeAudioContext;
+
+		expect(second).not.toBe(first);
+		expect(instances).toHaveLength(2);
+	});
+
+	it('retries the worklet module load after a failure', async () => {
+		stubWebAudioGlobals();
+		const { getSharedAudioContext, ensureStreamProcessorModule } = await loadModule();
+
+		const context = getSharedAudioContext(24000)!;
+		const addModule = (context as unknown as FakeAudioContext).audioWorklet.addModule;
+		addModule.mockRejectedValueOnce(new Error('blocked'));
+
+		await expect(ensureStreamProcessorModule(context)).rejects.toThrow('blocked');
+		await expect(ensureStreamProcessorModule(context)).resolves.toBeUndefined();
+		expect(addModule).toHaveBeenCalledTimes(2);
+	});
+});

--- a/web/pingpong/src/lib/wavtools/lib/shared_audio_context.ts
+++ b/web/pingpong/src/lib/wavtools/lib/shared_audio_context.ts
@@ -1,6 +1,8 @@
 import { StreamProcessorSrc } from './worklets/stream_processor';
 import { isAudioWorkletSupported } from './audio_support';
 
+// Long-lived contexts are intentional. TTS currently uses one sample rate, but
+// closed entries are pruned below so future rates do not accumulate stale refs.
 const contextsBySampleRate = new Map<number, AudioContext>();
 const workletLoads = new WeakMap<AudioContext, Promise<void>>();
 
@@ -18,6 +20,7 @@ export function getSharedAudioContext(sampleRate: number): AudioContext | null {
 	}
 	let context = contextsBySampleRate.get(sampleRate) ?? null;
 	if (context && context.state === 'closed') {
+		contextsBySampleRate.delete(sampleRate);
 		context = null;
 	}
 	if (!context) {

--- a/web/pingpong/src/lib/wavtools/lib/shared_audio_context.ts
+++ b/web/pingpong/src/lib/wavtools/lib/shared_audio_context.ts
@@ -1,0 +1,78 @@
+import { StreamProcessorSrc } from './worklets/stream_processor';
+import { isAudioWorkletSupported } from './audio_support';
+
+const contextsBySampleRate = new Map<number, AudioContext>();
+const workletLoads = new WeakMap<AudioContext, Promise<void>>();
+
+/**
+ * Get (or lazily create) the long-lived shared AudioContext for a sample rate.
+ *
+ * PCM written to the stream processor worklet plays at the context's rate, so
+ * callers must request the rate their audio is encoded at.
+ *
+ * Returns null when Web Audio / AudioWorklet is unavailable or creation fails.
+ */
+export function getSharedAudioContext(sampleRate: number): AudioContext | null {
+	if (!isAudioWorkletSupported()) {
+		return null;
+	}
+	let context = contextsBySampleRate.get(sampleRate) ?? null;
+	if (context && context.state === 'closed') {
+		context = null;
+	}
+	if (!context) {
+		try {
+			context = new AudioContext({ sampleRate });
+		} catch (err) {
+			console.warn('Shared AudioContext creation failed', err);
+			return null;
+		}
+		contextsBySampleRate.set(sampleRate, context);
+	}
+	return context;
+}
+
+/**
+ * Ensure the stream processor worklet module is loaded on a context, loading
+ * it at most once per context.
+ */
+export function ensureStreamProcessorModule(context: AudioContext): Promise<void> {
+	let load = workletLoads.get(context);
+	if (!load) {
+		load = context.audioWorklet.addModule(StreamProcessorSrc);
+		workletLoads.set(context, load);
+		load.catch(() => {
+			// Drop the cached rejection so the next call can retry.
+			if (workletLoads.get(context) === load) {
+				workletLoads.delete(context);
+			}
+		});
+	}
+	return load;
+}
+
+/**
+ * Synchronously create/resume the shared AudioContext and start loading its
+ * worklet module.
+ *
+ * MUST be called from within a user-gesture call stack. Safari only allows an
+ * AudioContext to start when it is created or resumed synchronously inside a
+ * gesture handler; a resume() issued later (e.g. when a network chunk arrives)
+ * can stay pending forever under autoplay policies, as can one issued from an
+ * embedded context such as an LTI iframe without autoplay delegation.
+ */
+export function unlockSharedAudioContext(sampleRate: number): AudioContext | null {
+	const context = getSharedAudioContext(sampleRate);
+	if (!context) {
+		return null;
+	}
+	if (context.state === 'suspended') {
+		context.resume().catch((err) => {
+			console.warn('Shared AudioContext resume failed', err);
+		});
+	}
+	void ensureStreamProcessorModule(context).catch(() => {
+		// Logged by the player when it tries to connect; unlock is best-effort.
+	});
+	return context;
+}

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { WavStreamPlayer } from './wav_stream_player';
+import { FakeAudioContext, stubWebAudioGlobals } from './fake_audio_context_test_util';
 
 describe('WavStreamPlayer', () => {
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
 	});
 
@@ -78,5 +80,43 @@ describe('WavStreamPlayer', () => {
 		player.finish();
 
 		expect(onPlaybackStopped).toHaveBeenCalledTimes(1);
+	});
+
+	it('reuses a provided context with a matching sample rate and never closes it', async () => {
+		const instances = stubWebAudioGlobals();
+		const shared = new FakeAudioContext({ sampleRate: 24000 });
+		const player = new WavStreamPlayer({
+			sampleRate: 24000,
+			context: shared as unknown as AudioContext
+		});
+
+		await player.connect();
+
+		// No context of its own was created.
+		expect(instances).toHaveLength(0);
+		expect(shared.resume).toHaveBeenCalledTimes(1);
+		expect(shared.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+
+		await player.close();
+		expect(shared.close).not.toHaveBeenCalled();
+	});
+
+	it('creates and closes its own context when the provided sample rate differs', async () => {
+		const instances = stubWebAudioGlobals();
+		const mismatched = new FakeAudioContext({ sampleRate: 48000 });
+		const player = new WavStreamPlayer({
+			sampleRate: 24000,
+			context: mismatched as unknown as AudioContext
+		});
+
+		await player.connect();
+
+		expect(instances).toHaveLength(1);
+		expect(instances[0].sampleRate).toBe(24000);
+		expect(mismatched.resume).not.toHaveBeenCalled();
+
+		await player.close();
+		expect(instances[0].close).toHaveBeenCalledTimes(1);
+		expect(mismatched.close).not.toHaveBeenCalled();
 	});
 });

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.test.ts
@@ -102,6 +102,7 @@ describe('WavStreamPlayer', () => {
 	});
 
 	it('creates and closes its own context when the provided sample rate differs', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		const instances = stubWebAudioGlobals();
 		const mismatched = new FakeAudioContext({ sampleRate: 48000 });
 		const player = new WavStreamPlayer({
@@ -114,6 +115,9 @@ describe('WavStreamPlayer', () => {
 		expect(instances).toHaveLength(1);
 		expect(instances[0].sampleRate).toBe(24000);
 		expect(mismatched.resume).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(
+			'Provided AudioContext sample rate 48000 does not match 24000; creating a dedicated context.'
+		);
 
 		await player.close();
 		expect(instances[0].close).toHaveBeenCalledTimes(1);

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
@@ -133,6 +133,15 @@ export class WavStreamPlayer {
 			this.context = this.providedContext;
 			this.ownsContext = false;
 		} else {
+			if (
+				this.providedContext &&
+				this.providedContext.state !== 'closed' &&
+				this.providedContext.sampleRate !== this.sampleRate
+			) {
+				console.warn(
+					`Provided AudioContext sample rate ${this.providedContext.sampleRate} does not match ${this.sampleRate}; creating a dedicated context.`
+				);
+			}
 			this.context = new AudioContext({ sampleRate: this.sampleRate });
 			this.ownsContext = true;
 		}

--- a/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
+++ b/web/pingpong/src/lib/wavtools/lib/wav_stream_player.ts
@@ -30,6 +30,7 @@
 import { StreamProcessorSrc } from './worklets/stream_processor';
 import { AudioAnalysis, type AudioAnalysisOutputType } from './analysis/audio_analysis';
 import { AUDIO_WORKLET_UNSUPPORTED_MESSAGE, isAudioWorkletSupported } from './audio_support';
+import { ensureStreamProcessorModule } from './shared_audio_context';
 
 export type OnAudioPartStartedProcessor = (data: {
 	trackId: string;
@@ -44,6 +45,13 @@ export type OnAudioPartEndedProcessor = (data: {
 export type OnPlaybackStoppedProcessor = () => void;
 interface WavStreamPlayerOptions {
 	sampleRate?: number;
+	/**
+	 * Externally owned AudioContext to play through (e.g. one unlocked during a
+	 * user gesture). Its sampleRate must match `sampleRate`; otherwise the
+	 * player falls back to creating its own context. A provided context is
+	 * never closed by this player.
+	 */
+	context?: AudioContext;
 	stopOnEmptyBuffer?: boolean;
 	onAudioPartStarted?: OnAudioPartStartedProcessor;
 	onAudioPartEnded?: OnAudioPartEndedProcessor;
@@ -66,6 +74,8 @@ const TRACK_SAMPLE_OFFSET_TIMEOUT_MS = 250;
 export class WavStreamPlayer {
 	private scriptSrc: string;
 	private sampleRate: number;
+	private providedContext: AudioContext | null;
+	private ownsContext: boolean;
 	private context: AudioContext | null;
 	private stream: AudioWorkletNode | null;
 	private analyser: AnalyserNode | null;
@@ -84,6 +94,7 @@ export class WavStreamPlayer {
 	 */
 	constructor({
 		sampleRate = 44100,
+		context,
 		stopOnEmptyBuffer = true,
 		onAudioPartStarted,
 		onAudioPartEnded,
@@ -91,6 +102,8 @@ export class WavStreamPlayer {
 	}: WavStreamPlayerOptions = {}) {
 		this.scriptSrc = StreamProcessorSrc;
 		this.sampleRate = sampleRate;
+		this.providedContext = context ?? null;
+		this.ownsContext = true;
 		this.context = null;
 		this.stream = null;
 		this.analyser = null;
@@ -112,12 +125,22 @@ export class WavStreamPlayer {
 			throw new Error(AUDIO_WORKLET_UNSUPPORTED_MESSAGE);
 		}
 
-		this.context = new AudioContext({ sampleRate: this.sampleRate });
+		if (
+			this.providedContext &&
+			this.providedContext.state !== 'closed' &&
+			this.providedContext.sampleRate === this.sampleRate
+		) {
+			this.context = this.providedContext;
+			this.ownsContext = false;
+		} else {
+			this.context = new AudioContext({ sampleRate: this.sampleRate });
+			this.ownsContext = true;
+		}
 		if (this.context.state === 'suspended') {
 			await this.context.resume();
 		}
 		try {
-			await this.context.audioWorklet.addModule(this.scriptSrc);
+			await ensureStreamProcessorModule(this.context);
 		} catch (e) {
 			throw new Error(`Could not add audioWorklet module: ${this.scriptSrc}`, { cause: e });
 		}
@@ -347,7 +370,10 @@ export class WavStreamPlayer {
 		if (this.context) {
 			const context = this.context;
 			this.context = null;
-			await context.close();
+			// A provided (shared) context outlives this player.
+			if (this.ownsContext) {
+				await context.close();
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Lecture Videos (Preview) & Lecture Slides (Under Development)
### Resolved Issues
* Fixed: Voice playback may fail to start in Lecture Videos and Lecture Slides when browser autoplay policies block audio setup after a message is sent, especially in Safari or embedded LMS iframes.
* Fixed: A Lecture Video or Lecture Slides chat response may appear stuck when text streaming waits for TTS audio playback setup to finish.
* Fixed: The beginning of generated voice audio may be dropped when audio chunks arrive before the playback engine is ready.
* Fixed: Interrupting or starting a new lesson chat response may leave an in-progress voice playback setup from the previous response alive.