### PR TITLE
change(ui): preserve lecture media aspect ratios

### DIFF
--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -216,8 +216,10 @@
 	function lectureSlidePageIndex(page: api.LectureSlidePage): number {
 		return lectureSlidePages.findIndex((item: api.LectureSlidePage) => item.id === page.id);
 	}
-	function handleLectureSlideImageLoad(event: Event) {
+	function handleLectureSlideImageLoad(event: Event, expectedImageUrl: string) {
 		const image = event.currentTarget as HTMLImageElement;
+
+		if (!image.isConnected || image.getAttribute('src') !== expectedImageUrl) return;
 
 		if (image.naturalWidth > 0 && image.naturalHeight > 0) {
 			lectureSlideMediaAspectRatio = image.naturalWidth / image.naturalHeight;
@@ -1797,7 +1799,7 @@
 									src={slideImageUrl}
 									alt={`Slide ${visiblePageIndex + 1}`}
 									class="h-full w-full object-contain"
-									onload={handleLectureSlideImageLoad}
+									onload={(event) => handleLectureSlideImageLoad(event, slideImageUrl)}
 								/>
 							{:else}
 								<div

--- a/web/pingpong/src/lib/components/ThreadDetailPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadDetailPage.svelte
@@ -171,9 +171,15 @@
 	$: lectureSlideCaptionsSrc = threadLectureSlideCaptionsAvailable
 		? api.getLectureSlideCaptionsUrl(classId, threadId)
 		: null;
+	let lectureSlideMediaAspectRatio: number | null = null;
+	let lectureSlideMediaAspectRatioDeckId: number | null = null;
 	$: lectureSlidePages = ((lectureSlideDeck?.pages ?? []) as api.LectureSlidePage[])
 		.slice()
 		.sort((a: api.LectureSlidePage, b: api.LectureSlidePage) => a.position - b.position);
+	$: if ((lectureSlideDeck?.id ?? null) !== lectureSlideMediaAspectRatioDeckId) {
+		lectureSlideMediaAspectRatioDeckId = lectureSlideDeck?.id ?? null;
+		lectureSlideMediaAspectRatio = null;
+	}
 	$: lectureSlideDurationMs = (() => {
 		if (lectureSlideDeck?.total_duration_ms && lectureSlideDeck.total_duration_ms > 0) {
 			return lectureSlideDeck.total_duration_ms;
@@ -209,6 +215,13 @@
 	}
 	function lectureSlidePageIndex(page: api.LectureSlidePage): number {
 		return lectureSlidePages.findIndex((item: api.LectureSlidePage) => item.id === page.id);
+	}
+	function handleLectureSlideImageLoad(event: Event) {
+		const image = event.currentTarget as HTMLImageElement;
+
+		if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+			lectureSlideMediaAspectRatio = image.naturalWidth / image.naturalHeight;
+		}
 	}
 	let runtimeLectureVideoAssistantMismatch = false;
 	let runtimeLectureVideoAssistantMismatchKey: string | null = null;
@@ -1769,6 +1782,7 @@
 				lessonMode="lecture_slides"
 				mediaKind="audio"
 				durationMsOverride={lectureSlideDurationMs}
+				mediaAspectRatio={lectureSlideMediaAspectRatio}
 				on:sessionchange={handleLectureSlideSessionChange}
 				on:playbackresumed={handleLecturePlaybackResumed}
 			>
@@ -1783,6 +1797,7 @@
 									src={slideImageUrl}
 									alt={`Slide ${visiblePageIndex + 1}`}
 									class="h-full w-full object-contain"
+									onload={handleLectureSlideImageLoad}
 								/>
 							{:else}
 								<div
@@ -1806,13 +1821,6 @@
 								</div>
 							</div>
 						{/if}
-						<div
-							class="absolute top-4 left-4 rounded-full bg-black/60 px-3 py-1 text-xs font-medium text-white"
-						>
-							{visiblePageIndex >= 0
-								? `Slide ${visiblePageIndex + 1} of ${lectureSlidePages.length}`
-								: 'Lecture Slides'}
-						</div>
 					</div>
 				{/snippet}
 				{#snippet chat(lectureSlideAtEnd = false)}

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -181,14 +181,35 @@
 			lessonThumbnailAspectRatio = '';
 		}
 	}
-	function handleLessonThumbnailLoad(event: Event) {
+	function handleLessonThumbnailLoad(event: Event, expectedThumbnailUrl: string) {
 		const image = event.currentTarget as HTMLImageElement;
+
+		if (
+			!image.isConnected ||
+			image.getAttribute('src') !== expectedThumbnailUrl ||
+			expectedThumbnailUrl !== lessonThumbnailUrl
+		) {
+			return;
+		}
 
 		if (image.naturalWidth > 0 && image.naturalHeight > 0) {
 			lessonThumbnailAspectRatio = `${image.naturalWidth} / ${image.naturalHeight}`;
 		}
 
 		lessonThumbnailLoaded = true;
+	}
+	function handleLessonThumbnailError(event: Event, expectedThumbnailUrl: string) {
+		const image = event.currentTarget as HTMLImageElement;
+
+		if (
+			!image.isConnected ||
+			image.getAttribute('src') !== expectedThumbnailUrl ||
+			expectedThumbnailUrl !== lessonThumbnailUrl
+		) {
+			return;
+		}
+
+		lessonThumbnailFailed = true;
 	}
 	// Whether billing is set up for the class (which controls everything).
 	$: hasVisibleAssistants = assistants.length > 0;
@@ -926,8 +947,8 @@
 								alt=""
 								class="absolute inset-0 h-full w-full object-cover transition-opacity"
 								class:opacity-0={!lessonThumbnailLoaded}
-								onload={handleLessonThumbnailLoad}
-								onerror={() => (lessonThumbnailFailed = true)}
+								onload={(event) => handleLessonThumbnailLoad(event, lessonThumbnailUrl)}
+								onerror={(event) => handleLessonThumbnailError(event, lessonThumbnailUrl)}
 							/>
 						</div>
 					{:else}

--- a/web/pingpong/src/lib/components/ThreadLandingPage.svelte
+++ b/web/pingpong/src/lib/components/ThreadLandingPage.svelte
@@ -164,6 +164,7 @@
 	$: assistantMeta = getAssistantMetadata(assistant);
 	let lessonThumbnailFailed = false;
 	let lessonThumbnailLoaded = false;
+	let lessonThumbnailAspectRatio = '';
 	let lessonThumbnailAssistantId: number | undefined;
 	$: lessonThumbnailUrl =
 		assistant.interaction_mode === 'lecture_video' && data?.class?.id && assistant.id
@@ -177,7 +178,17 @@
 			lessonThumbnailAssistantId = assistant.id;
 			lessonThumbnailFailed = false;
 			lessonThumbnailLoaded = false;
+			lessonThumbnailAspectRatio = '';
 		}
+	}
+	function handleLessonThumbnailLoad(event: Event) {
+		const image = event.currentTarget as HTMLImageElement;
+
+		if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+			lessonThumbnailAspectRatio = `${image.naturalWidth} / ${image.naturalHeight}`;
+		}
+
+		lessonThumbnailLoaded = true;
 	}
 	// Whether billing is set up for the class (which controls everything).
 	$: hasVisibleAssistants = assistants.length > 0;
@@ -896,7 +907,11 @@
 				{:else if assistant.interaction_mode === 'lecture_video' || assistant.interaction_mode === 'lecture_slides'}
 					<div class="h-[5%] max-h-8"></div>
 					{#if lessonThumbnailUrl && !lessonThumbnailFailed}
-						<div class="relative aspect-video w-full max-w-md overflow-hidden rounded-lg shadow-lg">
+						<div
+							class="relative w-full max-w-md overflow-hidden rounded-lg shadow-lg"
+							class:aspect-video={!lessonThumbnailAspectRatio}
+							style:aspect-ratio={lessonThumbnailAspectRatio || undefined}
+						>
 							{#if !lessonThumbnailLoaded}
 								<div class="flex h-full w-full items-center justify-center bg-blue-light-50">
 									{#if assistant.interaction_mode === 'lecture_slides'}
@@ -911,7 +926,7 @@
 								alt=""
 								class="absolute inset-0 h-full w-full object-cover transition-opacity"
 								class:opacity-0={!lessonThumbnailLoaded}
-								onload={() => (lessonThumbnailLoaded = true)}
+								onload={handleLessonThumbnailLoad}
 								onerror={() => (lessonThumbnailFailed = true)}
 							/>
 						</div>

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -103,6 +103,7 @@
 		paused = $bindable(true),
 		endedPlayback = $bindable(false),
 		effectiveVolume = $bindable(1),
+		mediaAspectRatio = $bindable(null),
 		ontimeupdate,
 		onseek,
 		onended,
@@ -135,6 +136,7 @@
 		paused?: boolean;
 		endedPlayback?: boolean;
 		effectiveVolume?: number;
+		mediaAspectRatio?: number | null;
 		ontimeupdate?: () => void;
 		onseek?: (toOffsetMs: number, fromOffsetMs: number) => void;
 		onended?: () => void;
@@ -307,6 +309,11 @@
 			: '--:-- / --:--'
 	);
 	let titleText = $derived(displayTitle.trim() || 'Lecture Video');
+	let measuredMediaAspectRatio = $derived(
+		mediaAspectRatio && Number.isFinite(mediaAspectRatio) && mediaAspectRatio > 0
+			? mediaAspectRatio
+			: null
+	);
 	let questionControlsLocked = $derived(questionPendingControls && maxSeekOffsetMs == null);
 	let captionsAvailable = $derived(Boolean(captionsSrc));
 	let captionOverlayBottomPx = $derived(
@@ -680,6 +687,13 @@
 	}
 
 	function handleLoadedMetadata() {
+		if (
+			videoElement instanceof HTMLVideoElement &&
+			videoElement.videoWidth > 0 &&
+			videoElement.videoHeight > 0
+		) {
+			mediaAspectRatio = videoElement.videoWidth / videoElement.videoHeight;
+		}
 		setMainVideoCurrentTime(startOffsetMs);
 	}
 
@@ -1313,7 +1327,9 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	bind:this={playerContainerElement}
-	class="relative aspect-video overflow-hidden rounded-3xl border border-slate-800/80 bg-black xl:h-full xl:w-full"
+	class="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-black"
+	class:aspect-video={measuredMediaAspectRatio == null}
+	style:aspect-ratio={measuredMediaAspectRatio ? String(measuredMediaAspectRatio) : undefined}
 	onkeydown={handleKeydown}
 	onmousemove={handleMouseMove}
 	onmouseenter={handleMouseEnter}

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -48,6 +48,7 @@
 	const ACTIVE_PAGE_RECOVERY_DEBOUNCE_MS = 150;
 	const COMPLETED_SEEK_TOLERANCE_MS = 2_000;
 	const DEFAULT_MEDIA_ASPECT_RATIO = 16 / 9;
+	const PLAYER_FRAME_CHROME_WIDTH = '1.625rem';
 	type InitErrorAction = 'refresh' | null;
 	type InitErrorState = {
 		detail: string;
@@ -148,11 +149,13 @@
 	let historyInteractions: LectureVideoInteractionHistoryItem[] = $state([]);
 	let initError = $state<InitErrorState | null>(null);
 	let sessionCleanupInFlight = false;
-	let playerMediaAspectRatio: number | null = $derived(
+	let inputMediaAspectRatio = $derived(
 		mediaAspectRatio && Number.isFinite(mediaAspectRatio) && mediaAspectRatio > 0
 			? mediaAspectRatio
 			: null
 	);
+	// Writable derived resets from slide-provided props and still accepts video metadata writes.
+	let playerMediaAspectRatio: number | null = $derived(inputMediaAspectRatio);
 
 	// Tracks which question we have already posted question_presented for
 	// to avoid duplicate posts.
@@ -197,12 +200,10 @@
 	let activePageRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
 	let initErrorCanRefresh = $derived(showRefreshAction && initError?.action === 'refresh');
 	let narrationVolume = $derived(playerVolume * LECTURE_NARRATION_VOLUME_SCALE);
-	let safePlayerMediaAspectRatio = $derived(
-		playerMediaAspectRatio && Number.isFinite(playerMediaAspectRatio) && playerMediaAspectRatio > 0
-			? playerMediaAspectRatio
-			: DEFAULT_MEDIA_ASPECT_RATIO
+	let safePlayerMediaAspectRatio = $derived(playerMediaAspectRatio ?? DEFAULT_MEDIA_ASPECT_RATIO);
+	let playerFrameStyle = $derived(
+		`--lecture-media-aspect-ratio: ${safePlayerMediaAspectRatio}; --lecture-player-frame-chrome: ${PLAYER_FRAME_CHROME_WIDTH};`
 	);
-	let playerFrameStyle = $derived(`--lecture-media-aspect-ratio: ${safePlayerMediaAspectRatio};`);
 	function shouldShowContinuePrompt(): boolean {
 		return (
 			(sessionState === 'awaiting_post_answer_resume' &&
@@ -2118,7 +2119,7 @@
 					/>
 				{:else if !isCompleted || canParticipate}
 					<div
-						class="mx-auto min-h-0 w-full max-w-[calc((40dvh-4rem)*var(--lecture-media-aspect-ratio)+1.625rem)] shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-white p-3 shadow-xl xl:max-w-[calc((50cqh-1.625rem)*var(--lecture-media-aspect-ratio)+1.625rem)]"
+						class="mx-auto min-h-0 w-full max-w-[calc((40dvh_-_4rem)_*_var(--lecture-media-aspect-ratio)_+_var(--lecture-player-frame-chrome))] shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-white p-3 shadow-xl xl:max-w-[calc((50cqh_-_var(--lecture-player-frame-chrome))_*_var(--lecture-media-aspect-ratio)_+_var(--lecture-player-frame-chrome))]"
 						style={playerFrameStyle}
 					>
 						<LectureVideoPlayer

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -47,6 +47,7 @@
 	const CONTROL_RECOVERY_GRACE_MS = 1_000;
 	const ACTIVE_PAGE_RECOVERY_DEBOUNCE_MS = 150;
 	const COMPLETED_SEEK_TOLERANCE_MS = 2_000;
+	const DEFAULT_MEDIA_ASPECT_RATIO = 16 / 9;
 	type InitErrorAction = 'refresh' | null;
 	type InitErrorState = {
 		detail: string;
@@ -76,6 +77,7 @@
 		lessonMode = 'lecture_video',
 		mediaKind = 'video',
 		durationMsOverride = null,
+		mediaAspectRatio = null,
 		visual = undefined
 	}: {
 		classId: number;
@@ -92,6 +94,7 @@
 		lessonMode?: LessonMode;
 		mediaKind?: 'video' | 'audio';
 		durationMsOverride?: number | null;
+		mediaAspectRatio?: number | null;
 		visual?: Snippet<[number]>;
 	} = $props();
 	const dispatch = createEventDispatcher<{
@@ -145,6 +148,11 @@
 	let historyInteractions: LectureVideoInteractionHistoryItem[] = $state([]);
 	let initError = $state<InitErrorState | null>(null);
 	let sessionCleanupInFlight = false;
+	let playerMediaAspectRatio: number | null = $derived(
+		mediaAspectRatio && Number.isFinite(mediaAspectRatio) && mediaAspectRatio > 0
+			? mediaAspectRatio
+			: null
+	);
 
 	// Tracks which question we have already posted question_presented for
 	// to avoid duplicate posts.
@@ -189,6 +197,12 @@
 	let activePageRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
 	let initErrorCanRefresh = $derived(showRefreshAction && initError?.action === 'refresh');
 	let narrationVolume = $derived(playerVolume * LECTURE_NARRATION_VOLUME_SCALE);
+	let safePlayerMediaAspectRatio = $derived(
+		playerMediaAspectRatio && Number.isFinite(playerMediaAspectRatio) && playerMediaAspectRatio > 0
+			? playerMediaAspectRatio
+			: DEFAULT_MEDIA_ASPECT_RATIO
+	);
+	let playerFrameStyle = $derived(`--lecture-media-aspect-ratio: ${safePlayerMediaAspectRatio};`);
 	function shouldShowContinuePrompt(): boolean {
 		return (
 			(sessionState === 'awaiting_post_answer_resume' &&
@@ -2086,7 +2100,7 @@
 			class="mx-auto flex h-full w-full max-w-screen-2xl flex-col gap-6 px-4 py-4 lg:px-6 xl:grid xl:grid-cols-5 xl:items-stretch xl:justify-center xl:gap-8 xl:py-6"
 		>
 			<div
-				class="col-span-3 flex max-h-[40%] min-h-0 min-w-0 shrink-0 flex-col gap-4 xl:h-full xl:max-h-none xl:shrink"
+				class="col-span-3 flex max-h-[40%] min-h-0 min-w-0 shrink-0 flex-col gap-4 xl:h-full xl:max-h-none xl:shrink xl:[container-type:size]"
 			>
 				{#if !canParticipate}
 					<div
@@ -2104,7 +2118,8 @@
 					/>
 				{:else if !isCompleted || canParticipate}
 					<div
-						class="mx-auto min-h-0 w-full max-w-[calc((40dvh-4rem)*16/9)] shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-white p-3 shadow-xl xl:max-h-[50%] xl:w-fit xl:max-w-none"
+						class="mx-auto min-h-0 w-full max-w-[calc((40dvh-4rem)*var(--lecture-media-aspect-ratio)+1.625rem)] shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-white p-3 shadow-xl xl:max-w-[calc((50cqh-1.625rem)*var(--lecture-media-aspect-ratio)+1.625rem)]"
+						style={playerFrameStyle}
 					>
 						<LectureVideoPlayer
 							src={lectureVideoSrc}
@@ -2112,6 +2127,7 @@
 							{mediaKind}
 							{durationMsOverride}
 							{visual}
+							bind:mediaAspectRatio={playerMediaAspectRatio}
 							displayTitle={sessionState === 'awaiting_answer'
 								? 'Answer the comprehension check to continue'
 								: title}


### PR DESCRIPTION
## Lecture Videos
### Updates & Improvements
* Lecture Video players now size the playback frame from the loaded video's actual aspect ratio instead of always using a 16:9 frame.

## Lecture Slides (Preview)
### Updates & Improvements
* Lecture Slides playback now sizes the shared player frame from the active slide image's aspect ratio, with a 16:9 fallback while slide media is loading.
* Removed the floating slide-count badge from the Lecture Slides playback surface.

## UI
### Updates & Improvements
* Lecture Video and Lecture Slides assistant thumbnails now preserve the original thumbnail aspect ratio after loading.
