### PR TITLE
feat(lessons): allow timeline bypass

### DIFF
--- a/alembic/versions/0a1b2c3d4e5f_add_lesson_timeline_bypass.py
+++ b/alembic/versions/0a1b2c3d4e5f_add_lesson_timeline_bypass.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
         sa.Column(
             "allow_lesson_timeline_bypass",
             sa.Boolean(),
-            server_default="false",
+            server_default=sa.false(),
             nullable=False,
         ),
     )

--- a/alembic/versions/0a1b2c3d4e5f_add_lesson_timeline_bypass.py
+++ b/alembic/versions/0a1b2c3d4e5f_add_lesson_timeline_bypass.py
@@ -1,0 +1,37 @@
+"""Add lesson timeline bypass assistant policy
+
+Revision ID: 0a1b2c3d4e5f
+Revises: 9f1a2b3c4d5e
+Create Date: 2026-06-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0a1b2c3d4e5f"
+down_revision: Union[str, None] = "9f1a2b3c4d5e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Resolves CodeQL's py/unused-global-variable
+    _ = revision, down_revision, branch_labels, depends_on
+    op.add_column(
+        "assistants",
+        sa.Column(
+            "allow_lesson_timeline_bypass",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("assistants", "allow_lesson_timeline_bypass")

--- a/pingpong/copy.py
+++ b/pingpong/copy.py
@@ -443,6 +443,7 @@ async def copy_assistant(
         elevenlabs_style=assistant.elevenlabs_style,
         elevenlabs_speed=assistant.elevenlabs_speed,
         assistant_should_message_first=assistant.assistant_should_message_first,
+        allow_lesson_timeline_bypass=assistant.allow_lesson_timeline_bypass,
         class_id=target_class_id,
         vector_store_id=new_vector_store_id,
         lecture_video_id=new_lecture_video_id,

--- a/pingpong/interactive_lesson_runtime.py
+++ b/pingpong/interactive_lesson_runtime.py
@@ -300,7 +300,7 @@ async def _reset_question_queue_for_offset(
                 adapter.get_questions(state.thread),
                 key=lambda item: item.stop_offset_ms,
             )
-            if question.stop_offset_ms > offset_ms
+            if question.stop_offset_ms >= offset_ms
             and question.id not in answered_question_ids
         ),
         None,
@@ -1162,6 +1162,10 @@ async def _handle_ended(
         raise InteractiveLessonValidationError(MSG_COMPLETE_FROM_SPOT_BLOCKED)
 
     _set_last_known_offset_ms(state, request.offset_ms)
+    if timeline_bypass_enabled and state.state != _state_enum(adapter).COMPLETED:
+        await _reset_question_queue_for_offset(
+            session, state, request.offset_ms, adapter=adapter
+        )
     await _append_interaction(
         session,
         state,

--- a/pingpong/interactive_lesson_runtime.py
+++ b/pingpong/interactive_lesson_runtime.py
@@ -78,6 +78,9 @@ class InteractiveLessonAdapter(Protocol):
     def lesson_chat_available(self, asset: object) -> bool:
         pass
 
+    def timeline_bypass_enabled(self, thread: models.Thread) -> bool:
+        pass
+
     def initial_state_fields(self) -> dict[str, Any]:
         pass
 
@@ -266,6 +269,48 @@ def _get_next_question(
     return None
 
 
+def _is_timeline_bypass_enabled(
+    thread: models.Thread, *, adapter: InteractiveLessonAdapter
+) -> bool:
+    return bool(adapter.timeline_bypass_enabled(thread))
+
+
+async def _get_answered_question_ids(
+    session: AsyncSession, state: LessonState, *, adapter: InteractiveLessonAdapter
+) -> set[int]:
+    return await adapter.interaction_model.get_answered_question_ids_by_thread_id(
+        session, state.thread_id
+    )
+
+
+async def _reset_question_queue_for_offset(
+    session: AsyncSession,
+    state: LessonState,
+    offset_ms: int,
+    *,
+    adapter: InteractiveLessonAdapter,
+) -> None:
+    answered_question_ids = await _get_answered_question_ids(
+        session, state, adapter=adapter
+    )
+    next_question = next(
+        (
+            question
+            for question in sorted(
+                adapter.get_questions(state.thread),
+                key=lambda item: item.stop_offset_ms,
+            )
+            if question.stop_offset_ms > offset_ms
+            and question.id not in answered_question_ids
+        ),
+        None,
+    )
+    state.active_option_id = None
+    state.active_option = None
+    state.current_question_id = next_question.id if next_question is not None else None
+    state.current_question = next_question
+
+
 def _build_continuation(
     thread: models.Thread, state: LessonState, *, adapter: InteractiveLessonAdapter
 ) -> schemas.InteractiveLessonContinuation | None:
@@ -331,6 +376,7 @@ def build_interactive_lesson_session(
         lesson_chat_available=bool(
             asset is not None and adapter.lesson_chat_available(asset)
         ),
+        timeline_bypass_enabled=_is_timeline_bypass_enabled(thread, adapter=adapter),
         last_known_offset_ms=state.last_known_offset_ms,
         furthest_offset_ms=furthest_offset_ms,
         latest_interaction_at=latest_interaction_at,
@@ -876,13 +922,16 @@ async def _handle_question_presented(
             "Question presentation must occur at the configured stop offset."
         )
 
-    plausible_offset_ms = await get_plausible_playback_offset_ms(
-        session, state, adapter=adapter, current_time=current_time
-    )
-    if request.offset_ms > plausible_offset_ms:
-        raise InteractiveLessonValidationError(
-            "Presenting a question past your unlocked progress is not allowed in this lecture video."
+    # With timeline bypass the participant may legitimately reach a checkpoint
+    # right after seeking near it, so plausible watched progress is no gate.
+    if not _is_timeline_bypass_enabled(state.thread, adapter=adapter):
+        plausible_offset_ms = await get_plausible_playback_offset_ms(
+            session, state, adapter=adapter, current_time=current_time
         )
+        if request.offset_ms > plausible_offset_ms:
+            raise InteractiveLessonValidationError(
+                "Presenting a question past your unlocked progress is not allowed in this lecture video."
+            )
 
     state.state = state_enum.AWAITING_ANSWER
     _set_last_known_offset_ms(state, request.offset_ms)
@@ -957,7 +1006,10 @@ async def _handle_resumed(
         plausible_offset_ms = await get_plausible_playback_offset_ms(
             session, state, adapter=adapter, current_time=current_time
         )
-        if request.offset_ms > plausible_offset_ms:
+        timeline_bypass_enabled = _is_timeline_bypass_enabled(
+            state.thread, adapter=adapter
+        )
+        if request.offset_ms > plausible_offset_ms and not timeline_bypass_enabled:
             raise InteractiveLessonValidationError(MSG_SKIP_AHEAD_BLOCKED)
         _set_last_known_offset_ms(state, request.offset_ms)
         await _append_interaction(
@@ -1032,7 +1084,8 @@ async def _handle_paused(
     plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, adapter=adapter, current_time=current_time
     )
-    if request.offset_ms > plausible_offset_ms:
+    timeline_bypass_enabled = _is_timeline_bypass_enabled(state.thread, adapter=adapter)
+    if request.offset_ms > plausible_offset_ms and not timeline_bypass_enabled:
         raise InteractiveLessonValidationError(MSG_PAUSE_AHEAD_OF_PROGRESS)
 
     _set_last_known_offset_ms(state, request.offset_ms)
@@ -1057,11 +1110,13 @@ async def _handle_seeked(
     event_type: schemas.InteractiveLessonInteractionEventType,
     current_time: datetime,
 ) -> None:
-    _require_playing_state_for_playback_event(state, adapter=adapter)
+    timeline_bypass_enabled = _is_timeline_bypass_enabled(state.thread, adapter=adapter)
+    if not timeline_bypass_enabled:
+        _require_playing_state_for_playback_event(state, adapter=adapter)
     plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, adapter=adapter, current_time=current_time
     )
-    if request.to_offset_ms > plausible_offset_ms:
+    if request.to_offset_ms > plausible_offset_ms and not timeline_bypass_enabled:
         raise InteractiveLessonValidationError(MSG_JUMP_AHEAD_BLOCKED)
 
     _set_seek_offset_ms(
@@ -1070,6 +1125,12 @@ async def _handle_seeked(
         to_offset_ms=request.to_offset_ms,
         plausible_offset_ms=plausible_offset_ms,
     )
+    state_enum = _state_enum(adapter)
+    if timeline_bypass_enabled and state.state != state_enum.COMPLETED:
+        await _reset_question_queue_for_offset(
+            session, state, request.to_offset_ms, adapter=adapter
+        )
+        state.state = state_enum.PLAYING
     await _append_interaction(
         session,
         state,
@@ -1096,7 +1157,8 @@ async def _handle_ended(
     plausible_offset_ms = await get_plausible_playback_offset_ms(
         session, state, adapter=adapter, current_time=current_time
     )
-    if request.offset_ms > plausible_offset_ms:
+    timeline_bypass_enabled = _is_timeline_bypass_enabled(state.thread, adapter=adapter)
+    if request.offset_ms > plausible_offset_ms and not timeline_bypass_enabled:
         raise InteractiveLessonValidationError(MSG_COMPLETE_FROM_SPOT_BLOCKED)
 
     _set_last_known_offset_ms(state, request.offset_ms)

--- a/pingpong/lecture_slide_runtime.py
+++ b/pingpong/lecture_slide_runtime.py
@@ -75,6 +75,9 @@ class LectureSlideAdapter:
         deck = cast(models.LectureSlideDeck, asset)
         return deck.context_version in {4, 5} and deck.lecture_slide_chat_available
 
+    def timeline_bypass_enabled(self, thread: models.Thread) -> bool:
+        return bool(thread.assistant and thread.assistant.allow_lesson_timeline_bypass)
+
     def initial_state_fields(self) -> dict[str, Any]:
         return {"last_chat_context_end_ms": 0}
 

--- a/pingpong/lecture_video_runtime.py
+++ b/pingpong/lecture_video_runtime.py
@@ -108,6 +108,9 @@ class LectureVideoAdapter:
         lecture_video = cast(models.LectureVideo, asset)
         return lecture_video.lecture_video_chat_available
 
+    def timeline_bypass_enabled(self, thread: models.Thread) -> bool:
+        return bool(thread.assistant and thread.assistant.allow_lesson_timeline_bypass)
+
     def initial_state_fields(self) -> dict[str, Any]:
         return {"last_chat_context_end_ms": 0}
 

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -3815,17 +3815,13 @@ class LectureSlideInteraction(Base):
     async def get_answered_question_ids_by_thread_id(
         cls, session: AsyncSession, thread_id: int
     ) -> set[int]:
-        stmt = select(LectureSlideInteraction.question_id).where(
+        stmt = select(distinct(LectureSlideInteraction.question_id)).where(
             LectureSlideInteraction.thread_id == thread_id,
             LectureSlideInteraction.question_id.is_not(None),
             LectureSlideInteraction.event_type
             == schemas.InteractiveLessonInteractionEventType.ANSWER_SUBMITTED,
         )
-        return {
-            int(question_id)
-            for question_id in await session.scalars(stmt)
-            if question_id is not None
-        }
+        return {int(question_id) for question_id in await session.scalars(stmt)}
 
 
 def _lecture_slide_post_narration_loader() -> Load:
@@ -4233,17 +4229,13 @@ class LectureVideoInteraction(Base):
     async def get_answered_question_ids_by_thread_id(
         cls, session: AsyncSession, thread_id: int
     ) -> set[int]:
-        stmt = select(LectureVideoInteraction.question_id).where(
+        stmt = select(distinct(LectureVideoInteraction.question_id)).where(
             LectureVideoInteraction.thread_id == thread_id,
             LectureVideoInteraction.question_id.is_not(None),
             LectureVideoInteraction.event_type
             == schemas.LectureVideoInteractionEventType.ANSWER_SUBMITTED,
         )
-        return {
-            int(question_id)
-            for question_id in await session.scalars(stmt)
-            if question_id is not None
-        }
+        return {int(question_id) for question_id in await session.scalars(stmt)}
 
 
 class S3File(Base):

--- a/pingpong/models.py
+++ b/pingpong/models.py
@@ -3811,6 +3811,22 @@ class LectureSlideInteraction(Base):
         )
         return await session.scalar(stmt)
 
+    @classmethod
+    async def get_answered_question_ids_by_thread_id(
+        cls, session: AsyncSession, thread_id: int
+    ) -> set[int]:
+        stmt = select(LectureSlideInteraction.question_id).where(
+            LectureSlideInteraction.thread_id == thread_id,
+            LectureSlideInteraction.question_id.is_not(None),
+            LectureSlideInteraction.event_type
+            == schemas.InteractiveLessonInteractionEventType.ANSWER_SUBMITTED,
+        )
+        return {
+            int(question_id)
+            for question_id in await session.scalars(stmt)
+            if question_id is not None
+        }
+
 
 def _lecture_slide_post_narration_loader() -> Load:
     return selectinload(LectureSlideQuestionOption.post_narration).selectinload(
@@ -3846,7 +3862,10 @@ def _thread_lecture_slide_base_loaders() -> tuple[Load, ...]:
             User.email,
         ),
         selectinload(Thread.assistant).load_only(
-            Assistant.id, Assistant.name, Assistant.lecture_slide_deck_id
+            Assistant.id,
+            Assistant.name,
+            Assistant.lecture_slide_deck_id,
+            Assistant.allow_lesson_timeline_bypass,
         ),
         selectinload(Thread.lecture_slide_deck).options(
             undefer(LectureSlideDeck.transcript_data),
@@ -3916,7 +3935,10 @@ def _thread_lecture_video_base_loaders() -> tuple[Load, ...]:
             User.email,
         ),
         selectinload(Thread.assistant).load_only(
-            Assistant.id, Assistant.name, Assistant.lecture_video_id
+            Assistant.id,
+            Assistant.name,
+            Assistant.lecture_video_id,
+            Assistant.allow_lesson_timeline_bypass,
         ),
         selectinload(Thread.lecture_video).options(
             undefer(LectureVideo.manifest_data),
@@ -4206,6 +4228,22 @@ class LectureVideoInteraction(Base):
             .limit(1)
         )
         return await session.scalar(stmt)
+
+    @classmethod
+    async def get_answered_question_ids_by_thread_id(
+        cls, session: AsyncSession, thread_id: int
+    ) -> set[int]:
+        stmt = select(LectureVideoInteraction.question_id).where(
+            LectureVideoInteraction.thread_id == thread_id,
+            LectureVideoInteraction.question_id.is_not(None),
+            LectureVideoInteraction.event_type
+            == schemas.LectureVideoInteractionEventType.ANSWER_SUBMITTED,
+        )
+        return {
+            int(question_id)
+            for question_id in await session.scalars(stmt)
+            if question_id is not None
+        }
 
 
 class S3File(Base):
@@ -5133,6 +5171,9 @@ class Assistant(Base):
     elevenlabs_style = Column(Float, nullable=True)
     elevenlabs_speed = Column(Float, nullable=True)
     assistant_should_message_first = Column(Boolean, server_default="false")
+    allow_lesson_timeline_bypass = Column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     should_record_user_information = Column(Boolean, server_default="false")
     disable_prompt_randomization = Column(
         Boolean, nullable=False, server_default="false"

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -660,6 +660,7 @@ class InteractiveLessonSessionController(BaseModel):
 class InteractiveLessonSession(BaseModel):
     state: InteractiveLessonSessionState
     lesson_chat_available: bool = False
+    timeline_bypass_enabled: bool = False
     last_known_offset_ms: int | None = None
     furthest_offset_ms: int | None = Field(None, ge=0)
     latest_interaction_at: datetime | None = None
@@ -1411,6 +1412,7 @@ class LectureVideoSessionController(BaseModel):
 class LectureVideoSession(BaseModel):
     state: LectureVideoSessionState
     lecture_video_chat_available: bool = False
+    timeline_bypass_enabled: bool = False
     last_known_offset_ms: int | None = None
     furthest_offset_ms: int | None = Field(None, ge=0)
     latest_interaction_at: datetime | None = None
@@ -1559,6 +1561,7 @@ class Assistant(BaseModel):
     creator_id: int
     locked: bool = False
     assistant_should_message_first: bool | None = None
+    allow_lesson_timeline_bypass: bool = False
     should_record_user_information: bool | None = None
     disable_prompt_randomization: bool | None = None
     allow_user_file_uploads: bool | None = None
@@ -1917,6 +1920,7 @@ class CreateAssistant(BaseModel):
     use_image_descriptions: bool = False
     hide_prompt: bool = False
     assistant_should_message_first: bool = False
+    allow_lesson_timeline_bypass: bool = False
     should_record_user_information: bool = False
     disable_prompt_randomization: bool = False
     allow_user_file_uploads: bool = True
@@ -2029,6 +2033,7 @@ class UpdateAssistant(BaseModel):
     use_latex: bool | None = None
     hide_prompt: bool | None = None
     assistant_should_message_first: bool | None = None
+    allow_lesson_timeline_bypass: bool | None = None
     should_record_user_information: bool | None = None
     disable_prompt_randomization: bool | None = None
     allow_user_file_uploads: bool | None = None

--- a/pingpong/schemas.py
+++ b/pingpong/schemas.py
@@ -1607,6 +1607,13 @@ def lecture_video_validator_create_assistant(self):
         if "overwrite_manifest" in self.model_fields_set
         else False
     )
+    if self.allow_lesson_timeline_bypass and self.interaction_mode not in {
+        InteractionMode.LECTURE_VIDEO,
+        InteractionMode.LECTURE_SLIDES,
+    }:
+        raise ValueError(
+            "allow_lesson_timeline_bypass can only be set for lecture lesson assistants."
+        )
     if self.interaction_mode == InteractionMode.LECTURE_VIDEO:
         if self.lecture_video_id is None:
             raise ValueError(

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -12918,6 +12918,12 @@ async def update_assistant(
         asst.should_record_user_information = req.should_record_user_information
 
     if (
+        "allow_lesson_timeline_bypass" in req.model_fields_set
+        and req.allow_lesson_timeline_bypass is not None
+    ):
+        asst.allow_lesson_timeline_bypass = req.allow_lesson_timeline_bypass
+
+    if (
         "allow_user_file_uploads" in req.model_fields_set
         and req.allow_user_file_uploads is not None
     ):

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -12039,6 +12039,15 @@ async def update_assistant(
             status_code=400,
             detail="Lecture video data and lecture slide data cannot be updated together.",
         )
+    if (
+        "allow_lesson_timeline_bypass" in req.model_fields_set
+        and req.allow_lesson_timeline_bypass is True
+        and not is_lesson_mode
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="allow_lesson_timeline_bypass can only be set for lecture lesson assistants.",
+        )
 
     if lecture_video_fields_present:
         if not is_video:

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -556,6 +556,43 @@ async def test_lecture_slide_timeline_bypass_seek_recomputes_question_queue(
 
 
 @with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_seek_to_exact_checkpoint_keeps_question(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="seek-to-first-checkpoint",
+                from_offset_ms=0,
+                to_offset_ms=questions[0].stop_offset_ms,
+            ),
+        )
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.PLAYING
+    assert slide_session.current_question is not None
+    assert slide_session.current_question.id == questions[0].id
+
+
+@with_institution(11, "Test Institution")
 async def test_lecture_slide_timeline_bypass_seek_clears_pending_question(
     db, institution
 ):
@@ -608,6 +645,78 @@ async def test_lecture_slide_timeline_bypass_seek_clears_pending_question(
     assert slide_session.current_question is not None
     assert slide_session.current_question.id == questions[1].id
     assert slide_session.current_continuation is None
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_seek_clears_post_answer_continuation(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+        first_question = questions[0]
+        first_option = first_question.options[0]
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonQuestionPresentedRequest(
+                type="question_presented",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="present-before-post-answer-seek",
+                question_id=first_question.id,
+                offset_ms=first_question.stop_offset_ms,
+            ),
+        )
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonAnswerSubmittedRequest(
+                type="answer_submitted",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="answer-before-post-answer-seek",
+                question_id=first_question.id,
+                option_id=first_option.id,
+            ),
+        )
+        assert (
+            slide_session.state
+            == schemas.InteractiveLessonSessionState.AWAITING_POST_ANSWER_RESUME
+        )
+        assert slide_session.current_continuation is not None
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="seek-out-of-post-answer",
+                from_offset_ms=first_question.stop_offset_ms,
+                to_offset_ms=2_000,
+            ),
+        )
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.PLAYING
+    assert slide_session.current_continuation is None
+    assert slide_session.current_question is not None
+    assert slide_session.current_question.id == questions[1].id
 
 
 @with_institution(11, "Test Institution")
@@ -719,6 +828,47 @@ async def test_lecture_slide_timeline_bypass_seek_keeps_completed_state(
     assert slide_session.current_question is None
     assert slide_session.last_known_offset_ms == 1_000
     assert slide_session.furthest_offset_ms == 10_000
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_ended_recomputes_question_queue(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, _ = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonEndedRequest(
+                type="lesson_ended",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="complete-after-skip-to-end",
+                offset_ms=10_000,
+            ),
+        )
+        interactions = await _list_slide_interactions(session, thread.id)
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.COMPLETED
+    assert slide_session.current_question is None
+    assert [interaction.event_type for interaction in interactions] == [
+        schemas.InteractiveLessonInteractionEventType.SESSION_INITIALIZED,
+        schemas.InteractiveLessonInteractionEventType.LESSON_ENDED,
+        schemas.InteractiveLessonInteractionEventType.SESSION_COMPLETED,
+    ]
 
 
 @with_institution(11, "Test Institution")

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -46,6 +46,7 @@ async def _create_slide_runtime_fixture(
     institution: models.Institution,
     *,
     with_questions: bool = True,
+    allow_lesson_timeline_bypass: bool = False,
 ) -> tuple[
     models.Class,
     models.LectureSlideDeck,
@@ -79,6 +80,7 @@ async def _create_slide_runtime_fixture(
         use_latex=False,
         use_image_descriptions=False,
         hide_prompt=False,
+        allow_lesson_timeline_bypass=allow_lesson_timeline_bypass,
     )
     thread = models.Thread(
         id=1,
@@ -420,6 +422,303 @@ async def test_process_lecture_slide_question_answer_and_resume(db, institution)
         schemas.InteractiveLessonInteractionEventType.ANSWER_SUBMITTED,
         schemas.InteractiveLessonInteractionEventType.LESSON_RESUMED,
     ]
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_seek_rejects_forward_jump_without_bypass(db, institution):
+    async with db.async_session() as session:
+        _, _, _, thread, _ = await _create_slide_runtime_fixture(session, institution)
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        with pytest.raises(lecture_slide_runtime.LectureSlideValidationError) as exc:
+            await lecture_slide_runtime.process_interaction(
+                session,
+                thread.id,
+                actor_user_id=123,
+                request=schemas.InteractiveLessonSeekedRequest(
+                    type="lesson_seeked",
+                    controller_session_id=controller_session_id,
+                    expected_state_version=slide_session.state_version,
+                    idempotency_key="blocked-forward-seek",
+                    from_offset_ms=0,
+                    to_offset_ms=3_000,
+                ),
+            )
+
+    assert (
+        str(exc.value)
+        == "You cannot jump ahead yet. Continue from where the lesson left off."
+    )
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_seek_recomputes_question_queue(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+        assert slide_session.timeline_bypass_enabled is True
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="skip-first-question",
+                from_offset_ms=0,
+                to_offset_ms=2_000,
+            ),
+        )
+        assert slide_session.state == schemas.InteractiveLessonSessionState.PLAYING
+        assert slide_session.last_known_offset_ms == 2_000
+        assert slide_session.furthest_offset_ms == 2_000
+        assert slide_session.current_question is not None
+        assert slide_session.current_question.id == questions[1].id
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="skip-all-questions",
+                from_offset_ms=2_000,
+                to_offset_ms=5_000,
+            ),
+        )
+        assert slide_session.current_question is None
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="reactivate-second-question",
+                from_offset_ms=5_000,
+                to_offset_ms=2_000,
+            ),
+        )
+        assert slide_session.current_question is not None
+        assert slide_session.current_question.id == questions[1].id
+        assert slide_session.furthest_offset_ms == 5_000
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="reactivate-first-question",
+                from_offset_ms=2_000,
+                to_offset_ms=500,
+            ),
+        )
+        interactions = await _list_slide_interactions(session, thread.id)
+
+    assert slide_session.current_question is not None
+    assert slide_session.current_question.id == questions[0].id
+    assert [interaction.event_type for interaction in interactions] == [
+        schemas.InteractiveLessonInteractionEventType.SESSION_INITIALIZED,
+        schemas.InteractiveLessonInteractionEventType.LESSON_SEEKED,
+        schemas.InteractiveLessonInteractionEventType.LESSON_SEEKED,
+        schemas.InteractiveLessonInteractionEventType.LESSON_SEEKED,
+        schemas.InteractiveLessonInteractionEventType.LESSON_SEEKED,
+    ]
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_seek_clears_pending_question(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonQuestionPresentedRequest(
+                type="question_presented",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="present-first-before-seek",
+                question_id=questions[0].id,
+                offset_ms=questions[0].stop_offset_ms,
+            ),
+        )
+        assert (
+            slide_session.state == schemas.InteractiveLessonSessionState.AWAITING_ANSWER
+        )
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="seek-out-of-pending-question",
+                from_offset_ms=questions[0].stop_offset_ms,
+                to_offset_ms=2_000,
+            ),
+        )
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.PLAYING
+    assert slide_session.current_question is not None
+    assert slide_session.current_question.id == questions[1].id
+    assert slide_session.current_continuation is None
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_allows_presenting_question_after_seek(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, questions = await _create_slide_runtime_fixture(
+            session, institution, allow_lesson_timeline_bypass=True
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        # Jump past the first question to a spot still ahead of plausible
+        # watched progress for the second question's checkpoint.
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="seek-near-second-question",
+                from_offset_ms=0,
+                to_offset_ms=1_500,
+            ),
+        )
+        assert slide_session.current_question is not None
+        assert slide_session.current_question.id == questions[1].id
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonQuestionPresentedRequest(
+                type="question_presented",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="present-second-after-seek",
+                question_id=questions[1].id,
+                offset_ms=questions[1].stop_offset_ms,
+            ),
+        )
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.AWAITING_ANSWER
+    assert slide_session.current_question is not None
+    assert slide_session.current_question.id == questions[1].id
+    assert slide_session.last_known_offset_ms == questions[1].stop_offset_ms
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_timeline_bypass_seek_keeps_completed_state(
+    db, institution
+):
+    async with db.async_session() as session:
+        _, _, _, thread, _ = await _create_slide_runtime_fixture(
+            session,
+            institution,
+            with_questions=False,
+            allow_lesson_timeline_bypass=True,
+        )
+
+        (
+            controller_session_id,
+            slide_session,
+        ) = await lecture_slide_runtime.acquire_control(
+            session,
+            thread.id,
+            actor_user_id=123,
+        )
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonEndedRequest(
+                type="lesson_ended",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="complete-lesson",
+                offset_ms=10_000,
+            ),
+        )
+        assert slide_session.state == schemas.InteractiveLessonSessionState.COMPLETED
+
+        slide_session = await lecture_slide_runtime.process_interaction(
+            session,
+            thread.id,
+            actor_user_id=123,
+            request=schemas.InteractiveLessonSeekedRequest(
+                type="lesson_seeked",
+                controller_session_id=controller_session_id,
+                expected_state_version=slide_session.state_version,
+                idempotency_key="seek-back-after-complete",
+                from_offset_ms=10_000,
+                to_offset_ms=1_000,
+            ),
+        )
+
+    assert slide_session.state == schemas.InteractiveLessonSessionState.COMPLETED
+    assert slide_session.current_question is None
+    assert slide_session.last_known_offset_ms == 1_000
+    assert slide_session.furthest_offset_ms == 10_000
 
 
 @with_institution(11, "Test Institution")

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -895,6 +895,7 @@ async def create_ready_lecture_video_assistant(
     lecture_video_id: int = 1,
     video_key: str = "lecture-runtime.mp4",
     manifest: dict | None = None,
+    allow_lesson_timeline_bypass: bool = False,
 ):
     class_ = models.Class(
         id=class_id,
@@ -966,6 +967,7 @@ async def create_ready_lecture_video_assistant(
         use_latex=False,
         use_image_descriptions=False,
         hide_prompt=False,
+        allow_lesson_timeline_bypass=allow_lesson_timeline_bypass,
     )
     session.add(assistant)
     await session.commit()
@@ -3450,6 +3452,90 @@ async def test_lecture_video_interactions_reject_seek_with_forged_from_offset(
         response.json()["detail"]
         == "You cannot jump ahead yet. Continue from where the lesson left off."
     )
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_create_thread", "class:1"),
+        ("user:123", "student", "class:1"),
+    ]
+)
+async def test_lecture_video_timeline_bypass_allows_forward_seek_and_backseek_reactivation(
+    api, authz, config, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_, _lecture_video, _assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+            allow_lesson_timeline_bypass=True,
+        )
+
+    create_response = api.post(
+        f"/api/v1/class/{class_.id}/thread/lecture",
+        json={"assistant_id": 1, "parties": [123]},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert create_response.status_code == 200
+    thread_id = create_response.json()["thread"]["id"]
+    await grant_thread_permissions(config, thread_id, 123)
+
+    acquire = api.post(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}/lecture-video/control/acquire",
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert acquire.status_code == 200
+    controller_session_id = acquire.json()["controller_session_id"]
+    acquired_session = acquire.json()["lecture_video_session"]
+    assert acquired_session["timeline_bypass_enabled"] is True
+
+    seek_past_question = api.post(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}/lecture-video/interactions",
+        json={
+            "type": "video_seeked",
+            "controller_session_id": controller_session_id,
+            "expected_state_version": acquired_session["state_version"],
+            "idempotency_key": "timeline-bypass-skip-question",
+            "from_offset_ms": 0,
+            "to_offset_ms": 2_000,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert seek_past_question.status_code == 200
+    skipped_session = seek_past_question.json()["lecture_video_session"]
+    assert skipped_session["last_known_offset_ms"] == 2_000
+    assert skipped_session["furthest_offset_ms"] == 2_000
+    assert skipped_session["current_question"] is None
+
+    seek_back_before_question = api.post(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}/lecture-video/interactions",
+        json={
+            "type": "video_seeked",
+            "controller_session_id": controller_session_id,
+            "expected_state_version": skipped_session["state_version"],
+            "idempotency_key": "timeline-bypass-reactivate-question",
+            "from_offset_ms": 2_000,
+            "to_offset_ms": 500,
+        },
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert seek_back_before_question.status_code == 200
+    reactivated_session = seek_back_before_question.json()["lecture_video_session"]
+    assert reactivated_session["current_question"] is not None
+    assert reactivated_session["current_question"]["stop_offset_ms"] == 1_000
+    assert reactivated_session["furthest_offset_ms"] == 2_000
+
+    async with db.async_session() as session:
+        interactions = await models.LectureVideoInteraction.list_by_thread_id(
+            session, thread_id
+        )
+
+    assert [interaction.event_type for interaction in interactions] == [
+        schemas.LectureVideoInteractionEventType.SESSION_INITIALIZED,
+        schemas.LectureVideoInteractionEventType.VIDEO_SEEKED,
+        schemas.LectureVideoInteractionEventType.VIDEO_SEEKED,
+    ]
 
 
 @with_user(123)
@@ -9493,6 +9579,51 @@ async def test_update_assistant_with_same_lecture_video_config_is_a_no_op(
     assert refreshed_video is not None
     assert refreshed_video.voice_id == DEFAULT_LECTURE_VIDEO_VOICE_ID
     assert question == "No-op question?"
+
+
+@with_user(123)
+@with_institution(11, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
+async def test_update_assistant_timeline_bypass_does_not_clone_lecture_video(
+    api, db, institution, valid_user_token, monkeypatch
+):
+    patch_lecture_video_model_list(monkeypatch)
+
+    async with db.async_session() as session:
+        class_, lecture_video, assistant = await create_ready_lecture_video_assistant(
+            session,
+            institution,
+        )
+        assistant.creator_id = 123
+        session.add(assistant)
+        await session.commit()
+
+    update_response = api.put(
+        f"/api/v1/class/{class_.id}/assistant/{assistant.id}",
+        json={"allow_lesson_timeline_bypass": True},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["allow_lesson_timeline_bypass"] is True
+    assert update_response.json()["lecture_video"]["id"] == lecture_video.id
+
+    async with db.async_session() as session:
+        refreshed_assistant = await session.get(models.Assistant, assistant.id)
+        lecture_video_count = await session.scalar(
+            select(func.count()).select_from(models.LectureVideo)
+        )
+        refreshed_video = await session.get(models.LectureVideo, lecture_video.id)
+
+    assert refreshed_assistant is not None
+    assert refreshed_assistant.allow_lesson_timeline_bypass is True
+    assert refreshed_assistant.lecture_video_id == lecture_video.id
+    assert lecture_video_count == 1
+    assert refreshed_video is not None
 
 
 @with_user(123)

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -21,6 +21,35 @@ async def _async_return(value):
     return value
 
 
+def test_lesson_timeline_bypass_schema_defaults():
+    create_request = schemas.CreateAssistant(
+        name="Timeline Test",
+        instructions="Be helpful",
+        description="Test assistant",
+        model="gpt-4o-mini",
+    )
+    update_request = schemas.UpdateAssistant()
+
+    assert create_request.allow_lesson_timeline_bypass is False
+    assert update_request.allow_lesson_timeline_bypass is None
+    assert (
+        schemas.InteractiveLessonSession(
+            state=schemas.InteractiveLessonSessionState.PLAYING,
+            state_version=1,
+            controller=schemas.InteractiveLessonSessionController(),
+        ).timeline_bypass_enabled
+        is False
+    )
+    assert (
+        schemas.LectureVideoSession(
+            state=schemas.LectureVideoSessionState.PLAYING,
+            state_version=1,
+            controller=schemas.LectureVideoSessionController(),
+        ).timeline_bypass_enabled
+        is False
+    )
+
+
 @with_user(123)
 @with_institution(11, "Harvard Kennedy School")
 @with_authz(grants=[])
@@ -1755,6 +1784,7 @@ async def test_copy_assistant_within_class(
             creator_id=123,
             published=None,
             version=3,
+            allow_lesson_timeline_bypass=True,
         )
         session.add_all([class_, assistant])
         await session.commit()
@@ -1774,11 +1804,13 @@ async def test_copy_assistant_within_class(
     assert data["name"].endswith(" (Copy)")
     assert len(data["name"]) == 100
     assert data["published"] is None
+    assert data["allow_lesson_timeline_bypass"] is True
 
     async with db.async_session() as session:
         saved = await models.Assistant.get_by_id(session, data["id"])
         assert saved.instructions == original_instructions
         assert saved.creator_id == creator_id
+        assert saved.allow_lesson_timeline_bypass is True
 
     assert await authz.get_all_calls() == [
         ("grant", f"class:{class_id}", "parent", f"assistant:{data['id']}"),

--- a/pingpong/test_server.py
+++ b/pingpong/test_server.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import select
 
 from pingpong import models
@@ -48,6 +49,70 @@ def test_lesson_timeline_bypass_schema_defaults():
         ).timeline_bypass_enabled
         is False
     )
+
+
+def test_create_assistant_rejects_timeline_bypass_for_non_lecture_mode():
+    with pytest.raises(
+        ValidationError,
+        match="allow_lesson_timeline_bypass can only be set for lecture lesson assistants",
+    ):
+        schemas.CreateAssistant(
+            name="Timeline Test",
+            instructions="Be helpful",
+            description="Test assistant",
+            model="gpt-4o-mini",
+            interaction_mode=schemas.InteractionMode.CHAT,
+            allow_lesson_timeline_bypass=True,
+        )
+
+
+@with_user(123)
+@with_institution(1, "Test Institution")
+@with_authz(
+    grants=[
+        ("user:123", "can_edit", "assistant:1"),
+        ("user:123", "admin", "class:1"),
+    ]
+)
+async def test_update_assistant_rejects_timeline_bypass_for_non_lecture_mode(
+    api, db, institution, valid_user_token
+):
+    async with db.async_session() as session:
+        class_ = models.Class(
+            id=1, name="Test Class", institution_id=institution.id, api_key="test-key"
+        )
+        assistant = models.Assistant(
+            id=1,
+            name="Chat Assistant",
+            instructions="Be helpful",
+            description="original",
+            interaction_mode=schemas.InteractionMode.CHAT,
+            model="gpt-4o-mini",
+            temperature=0.2,
+            class_id=class_.id,
+            tools="[]",
+            creator_id=123,
+            published=None,
+            version=3,
+        )
+        session.add_all([class_, assistant])
+        await session.commit()
+
+    response = api.put(
+        "/api/v1/class/1/assistant/1",
+        json={"allow_lesson_timeline_bypass": True},
+        headers={"Authorization": f"Bearer {valid_user_token}"},
+    )
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "allow_lesson_timeline_bypass can only be set for lecture lesson assistants."
+    )
+
+    async with db.async_session() as session:
+        saved = await session.get(models.Assistant, 1)
+        assert saved is not None
+        assert saved.allow_lesson_timeline_bypass is False
 
 
 @with_user(123)

--- a/web/pingpong/src/lib/api.ts
+++ b/web/pingpong/src/lib/api.ts
@@ -1772,6 +1772,7 @@ export type InteractiveLessonSessionController = {
 export type InteractiveLessonSession = {
 	state: InteractiveLessonSessionState;
 	lesson_chat_available: boolean;
+	timeline_bypass_enabled: boolean;
 	last_known_offset_ms: number | null;
 	furthest_offset_ms: number | null;
 	latest_interaction_at: string | null;
@@ -1978,6 +1979,7 @@ export type LectureVideoSessionController = {
 export type LectureVideoSession = {
 	state: LectureVideoSessionState;
 	lecture_video_chat_available: boolean;
+	timeline_bypass_enabled: boolean;
 	last_known_offset_ms: number | null;
 	furthest_offset_ms: number | null;
 	latest_interaction_at: string | null;
@@ -2824,6 +2826,7 @@ export type Assistant = {
 	hide_prompt: boolean | null;
 	locked: boolean | null;
 	assistant_should_message_first: boolean | null;
+	allow_lesson_timeline_bypass: boolean;
 	should_record_user_information: boolean | null;
 	disable_prompt_randomization: boolean | null;
 	allow_user_file_uploads: boolean | null;
@@ -2993,6 +2996,7 @@ export type CreateAssistantRequest = {
 	hide_prompt?: boolean;
 	deleted_private_files?: number[];
 	assistant_should_message_first?: boolean;
+	allow_lesson_timeline_bypass?: boolean;
 	should_record_user_information?: boolean;
 	disable_prompt_randomization?: boolean;
 	allow_user_file_uploads?: boolean;
@@ -3066,6 +3070,7 @@ export type UpdateAssistantRequest = {
 	hide_prompt?: boolean;
 	deleted_private_files?: number[];
 	assistant_should_message_first?: boolean;
+	allow_lesson_timeline_bypass?: boolean | null;
 	should_record_user_information?: boolean;
 	disable_prompt_randomization?: boolean;
 	allow_user_file_uploads?: boolean;

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoPlayer.svelte
@@ -314,7 +314,9 @@
 			? mediaAspectRatio
 			: null
 	);
-	let questionControlsLocked = $derived(questionPendingControls && maxSeekOffsetMs == null);
+	let questionControlsLocked = $derived(
+		questionPendingControls && maxSeekOffsetMs == null && !allowFullSeek
+	);
 	let captionsAvailable = $derived(Boolean(captionsSrc));
 	let captionOverlayBottomPx = $derived(
 		visibleControls ? controlsOverlayHeight + CAPTION_CONTROL_GAP_PX : 20

--- a/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
+++ b/web/pingpong/src/lib/components/lecture-video/LectureVideoView.svelte
@@ -136,6 +136,7 @@
 	let questionPlaybackLocked: boolean = $state(false);
 	let questionPresentationVersion: number = $state(0);
 	let furthestOffsetMs: number = $state(0);
+	let timelineBypassEnabled: boolean = $state(false);
 	let initialStartOffsetMs: number = $state(0);
 	let videoReadyForPlayback: boolean = $state(false);
 	let introNarrationPending: boolean = $state(false);
@@ -160,6 +161,10 @@
 	// Tracks which question we have already posted question_presented for
 	// to avoid duplicate posts.
 	let questionPresentedForId: number | null = $state(null);
+
+	// While a seek interaction is awaiting the server, the local playhead and
+	// currentQuestion disagree; suppress checkpoint auto-pause until it settles.
+	let seekInteractionsInFlight = $state(0);
 
 	// When resuming mid-session, seek video to this offset once it can play.
 	let resumeOffsetOnCanPlay: number | null = $state(null);
@@ -295,7 +300,9 @@
 	);
 	let questionReviewSeekLimitMs = $derived.by(() => {
 		const question: LessonQuestionPrompt | null = currentQuestion;
-		return questionReviewPlaybackAllowed && question ? question.stop_offset_ms : null;
+		return questionReviewPlaybackAllowed && question && !timelineBypassEnabled
+			? question.stop_offset_ms
+			: null;
 	});
 	let playerInteractionDisabled = $derived(
 		!canParticipate || (playbackLocked && !questionReviewPlaybackAllowed)
@@ -533,6 +540,7 @@
 		playerDisabled = false;
 		questionPlaybackLocked = false;
 		furthestOffsetMs = 0;
+		timelineBypassEnabled = false;
 		initialStartOffsetMs = 0;
 		videoReadyForPlayback = false;
 		introNarrationPending = false;
@@ -542,6 +550,7 @@
 		historyInteractions = [];
 		initError = null;
 		questionPresentedForId = null;
+		seekInteractionsInFlight = 0;
 		resumeOffsetOnCanPlay = null;
 		suppressPauseInteraction = false;
 		suppressPlayInteraction = false;
@@ -1388,8 +1397,16 @@
 			autoContinueFailed = false;
 		}
 		furthestOffsetMs = session.furthest_offset_ms ?? 0;
+		timelineBypassEnabled = session.timeline_bypass_enabled;
 		questionPlaybackLocked =
 			session.state === 'awaiting_answer' || session.state === 'awaiting_post_answer_resume';
+		if (
+			session.state === 'playing' &&
+			session.current_question &&
+			currentTimeMs < session.current_question.stop_offset_ms
+		) {
+			questionPresentedForId = null;
+		}
 
 		trackQuestion(session.current_question);
 		trackQuestion(session.current_continuation?.next_question ?? null);
@@ -1497,6 +1514,9 @@
 	}
 
 	function handleTimeUpdate() {
+		// The playhead already moved but currentQuestion still reflects the
+		// pre-seek session; acting now would auto-present the wrong question.
+		if (seekInteractionsInFlight > 0) return;
 		if (questionReviewPlaybackAllowed && currentQuestion) {
 			if (currentTimeMs >= currentQuestion.stop_offset_ms) {
 				if (!videoElement?.paused) {
@@ -1581,7 +1601,8 @@
 
 	async function handleSeek(toOffsetMs: number, fromOffsetMs: number) {
 		const seekControllerSessionId = controllerSessionId;
-		if (!seekControllerSessionId || !videoElement || playbackLocked) return;
+		if (!seekControllerSessionId || !videoElement || (playbackLocked && !timelineBypassEnabled))
+			return;
 		if (toOffsetMs === fromOffsetMs) return;
 
 		const payload = {
@@ -1598,6 +1619,8 @@
 				toOffsetMs < currentQuestion.stop_offset_ms ? null : questionPresentedForId;
 		}
 
+		const wasInQuestionState = hasVisibleQuestionPrompt(sessionState);
+		seekInteractionsInFlight += 1;
 		try {
 			const expanded = await postLessonInteraction(payload);
 			if (controllerSessionId !== seekControllerSessionId) {
@@ -1614,6 +1637,15 @@
 					)
 				) {
 					setVideoPosition(fromOffsetMs);
+					return;
+				}
+				if (wasInQuestionState && sessionState === 'playing') {
+					cancelPendingNarration();
+					subtitleText = null;
+					playerDisabled = false;
+					introNarrationPending = false;
+					postAnswerNarrationPending = false;
+					setVideoPosition(toOffsetMs);
 				}
 				return;
 			}
@@ -1632,6 +1664,8 @@
 			}
 			setVideoPosition(fromOffsetMs);
 			failClosedControl(error instanceof Error ? error.message : String(error));
+		} finally {
+			seekInteractionsInFlight = Math.max(0, seekInteractionsInFlight - 1);
 		}
 	}
 
@@ -2139,7 +2173,8 @@
 							{activeQuestionIds}
 							{questionPresentationVersion}
 							{furthestOffsetMs}
-							allowFullSeek={isCompleted && canParticipate && completedPlaybackReachedEnd}
+							allowFullSeek={timelineBypassEnabled ||
+								(isCompleted && canParticipate && completedPlaybackReachedEnd)}
 							maxSeekOffsetMs={questionReviewSeekLimitMs}
 							manualPlaybackPrompt={playbackRequiresManualStart}
 							bind:videoElement

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -1957,6 +1957,16 @@
 		assistantShouldMessageFirst = assistant?.assistant_should_message_first;
 		hasSetAssistantShouldMessageFirst = true;
 	}
+	let allowLessonTimelineBypass = false;
+	let hasSetAllowLessonTimelineBypass = false;
+	$: if (
+		assistant?.allow_lesson_timeline_bypass !== undefined &&
+		assistant?.allow_lesson_timeline_bypass !== null &&
+		!hasSetAllowLessonTimelineBypass
+	) {
+		allowLessonTimelineBypass = assistant.allow_lesson_timeline_bypass;
+		hasSetAllowLessonTimelineBypass = true;
+	}
 	const realtimeEagernessOptions: { value: api.RealtimeEagerness; label: string }[] = [
 		{ value: 'auto', label: 'Auto' },
 		{ value: 'low', label: 'Low' },
@@ -2691,6 +2701,12 @@
 		if (voiceId.trim() !== currentVoiceId.trim()) {
 			modifiedFields.push('voice id');
 		}
+		if (
+			isLectureMode &&
+			allowLessonTimelineBypass !== (assistant?.allow_lesson_timeline_bypass ?? false)
+		) {
+			modifiedFields.push('timeline bypass');
+		}
 		const selectedLectureSlideDeckId = selectedLectureSlideDeck?.id ?? null;
 		const currentLectureSlideDeckId = currentLectureSlideDeck?.id ?? null;
 		if (selectedLectureSlideDeckId !== currentLectureSlideDeckId) {
@@ -2901,6 +2917,7 @@
 				? (assistant?.hide_prompt ?? true)
 				: body.hide_prompt?.toString() === 'on',
 			assistant_should_message_first: assistantShouldMessageFirst,
+			allow_lesson_timeline_bypass: isLectureMode ? allowLessonTimelineBypass : false,
 			create_classic_assistant: createClassicAssistant,
 			deleted_private_files: [...$trashPrivateFileIds, ...fileSearchCodeInterpreterUnusedFiles],
 			should_record_user_information: shouldRecordNameOrVoice,
@@ -5927,6 +5944,23 @@
 							>
 						</div>
 						{#if isLectureMode}
+							<div class="col-span-2 mb-1">
+								<Checkbox
+									id="allow_lesson_timeline_bypass"
+									name="allow_lesson_timeline_bypass"
+									disabled={preventEdits}
+									bind:checked={allowLessonTimelineBypass}>Allow Timeline Bypass</Checkbox
+								>
+								<Helper
+									>Allow participants to seek ahead in the lesson timeline. When enabled,
+									participants can skip ahead to any point in the lesson timeline, skipping any
+									knowledge checks in between. Changing this setting will affect existing and future
+									lesson sessions.{#if assistant?.allow_lesson_timeline_bypass}&nbsp;If you disable
+										this setting, participants will no longer be able to seek ahead in existing
+										lesson sessions.{:else}&nbsp;If you enable this setting, participants will be
+										able to seek ahead in existing lesson sessions.{/if}</Helper
+								>
+							</div>
 							<hr />
 						{:else}
 							<div class="col-span-2 mb-1">

--- a/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
+++ b/web/pingpong/src/routes/group/[classId]/assistant/[assistantId]/+page.svelte
@@ -2917,7 +2917,7 @@
 				? (assistant?.hide_prompt ?? true)
 				: body.hide_prompt?.toString() === 'on',
 			assistant_should_message_first: assistantShouldMessageFirst,
-			allow_lesson_timeline_bypass: isLectureMode ? allowLessonTimelineBypass : false,
+			allow_lesson_timeline_bypass: isLectureMode ? allowLessonTimelineBypass : undefined,
 			create_classic_assistant: createClassicAssistant,
 			deleted_private_files: [...$trashPrivateFileIds, ...fileSearchCodeInterpreterUnusedFiles],
 			should_record_user_information: shouldRecordNameOrVoice,
@@ -5955,10 +5955,10 @@
 									>Allow participants to seek ahead in the lesson timeline. When enabled,
 									participants can skip ahead to any point in the lesson timeline, skipping any
 									knowledge checks in between. Changing this setting will affect existing and future
-									lesson sessions.{#if assistant?.allow_lesson_timeline_bypass}&nbsp;If you disable
-										this setting, participants will no longer be able to seek ahead in existing
-										lesson sessions.{:else}&nbsp;If you enable this setting, participants will be
-										able to seek ahead in existing lesson sessions.{/if}</Helper
+									lesson sessions.{#if allowLessonTimelineBypass}&nbsp;If you disable this setting,
+										participants will no longer be able to seek ahead in existing lesson sessions.{:else}&nbsp;If
+										you enable this setting, participants will be able to seek ahead in existing
+										lesson sessions.{/if}</Helper
 								>
 							</div>
 							<hr />


### PR DESCRIPTION
## Lecture Lessons (Preview)

### New Features
* Use the new Allow Timeline Bypass setting under Advanced Options while creating or editing an assistant to allow participants to seek ahead in the lesson timeline. When enabled, participants can skip ahead to any point in the lesson timeline, skipping any knowledge checks in between. Changing this setting will affect existing and future lesson sessions.