### PR TITLE
feat(slides): remux to webm container

### DIFF
--- a/pingpong/__main__.py
+++ b/pingpong/__main__.py
@@ -75,6 +75,9 @@ from pingpong.migrations.m11_move_lecture_slide_questions_to_slide_ends import (
 from pingpong.migrations.m12_upload_lecture_slide_sources_to_openai import (
     upload_lecture_slide_sources_to_openai,
 )
+from pingpong.migrations.m13_remux_lecture_slide_narration_to_webm import (
+    remux_lecture_slide_narration_to_webm,
+)
 from pingpong.now import _get_next_run_time, croner, utcnow
 from pingpong.schemas import LMSType, RunStatus
 from pingpong.lti.course_bridge import course_bridge_sync_all
@@ -1137,6 +1140,22 @@ def m12_upload_lecture_slide_sources_to_openai() -> None:
             )
 
     asyncio.run(_m12_upload_lecture_slide_sources_to_openai())
+
+
+@db.command("m13_remux_lecture_slide_narration_to_webm")
+def m13_remux_lecture_slide_narration_to_webm() -> None:
+    async def _m13_remux_lecture_slide_narration_to_webm() -> None:
+        async with config.db.driver.async_session() as session:
+            logger.info("Remuxing lecture slide continuous narration to WebM...")
+            result = await remux_lecture_slide_narration_to_webm(session)
+            logger.info(
+                "Done! remuxed=%s skipped=%s failed=%s",
+                result.remuxed,
+                result.skipped,
+                result.failed,
+            )
+
+    asyncio.run(_m13_remux_lecture_slide_narration_to_webm())
 
 
 @db.command("m02_remove_responses_threads")

--- a/pingpong/audio_store.py
+++ b/pingpong/audio_store.py
@@ -307,20 +307,22 @@ class S3AudioStore(BaseAudioStore):
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code", "")
                 if error_code == "InvalidRange":
-                    raise AudioStoreError(code=416, detail="Range entered is invalid")
+                    raise AudioStoreError(
+                        code=416, detail="Range entered is invalid"
+                    ) from e
                 if error_code == "AccessDenied":
                     raise AudioStoreError(
                         code=403,
                         detail="You don't have the permissions to view the resource",
-                    )
+                    ) from e
                 if error_code == "NoSuchKey":
                     raise AudioStoreError(
                         code=404, detail="The specified key does not exist"
-                    )
+                    ) from e
                 logger.exception(f"Error streaming file {key}: {e}")
                 raise AudioStoreError(
                     code=500, detail=f"Error downloading Voice mode recording: {str(e)}"
-                )
+                ) from e
 
 
 class LocalAudioStore(BaseAudioStore):

--- a/pingpong/audio_store.py
+++ b/pingpong/audio_store.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import IO, AsyncGenerator, TypedDict
 
-from aiohttp import ClientError
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 

--- a/pingpong/audio_store.py
+++ b/pingpong/audio_store.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import aioboto3
+import inspect
 import logging
 
 from abc import ABC, abstractmethod
@@ -72,6 +73,17 @@ class BaseAudioStore(ABC):
         self, key: str, chunk_size: int = 1024 * 1024
     ) -> AsyncGenerator[bytes, None]:
         """Get a file from the store."""
+        yield b""
+
+    @abstractmethod
+    async def stream_file_range(
+        self,
+        key: str,
+        start: int | None = None,
+        end: int | None = None,
+        chunk_size: int = 1024 * 1024,
+    ) -> AsyncGenerator[bytes, None]:
+        """Get a file or byte range from the store."""
         yield b""
 
 
@@ -256,12 +268,55 @@ class S3AudioStore(BaseAudioStore):
         self, key: str, chunk_size: int = 1024 * 1024
     ) -> AsyncGenerator[bytes, None]:
         """Get a file from S3."""
+        async for chunk in self.stream_file_range(
+            key=key,
+            start=None,
+            end=None,
+            chunk_size=chunk_size,
+        ):
+            yield chunk
+
+    async def stream_file_range(
+        self,
+        key: str,
+        start: int | None = None,
+        end: int | None = None,
+        chunk_size: int = 1024 * 1024,
+    ) -> AsyncGenerator[bytes, None]:
+        """Get a file or byte range from S3."""
         async with aioboto3.Session().client("s3") as s3_client:
             try:
-                s3_object = await s3_client.get_object(Bucket=self.__bucket, Key=key)
-                async for chunk in s3_object["Body"].iter_chunks(chunk_size=chunk_size):
-                    yield chunk
+                params = {
+                    "Bucket": self.__bucket,
+                    "Key": key,
+                }
+                if start is not None or end is not None:
+                    params["Range"] = f"bytes={start or 0}-{'' if end is None else end}"
+
+                s3_object = await s3_client.get_object(**params)
+                body = s3_object["Body"]
+                try:
+                    async for chunk in body.iter_chunks(chunk_size=chunk_size):
+                        yield chunk
+                finally:
+                    close = getattr(body, "close", None)
+                    if callable(close):
+                        close_result = close()
+                        if inspect.isawaitable(close_result):
+                            await close_result
             except ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code", "")
+                if error_code == "InvalidRange":
+                    raise AudioStoreError(code=416, detail="Range entered is invalid")
+                if error_code == "AccessDenied":
+                    raise AudioStoreError(
+                        code=403,
+                        detail="You don't have the permissions to view the resource",
+                    )
+                if error_code == "NoSuchKey":
+                    raise AudioStoreError(
+                        code=404, detail="The specified key does not exist"
+                    )
                 logger.exception(f"Error streaming file {key}: {e}")
                 raise AudioStoreError(
                     code=500, detail=f"Error downloading Voice mode recording: {str(e)}"
@@ -323,14 +378,55 @@ class LocalAudioStore(BaseAudioStore):
         self, key: str, chunk_size: int = 1024 * 1024
     ) -> AsyncGenerator[bytes, None]:
         """Get a file from local storage."""
+        async for chunk in self.stream_file_range(
+            key=key,
+            start=None,
+            end=None,
+            chunk_size=chunk_size,
+        ):
+            yield chunk
+
+    async def stream_file_range(
+        self,
+        key: str,
+        start: int | None = None,
+        end: int | None = None,
+        chunk_size: int = 1024 * 1024,
+    ) -> AsyncGenerator[bytes, None]:
+        """Get a file or byte range from local storage."""
         file_path = self._directory / key
         if not file_path.exists():
             raise AudioStoreError(code=404, detail="File not found")
 
         try:
+            file_size = file_path.stat().st_size
+            if start is not None and (start < 0 or start >= file_size):
+                raise AudioStoreError(code=416, detail="Start range entered is invalid")
+            if end is not None:
+                if end < 0 or end >= file_size:
+                    raise AudioStoreError(
+                        code=416, detail="End range entered is invalid"
+                    )
+                if start is not None and end < start:
+                    raise AudioStoreError(
+                        code=416, detail="Start range entered is after end range"
+                    )
+
+            start_pos = start if start is not None else 0
+            end_pos = end if end is not None else file_size - 1
+
             with open(file_path, "rb") as f:
-                while chunk := f.read(chunk_size):
+                f.seek(start_pos)
+                bytes_to_read = end_pos - start_pos + 1
+                bytes_read = 0
+                while bytes_read < bytes_to_read:
+                    chunk = f.read(min(chunk_size, bytes_to_read - bytes_read))
+                    if not chunk:
+                        break
+                    bytes_read += len(chunk)
                     yield chunk
+        except AudioStoreError:
+            raise
         except Exception as e:
             logger.exception(f"Error reading file {key}: {e}")
             raise AudioStoreError(code=500, detail=f"Error reading file: {str(e)}")

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -3286,7 +3286,7 @@ async def _combine_audio_objects(
         temp_dir = Path(temp_dir_name)
         input_paths: list[Path] = []
         for index, stored_object in enumerate(stored_objects):
-            input_path = temp_dir / f"input-{index}.ogg"
+            input_path = temp_dir / f"input-{index}.audio"
             with input_path.open("wb") as file:
                 async for chunk in config.lecture_video_audio_store.store.get_file(
                     stored_object.key
@@ -3331,9 +3331,9 @@ async def remux_continuous_narration_to_webm(ogg_audio: bytes) -> bytes:
         output_path = temp_dir / "combined.webm"
         try:
             await asyncio.to_thread(
-                _run_ffmpeg_concat,
+                _run_ffmpeg_remux,
                 ffmpeg_path,
-                [input_path],
+                input_path,
                 output_path,
                 stream_copy=True,
             )
@@ -3343,9 +3343,9 @@ async def remux_continuous_narration_to_webm(ogg_audio: bytes) -> bytes:
                 exc_info=True,
             )
             await asyncio.to_thread(
-                _run_ffmpeg_concat,
+                _run_ffmpeg_remux,
                 ffmpeg_path,
-                [input_path],
+                input_path,
                 output_path,
                 stream_copy=False,
             )
@@ -3418,6 +3418,49 @@ def _run_ffmpeg_concat(
     if completed.returncode != 0:
         stderr = completed.stderr.strip()
         raise RuntimeError(f"ffmpeg concat failed: {stderr or completed.returncode}")
+
+
+def _run_ffmpeg_remux(
+    ffmpeg_path: str,
+    input_path: Path,
+    output_path: Path,
+    *,
+    stream_copy: bool,
+) -> None:
+    """Run ffmpeg for a single-file container remux."""
+    codec_args = (
+        ["-c", "copy"]
+        if stream_copy
+        else ["-c:a", "libopus", "-b:a", "64k", "-application", "voip"]
+    )
+    command = [
+        ffmpeg_path,
+        "-y",
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        str(input_path),
+        *codec_args,
+        str(output_path),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=FFMPEG_CONCAT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = _subprocess_timeout_output(exc)
+        raise RuntimeError(
+            f"ffmpeg remux timed out after {FFMPEG_CONCAT_TIMEOUT_SECONDS} seconds"
+            f"{output}"
+        ) from exc
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise RuntimeError(f"ffmpeg remux failed: {stderr or completed.returncode}")
 
 
 def _subprocess_timeout_output(exc: subprocess.TimeoutExpired) -> str:

--- a/pingpong/lecture_slide_processing.py
+++ b/pingpong/lecture_slide_processing.py
@@ -187,6 +187,7 @@ RUN_LEASE_DURATION = timedelta(minutes=10)
 RUN_LEASE_HEARTBEAT_INTERVAL = min(timedelta(minutes=1), RUN_LEASE_DURATION / 2)
 UNEXPECTED_WORKER_EXIT_ERROR_MESSAGE = "Lecture slide worker exited unexpectedly."
 LECTURE_SLIDE_AUDIO_CONTENT_TYPE = "audio/ogg"
+LECTURE_SLIDE_CONTINUOUS_AUDIO_CONTENT_TYPE = "audio/webm"
 FFMPEG_CONCAT_TIMEOUT_SECONDS = 300
 MAX_RUN_CREATE_RETRIES = 3
 OPENAI_GENERATION_MAX_ATTEMPTS = 3
@@ -3212,7 +3213,7 @@ async def _persist_composite_artifacts(
         ]
         duration_ms = _total_stored_audio_duration_ms(stored_objects)
     combined_audio = await _combine_audio_objects(stored_objects)
-    content_type = LECTURE_SLIDE_AUDIO_CONTENT_TYPE
+    content_type = LECTURE_SLIDE_CONTINUOUS_AUDIO_CONTENT_TYPE
     audio_key, audio_length = await _store_audio(
         generate_slide_continuous_narration_store_key(),
         content_type,
@@ -3293,7 +3294,7 @@ async def _combine_audio_objects(
                     file.write(chunk)
             input_paths.append(input_path)
 
-        output_path = temp_dir / "combined.ogg"
+        output_path = temp_dir / "combined.webm"
         try:
             await asyncio.to_thread(
                 _run_ffmpeg_concat,
@@ -3311,6 +3312,40 @@ async def _combine_audio_objects(
                 _run_ffmpeg_concat,
                 ffmpeg_path,
                 input_paths,
+                output_path,
+                stream_copy=False,
+            )
+        return output_path.read_bytes()
+
+
+async def remux_continuous_narration_to_webm(ogg_audio: bytes) -> bytes:
+    """Losslessly remux an Opus-in-Ogg continuous narration into WebM."""
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise RuntimeError("ffmpeg is required for lecture slide audio remuxing.")
+
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        input_path = temp_dir / "input.ogg"
+        input_path.write_bytes(ogg_audio)
+        output_path = temp_dir / "combined.webm"
+        try:
+            await asyncio.to_thread(
+                _run_ffmpeg_concat,
+                ffmpeg_path,
+                [input_path],
+                output_path,
+                stream_copy=True,
+            )
+        except RuntimeError:
+            logger.warning(
+                "ffmpeg stream-copy remux failed; retrying with Opus re-encode.",
+                exc_info=True,
+            )
+            await asyncio.to_thread(
+                _run_ffmpeg_concat,
+                ffmpeg_path,
+                [input_path],
                 output_path,
                 stream_copy=False,
             )
@@ -3491,7 +3526,7 @@ def generate_slide_narration_store_key() -> str:
 
 
 def generate_slide_continuous_narration_store_key() -> str:
-    return f"ls_continuous_narration_{uuid.uuid7()}.ogg"
+    return f"ls_continuous_narration_{uuid.uuid7()}.webm"
 
 
 def generate_slide_caption_store_key() -> str:

--- a/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
+++ b/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
@@ -99,9 +99,9 @@ async def remux_lecture_slide_narration_to_webm(
             stored_object.key = new_key
             stored_object.content_type = _TARGET_CONTENT_TYPE
             stored_object.content_length = content_length
-            session.add(stored_object)
-            await session.commit()
+            await session.flush()
             await lecture_slide_processing._delete_audio_key_quietly(old_key)
+            await session.commit()
             remuxed += 1
             logger.info(
                 "Remuxed continuous narration to WebM. deck_id=%s old_key=%s new_key=%s",

--- a/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
+++ b/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
@@ -1,0 +1,115 @@
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+import pingpong.models as models
+from pingpong import lecture_slide_processing
+from pingpong.config import config
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 50
+_TARGET_CONTENT_TYPE = (
+    lecture_slide_processing.LECTURE_SLIDE_CONTINUOUS_AUDIO_CONTENT_TYPE
+)
+
+
+@dataclass(frozen=True)
+class RemuxLectureSlideNarrationResult:
+    remuxed: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+async def _read_audio_bytes(key: str) -> bytes:
+    buffer = bytearray()
+    async for chunk in config.lecture_video_audio_store.store.get_file(key):
+        buffer.extend(chunk)
+    return bytes(buffer)
+
+
+async def remux_lecture_slide_narration_to_webm(
+    session: AsyncSession,
+) -> RemuxLectureSlideNarrationResult:
+    if not config.lecture_video_audio_store:
+        logger.warning(
+            "No lecture video audio store configured; skipping continuous "
+            "narration WebM remux."
+        )
+        return RemuxLectureSlideNarrationResult()
+
+    remuxed = 0
+    skipped = 0
+    failed = 0
+    last_processed_id = 0
+
+    while True:
+        result = await session.execute(
+            select(models.LectureSlideDeck)
+            .where(
+                models.LectureSlideDeck.continuous_narration_stored_object_id.isnot(
+                    None
+                )
+            )
+            .where(models.LectureSlideDeck.id > last_processed_id)
+            .order_by(models.LectureSlideDeck.id.asc())
+            .options(
+                selectinload(models.LectureSlideDeck.continuous_narration_stored_object)
+            )
+            .limit(_BATCH_SIZE)
+        )
+        decks = result.scalars().all()
+        if not decks:
+            break
+
+        for deck in decks:
+            last_processed_id = deck.id
+            stored_object = deck.continuous_narration_stored_object
+            if (
+                stored_object is None
+                or stored_object.content_type == _TARGET_CONTENT_TYPE
+            ):
+                skipped += 1
+                continue
+
+            old_key = stored_object.key
+            try:
+                ogg_audio = await _read_audio_bytes(old_key)
+                webm_audio = (
+                    await lecture_slide_processing.remux_continuous_narration_to_webm(
+                        ogg_audio
+                    )
+                )
+                new_key = lecture_slide_processing.generate_slide_continuous_narration_store_key()
+                _, content_length = await lecture_slide_processing._store_audio(
+                    new_key, _TARGET_CONTENT_TYPE, webm_audio
+                )
+            except Exception:
+                failed += 1
+                logger.exception(
+                    "Failed to remux continuous narration to WebM. deck_id=%s key=%s",
+                    deck.id,
+                    old_key,
+                )
+                continue
+
+            stored_object.key = new_key
+            stored_object.content_type = _TARGET_CONTENT_TYPE
+            stored_object.content_length = content_length
+            session.add(stored_object)
+            await session.commit()
+            await lecture_slide_processing._delete_audio_key_quietly(old_key)
+            remuxed += 1
+            logger.info(
+                "Remuxed continuous narration to WebM. deck_id=%s old_key=%s new_key=%s",
+                deck.id,
+                old_key,
+                new_key,
+            )
+
+    return RemuxLectureSlideNarrationResult(
+        remuxed=remuxed, skipped=skipped, failed=failed
+    )

--- a/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
+++ b/pingpong/migrations/m13_remux_lecture_slide_narration_to_webm.py
@@ -99,9 +99,22 @@ async def remux_lecture_slide_narration_to_webm(
             stored_object.key = new_key
             stored_object.content_type = _TARGET_CONTENT_TYPE
             stored_object.content_length = content_length
-            await session.flush()
+            try:
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                await lecture_slide_processing._delete_audio_key_quietly(new_key)
+                failed += 1
+                logger.exception(
+                    "Failed to persist remuxed continuous narration metadata. "
+                    "deck_id=%s old_key=%s new_key=%s",
+                    deck.id,
+                    old_key,
+                    new_key,
+                )
+                continue
+
             await lecture_slide_processing._delete_audio_key_quietly(old_key)
-            await session.commit()
             remuxed += 1
             logger.info(
                 "Remuxed continuous narration to WebM. deck_id=%s old_key=%s new_key=%s",

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -5033,7 +5033,7 @@ async def _stream_audio_file_response(
             unexpected_error_log=unexpected_error_log,
         )
     except AudioStoreError as e:
-        if e.detail and "range" in e.detail.lower():
+        if e.code == 416:
             raise HTTPException(
                 status_code=416,
                 detail=e.detail,

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -5021,17 +5021,19 @@ async def _stream_audio_file_response(
         ) from e
 
     try:
-        stream = await prefetch_stream(
-            store.stream_file_range(
-                key=key,
-                start=start,
-                end=end,
-            ),
-            store_error=AudioStoreError,
-            logger=logger,
-            store_error_log=store_error_log,
-            unexpected_error_log=unexpected_error_log,
-        )
+        iterator = store.stream_file_range(
+            key=key,
+            start=start,
+            end=end,
+        ).__aiter__()
+        first_chunk = await iterator.__anext__()
+    except StopAsyncIteration:
+
+        async def empty_stream():
+            if False:
+                yield b""
+
+        stream = empty_stream()
     except AudioStoreError as e:
         if e.code == 416:
             raise HTTPException(
@@ -5042,10 +5044,22 @@ async def _stream_audio_file_response(
                     "Content-Range": f"bytes */{total_length}",
                 },
             ) from e
+        status_code = e.code if e.code is not None and 400 <= e.code <= 599 else 400
         raise HTTPException(
-            status_code=400,
-            detail=retrieval_error_detail,
+            status_code=status_code,
+            detail=e.detail or retrieval_error_detail,
         ) from e
+    except Exception as e:
+        logger.exception(unexpected_error_log)
+        raise HTTPException(status_code=500, detail=retrieval_error_detail) from e
+    else:
+
+        async def response_stream():
+            yield first_chunk
+            async for chunk in iterator:
+                yield chunk
+
+        stream = response_stream()
 
     response_headers = {
         "Accept-Ranges": "bytes",

--- a/pingpong/server.py
+++ b/pingpong/server.py
@@ -4996,6 +4996,78 @@ def _parse_single_byte_range(
     return start, min(end, content_length - 1), True
 
 
+async def _stream_audio_file_response(
+    *,
+    store,
+    key: str,
+    content_length: int,
+    content_type: str | None,
+    range_header: str | None,
+    store_error_log: str,
+    unexpected_error_log: str,
+    retrieval_error_detail: str,
+) -> StreamingResponse:
+    total_length = content_length
+    try:
+        start, end, is_partial = _parse_single_byte_range(range_header, total_length)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=416,
+            detail=str(e),
+            headers={
+                "Accept-Ranges": "bytes",
+                "Content-Range": f"bytes */{total_length}",
+            },
+        ) from e
+
+    try:
+        stream = await prefetch_stream(
+            store.stream_file_range(
+                key=key,
+                start=start,
+                end=end,
+            ),
+            store_error=AudioStoreError,
+            logger=logger,
+            store_error_log=store_error_log,
+            unexpected_error_log=unexpected_error_log,
+        )
+    except AudioStoreError as e:
+        if e.detail and "range" in e.detail.lower():
+            raise HTTPException(
+                status_code=416,
+                detail=e.detail,
+                headers={
+                    "Accept-Ranges": "bytes",
+                    "Content-Range": f"bytes */{total_length}",
+                },
+            ) from e
+        raise HTTPException(
+            status_code=400,
+            detail=retrieval_error_detail,
+        ) from e
+
+    response_headers = {
+        "Accept-Ranges": "bytes",
+        "Content-Length": str(
+            (end - start + 1)
+            if is_partial and start is not None and end is not None
+            else total_length
+        ),
+    }
+    status_code = 200
+    if is_partial and start is not None and end is not None:
+        response_headers["Content-Range"] = f"bytes {start}-{end}/{total_length}"
+        status_code = 206
+
+    return StreamingResponse(
+        stream,
+        status_code=status_code,
+        media_type=content_type or "application/octet-stream",
+        headers=response_headers,
+    )
+
+
 @v1.get(
     "/class/{class_id}/thread/{thread_id}/video",
     dependencies=[
@@ -5277,18 +5349,18 @@ async def get_thread_lecture_slide_continuous_narration(
         )
 
     try:
-        stream = await prefetch_stream(
-            config.lecture_video_audio_store.store.get_file(narration.key),
-            store_error=AudioStoreError,
-            logger=logger,
+        return await _stream_audio_file_response(
+            store=config.lecture_video_audio_store.store,
+            key=narration.key,
+            content_length=narration.content_length,
+            content_type=narration.content_type,
+            range_header=request.headers.get("range"),
             store_error_log="AudioStoreError while streaming lecture slide narration; aborting stream.",
             unexpected_error_log="Unexpected error while streaming lecture slide narration",
+            retrieval_error_detail="Unable to retrieve the lecture slide narration audio.",
         )
-        return StreamingResponse(
-            stream,
-            media_type=narration.content_type or "application/octet-stream",
-            headers={"Content-Length": str(narration.content_length)},
-        )
+    except HTTPException:
+        raise
     except AudioStoreError as e:
         raise HTTPException(
             status_code=400,
@@ -5512,20 +5584,18 @@ async def get_thread_lecture_slide_narration(
         )
 
     try:
-        stream = await prefetch_stream(
-            config.lecture_video_audio_store.store.get_file(
-                narration.stored_object.key
-            ),
-            store_error=AudioStoreError,
-            logger=logger,
+        return await _stream_audio_file_response(
+            store=config.lecture_video_audio_store.store,
+            key=narration.stored_object.key,
+            content_length=narration.stored_object.content_length,
+            content_type=narration.stored_object.content_type,
+            range_header=request.headers.get("range"),
             store_error_log="AudioStoreError while streaming lecture slide narration; aborting stream.",
             unexpected_error_log="Unexpected error while streaming lecture slide narration",
+            retrieval_error_detail="Unable to retrieve the lecture slide narration audio.",
         )
-        return StreamingResponse(
-            stream,
-            media_type=narration.stored_object.content_type
-            or "application/octet-stream",
-        )
+    except HTTPException:
+        raise
     except AudioStoreError as e:
         raise HTTPException(
             status_code=400,
@@ -5602,20 +5672,18 @@ async def get_thread_lecture_video_narration(
         )
 
     try:
-        stream = await prefetch_stream(
-            config.lecture_video_audio_store.store.get_file(
-                narration.stored_object.key
-            ),
-            store_error=AudioStoreError,
-            logger=logger,
+        return await _stream_audio_file_response(
+            store=config.lecture_video_audio_store.store,
+            key=narration.stored_object.key,
+            content_length=narration.stored_object.content_length,
+            content_type=narration.stored_object.content_type,
+            range_header=request.headers.get("range"),
             store_error_log="AudioStoreError while streaming lecture narration; aborting stream.",
             unexpected_error_log="Unexpected error while streaming lecture narration",
+            retrieval_error_detail="Unable to retrieve the lecture narration audio.",
         )
-        return StreamingResponse(
-            stream,
-            media_type=narration.stored_object.content_type
-            or "application/octet-stream",
-        )
+    except HTTPException:
+        raise
     except AudioStoreError as e:
         raise HTTPException(
             status_code=400,

--- a/pingpong/test_audio_store_range.py
+++ b/pingpong/test_audio_store_range.py
@@ -1,6 +1,9 @@
-import pytest
+from unittest.mock import AsyncMock, Mock
 
-from pingpong.audio_store import AudioStoreError, LocalAudioStore
+import pytest
+from botocore.exceptions import ClientError
+
+from pingpong.audio_store import AudioStoreError, LocalAudioStore, S3AudioStore
 
 pytestmark = pytest.mark.asyncio
 
@@ -10,6 +13,17 @@ async def _collect(gen) -> bytes:
     async for chunk in gen:
         out.extend(chunk)
     return bytes(out)
+
+
+class AsyncContextManager:
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    async def __aenter__(self):
+        return self.return_value
+
+    async def __aexit__(self, *args):
+        pass
 
 
 async def _write(store: LocalAudioStore, key: str, data: bytes) -> None:
@@ -56,3 +70,37 @@ async def test_stream_file_range_rejects_unsatisfiable_ranges(tmp_path):
     with pytest.raises(AudioStoreError) as missing:
         await _collect(store.stream_file_range("missing.webm", start=0, end=None))
     assert missing.value.code == 404
+
+
+async def test_s3_stream_file_range_maps_client_errors(monkeypatch):
+    mock_client = AsyncMock()
+    mock_session = AsyncMock()
+    mock_session.client = Mock(return_value=AsyncContextManager(mock_client))
+    monkeypatch.setattr(
+        "pingpong.audio_store.aioboto3.Session", Mock(return_value=mock_session)
+    )
+
+    store = S3AudioStore(bucket="test-bucket")
+    cases = [
+        ("InvalidRange", 416),
+        ("NoSuchKey", 404),
+        ("AccessDenied", 403),
+    ]
+
+    for error_code, expected_code in cases:
+        mock_client.get_object = AsyncMock(
+            side_effect=ClientError(
+                {"Error": {"Code": error_code}},
+                "GetObject",
+            )
+        )
+
+        with pytest.raises(AudioStoreError) as exc_info:
+            await _collect(store.stream_file_range("audio.webm", start=4, end=8))
+
+        assert exc_info.value.code == expected_code
+        mock_client.get_object.assert_awaited_once_with(
+            Bucket="test-bucket",
+            Key="audio.webm",
+            Range="bytes=4-8",
+        )

--- a/pingpong/test_audio_store_range.py
+++ b/pingpong/test_audio_store_range.py
@@ -1,0 +1,58 @@
+import pytest
+
+from pingpong.audio_store import AudioStoreError, LocalAudioStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _collect(gen) -> bytes:
+    out = bytearray()
+    async for chunk in gen:
+        out.extend(chunk)
+    return bytes(out)
+
+
+async def _write(store: LocalAudioStore, key: str, data: bytes) -> None:
+    upload = await store.create_upload(name=key, content_type="audio/webm")
+    import io
+
+    await upload.upload_part(io.BytesIO(data))
+    await upload.complete_upload()
+
+
+async def test_stream_file_range_returns_requested_slice(tmp_path):
+    store = LocalAudioStore(str(tmp_path))
+    payload = bytes(range(256)) * 10  # 2560 bytes
+    await _write(store, "audio.webm", payload)
+
+    # Open-ended range (the shape a browser sends when it seeks): bytes=N-
+    assert (
+        await _collect(store.stream_file_range("audio.webm", start=1000, end=None))
+        == payload[1000:]
+    )
+    # Bounded range: bytes=N-M (end is inclusive, matching HTTP semantics)
+    assert (
+        await _collect(store.stream_file_range("audio.webm", start=1000, end=1099))
+        == payload[1000:1100]
+    )
+    # No range => whole file
+    assert await _collect(store.stream_file_range("audio.webm")) == payload
+    # get_file remains equivalent to a full-range read
+    assert await _collect(store.get_file("audio.webm")) == payload
+
+
+async def test_stream_file_range_rejects_unsatisfiable_ranges(tmp_path):
+    store = LocalAudioStore(str(tmp_path))
+    await _write(store, "audio.webm", b"0123456789")
+
+    with pytest.raises(AudioStoreError) as start_oob:
+        await _collect(store.stream_file_range("audio.webm", start=10, end=None))
+    assert start_oob.value.code == 416
+
+    with pytest.raises(AudioStoreError) as end_before_start:
+        await _collect(store.stream_file_range("audio.webm", start=5, end=2))
+    assert end_before_start.value.code == 416
+
+    with pytest.raises(AudioStoreError) as missing:
+        await _collect(store.stream_file_range("missing.webm", start=0, end=None))
+    assert missing.value.code == 404

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -2074,8 +2074,8 @@ async def test_combine_audio_objects_uses_ffmpeg_stream_copy(monkeypatch):
     assert commands[0][commands[0].index("-c") + 1] == "copy"
     assert commands[0][-1].endswith(".webm")
     assert "file '" in concat_files[0]
-    assert "input-0.ogg" in concat_files[0]
-    assert "input-1.ogg" in concat_files[0]
+    assert "input-0.audio" in concat_files[0]
+    assert "input-1.audio" in concat_files[0]
 
 
 async def test_combine_audio_objects_reencodes_when_stream_copy_fails(monkeypatch):
@@ -2159,6 +2159,35 @@ async def test_combine_audio_objects_reencodes_when_stream_copy_times_out(monkey
     assert len(commands) == 2
     assert commands[0][commands[0].index("-c") + 1] == "copy"
     assert commands[1][commands[1].index("-c:a") + 1] == "libopus"
+
+
+async def test_remux_continuous_narration_to_webm_uses_direct_ffmpeg_input(
+    monkeypatch,
+):
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, capture_output, text, timeout):
+        commands.append(command)
+        assert timeout == lecture_slide_processing.FFMPEG_CONCAT_TIMEOUT_SECONDS
+        Path(command[-1]).write_bytes(b"webm-audio")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(
+        lecture_slide_processing.shutil, "which", lambda _name: "ffmpeg"
+    )
+    monkeypatch.setattr(lecture_slide_processing.subprocess, "run", fake_run)
+
+    result = await lecture_slide_processing.remux_continuous_narration_to_webm(
+        b"ogg-audio"
+    )
+
+    assert result == b"webm-audio"
+    assert len(commands) == 1
+    assert "-f" not in commands[0]
+    assert commands[0][commands[0].index("-c") + 1] == "copy"
+    input_path = Path(commands[0][commands[0].index("-i") + 1])
+    assert input_path.name == "input.ogg"
+    assert commands[0][-1].endswith(".webm")
 
 
 async def test_total_stored_audio_duration_requires_every_duration():
@@ -2671,7 +2700,7 @@ async def test_transcribe_and_persist_slide_audio_uses_supported_temp_extension(
     assert [Path(path).suffix for path in seen_paths] == [".ogg"]
 
 
-async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
+async def test_persist_composite_artifacts_stores_combined_audio_as_webm(
     db, monkeypatch
 ):
     await _create_class_and_deck(db, slide_count=2)
@@ -2738,7 +2767,7 @@ async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
     monkeypatch.setattr(
         lecture_slide_processing,
         "_combine_audio_objects",
-        lambda _stored_objects: _async_value(b"combined-ogg"),
+        lambda _stored_objects: _async_value(b"combined-webm"),
     )
     monkeypatch.setattr(lecture_slide_processing, "_store_audio", fake_store_audio)
     monkeypatch.setattr(
@@ -2897,7 +2926,7 @@ async def test_persist_composite_artifacts_deletes_uploads_when_db_lookup_raises
     monkeypatch.setattr(
         lecture_slide_processing,
         "_combine_audio_objects",
-        lambda _stored_objects: _async_value(b"combined-ogg"),
+        lambda _stored_objects: _async_value(b"combined-webm"),
     )
     monkeypatch.setattr(lecture_slide_processing, "_store_audio", fake_store_audio)
     monkeypatch.setattr(

--- a/pingpong/test_lecture_slide_processing.py
+++ b/pingpong/test_lecture_slide_processing.py
@@ -2072,6 +2072,7 @@ async def test_combine_audio_objects_uses_ffmpeg_stream_copy(monkeypatch):
     assert downloaded_keys == ["first.ogg", "second.ogg"]
     assert len(commands) == 1
     assert commands[0][commands[0].index("-c") + 1] == "copy"
+    assert commands[0][-1].endswith(".webm")
     assert "file '" in concat_files[0]
     assert "input-0.ogg" in concat_files[0]
     assert "input-1.ogg" in concat_files[0]
@@ -2755,14 +2756,14 @@ async def test_persist_composite_artifacts_stores_combined_audio_as_ogg(
         ],
     )
 
-    assert stored_content_types == ["audio/ogg"]
+    assert stored_content_types == ["audio/webm"]
     async with db.async_session() as session:
         deck = await models.LectureSlideDeck.get_by_id_with_processing_context(
             session, 1
         )
         assert deck is not None
         assert deck.continuous_narration_stored_object is not None
-        assert deck.continuous_narration_stored_object.content_type == "audio/ogg"
+        assert deck.continuous_narration_stored_object.content_type == "audio/webm"
         assert deck.continuous_narration_stored_object.duration_ms == 200
 
 

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -1253,6 +1253,7 @@ async def test_lecture_slide_question_narration_endpoint_streams_allowed_audio(
             assert key == "slides/question.ogg"
             assert start is None
             assert end is None
+            yield b"question-audio"
 
     monkeypatch.setattr(
         config,

--- a/pingpong/test_lecture_slide_runtime.py
+++ b/pingpong/test_lecture_slide_runtime.py
@@ -1152,8 +1152,10 @@ async def test_lecture_slide_continuous_narration_endpoint_streams_audio(
     db, institution, monkeypatch
 ):
     class FakeAudioStore:
-        async def get_file(self, key):
+        async def stream_file_range(self, *, key, start=None, end=None):
             assert key == "slides/audio.ogg"
+            assert start is None
+            assert end is None
             yield b"audio"
 
     monkeypatch.setattr(
@@ -1187,7 +1189,59 @@ async def test_lecture_slide_continuous_narration_endpoint_streams_audio(
     chunks = [chunk async for chunk in response.body_iterator]
     assert response.status_code == 200
     assert response.media_type == "audio/ogg"
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.headers["content-length"] == "5"
     assert b"".join(chunks) == b"audio"
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_continuous_narration_endpoint_streams_audio_range(
+    db, institution, monkeypatch
+):
+    audio = b"slide-audio"
+
+    class FakeAudioStore:
+        async def stream_file_range(self, *, key, start=None, end=None):
+            assert key == "slides/audio.ogg"
+            assert start == 2
+            assert end == 5
+            yield audio[start : end + 1]
+
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        SimpleNamespace(store=FakeAudioStore()),
+    )
+
+    async with db.async_session() as session:
+        class_, deck, assistant, thread, _ = await _create_slide_runtime_fixture(
+            session, institution
+        )
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        assistant.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        narration = models.LectureSlideNarrationStoredObject(
+            key="slides/audio.ogg",
+            content_type="audio/ogg",
+            content_length=len(audio),
+            duration_ms=10_000,
+        )
+        deck.continuous_narration_stored_object = narration
+        session.add(narration)
+        await session.flush()
+
+        response = await server_module.get_thread_lecture_slide_continuous_narration(
+            str(class_.id),
+            str(thread.id),
+            _server_request(session, headers={"range": "bytes=2-5"}),
+        )
+
+    chunks = [chunk async for chunk in response.body_iterator]
+    assert response.status_code == 206
+    assert response.media_type == "audio/ogg"
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.headers["content-range"] == f"bytes 2-5/{len(audio)}"
+    assert response.headers["content-length"] == "4"
+    assert b"".join(chunks) == audio[2:6]
 
 
 @with_institution(11, "Test Institution")
@@ -1195,9 +1249,10 @@ async def test_lecture_slide_question_narration_endpoint_streams_allowed_audio(
     db, institution, monkeypatch
 ):
     class FakeAudioStore:
-        async def get_file(self, key):
+        async def stream_file_range(self, *, key, start=None, end=None):
             assert key == "slides/question.ogg"
-            yield b"question-audio"
+            assert start is None
+            assert end is None
 
     monkeypatch.setattr(
         config,
@@ -1247,7 +1302,53 @@ async def test_lecture_slide_question_narration_endpoint_streams_allowed_audio(
     chunks = [chunk async for chunk in response.body_iterator]
     assert response.status_code == 200
     assert response.media_type == "audio/ogg"
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.headers["content-length"] == "14"
     assert b"".join(chunks) == b"question-audio"
+
+
+@with_institution(11, "Test Institution")
+async def test_lecture_slide_continuous_narration_endpoint_rejects_invalid_range(
+    db, institution, monkeypatch
+):
+    class FakeAudioStore:
+        async def stream_file_range(self, *, key, start=None, end=None):
+            raise AssertionError("invalid ranges should not reach the store")
+
+    monkeypatch.setattr(
+        config,
+        "lecture_video_audio_store",
+        SimpleNamespace(store=FakeAudioStore()),
+    )
+
+    async with db.async_session() as session:
+        class_, deck, assistant, thread, _ = await _create_slide_runtime_fixture(
+            session, institution
+        )
+        thread.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        assistant.interaction_mode = schemas.InteractionMode.LECTURE_SLIDES
+        narration = models.LectureSlideNarrationStoredObject(
+            key="slides/audio.ogg",
+            content_type="audio/ogg",
+            content_length=5,
+            duration_ms=10_000,
+        )
+        deck.continuous_narration_stored_object = narration
+        session.add(narration)
+        await session.flush()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await server_module.get_thread_lecture_slide_continuous_narration(
+                str(class_.id),
+                str(thread.id),
+                _server_request(session, headers={"range": "bytes=20-30"}),
+            )
+
+    assert exc_info.value.status_code == 416
+    assert exc_info.value.headers == {
+        "Accept-Ranges": "bytes",
+        "Content-Range": "bytes */5",
+    }
 
 
 @with_institution(11, "Test Institution")

--- a/pingpong/test_lecture_video_server.py
+++ b/pingpong/test_lecture_video_server.py
@@ -13017,7 +13017,22 @@ async def test_get_thread_lecture_video_narration_streams_audio(
     )
     assert response.status_code == 200
     assert response.content == narration_bytes
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.headers["content-length"] == str(len(narration_bytes))
     assert response.headers["content-type"].startswith("audio/ogg")
+
+    partial = api.get(
+        f"/api/v1/class/{class_.id}/thread/{thread_id}/lecture-video/narration/{question.intro_narration.id}",
+        headers={
+            "Authorization": f"Bearer {valid_user_token}",
+            "Range": "bytes=2-6",
+        },
+    )
+    assert partial.status_code == 206
+    assert partial.headers["accept-ranges"] == "bytes"
+    assert partial.headers["content-range"] == f"bytes 2-6/{len(narration_bytes)}"
+    assert partial.headers["content-length"] == "5"
+    assert partial.content == narration_bytes[2:7]
 
     missing = api.get(
         f"/api/v1/class/{class_.id}/thread/{thread_id}/lecture-video/narration/99999",

--- a/pingpong/test_migrations_m13_remux_lecture_slide_narration_to_webm.py
+++ b/pingpong/test_migrations_m13_remux_lecture_slide_narration_to_webm.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace
+
+import pytest
+
+from pingpong import lecture_slide_processing, models, schemas
+from pingpong.migrations import m13_remux_lecture_slide_narration_to_webm as migration
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_deck(session, *, deck_id: int, content_type: str, key: str) -> None:
+    class_ = await session.get(models.Class, 1)
+    if class_ is None:
+        session.add(models.Class(id=1, name="Class", api_key="sk-test"))
+        await session.flush()
+    source = models.LectureSlideSourceStoredObject(
+        key=f"slides-{deck_id}.pdf",
+        original_filename=f"slides-{deck_id}.pdf",
+        content_type="application/pdf",
+        content_length=100,
+    )
+    stored_object = models.LectureSlideNarrationStoredObject(
+        key=key,
+        content_type=content_type,
+        content_length=10,
+        duration_ms=1000,
+    )
+    session.add_all([source, stored_object])
+    await session.flush()
+    deck = models.LectureSlideDeck(
+        id=deck_id,
+        class_id=1,
+        source_stored_object_id=source.id,
+        continuous_narration_stored_object_id=stored_object.id,
+        display_name=f"Slides {deck_id}",
+        voice_id="voice-test",
+        generation_prompt="Manifest prompt",
+        narration_prompt="Narration prompt",
+        status=schemas.LectureSlideDeckStatus.READY,
+        slide_count=1,
+    )
+    session.add(deck)
+    await session.flush()
+
+
+async def test_remux_backfills_ogg_decks_and_skips_webm(db, config, monkeypatch):
+    async with db.async_session() as session:
+        await _make_deck(session, deck_id=1, content_type="audio/ogg", key="old.ogg")
+        await _make_deck(session, deck_id=2, content_type="audio/webm", key="new.webm")
+        await session.commit()
+
+    read_keys: list[str] = []
+    deleted_keys: list[str] = []
+
+    class FakeAudioStore:
+        async def get_file(self, key, chunk_size=1024 * 1024):
+            read_keys.append(key)
+            yield b"ogg-bytes"
+
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=FakeAudioStore())
+    )
+
+    async def fake_remux(ogg_audio: bytes) -> bytes:
+        assert ogg_audio == b"ogg-bytes"
+        return b"webm-bytes"
+
+    async def fake_store_audio(store_key, content_type, audio):
+        assert content_type == "audio/webm"
+        assert store_key.endswith(".webm")
+        assert audio == b"webm-bytes"
+        return store_key, len(audio)
+
+    async def fake_delete(key):
+        deleted_keys.append(key)
+
+    monkeypatch.setattr(
+        lecture_slide_processing, "remux_continuous_narration_to_webm", fake_remux
+    )
+    monkeypatch.setattr(lecture_slide_processing, "_store_audio", fake_store_audio)
+    monkeypatch.setattr(
+        lecture_slide_processing, "_delete_audio_key_quietly", fake_delete
+    )
+
+    async with db.async_session() as session:
+        result = await migration.remux_lecture_slide_narration_to_webm(session)
+
+    assert result.remuxed == 1
+    assert result.skipped == 1
+    assert result.failed == 0
+    assert read_keys == ["old.ogg"]
+    assert deleted_keys == ["old.ogg"]
+
+    async with db.async_session() as session:
+        deck = await session.get(models.LectureSlideDeck, 1)
+        stored_object = await session.get(
+            models.LectureSlideNarrationStoredObject,
+            deck.continuous_narration_stored_object_id,
+        )
+        assert stored_object.content_type == "audio/webm"
+        assert stored_object.key.endswith(".webm")
+        assert stored_object.content_length == len(b"webm-bytes")
+        # Duration bookkeeping is unchanged by the container swap.
+        assert stored_object.duration_ms == 1000
+
+
+async def test_remux_records_failures_without_mutating_row(db, config, monkeypatch):
+    async with db.async_session() as session:
+        await _make_deck(session, deck_id=1, content_type="audio/ogg", key="old.ogg")
+        await session.commit()
+
+    class FakeAudioStore:
+        async def get_file(self, key, chunk_size=1024 * 1024):
+            yield b"ogg-bytes"
+
+    monkeypatch.setattr(
+        config, "lecture_video_audio_store", SimpleNamespace(store=FakeAudioStore())
+    )
+
+    async def fake_remux(_ogg_audio: bytes) -> bytes:
+        raise RuntimeError("ffmpeg unavailable")
+
+    monkeypatch.setattr(
+        lecture_slide_processing, "remux_continuous_narration_to_webm", fake_remux
+    )
+
+    async with db.async_session() as session:
+        result = await migration.remux_lecture_slide_narration_to_webm(session)
+
+    assert result.remuxed == 0
+    assert result.failed == 1
+
+    async with db.async_session() as session:
+        deck = await session.get(models.LectureSlideDeck, 1)
+        stored_object = await session.get(
+            models.LectureSlideNarrationStoredObject,
+            deck.continuous_narration_stored_object_id,
+        )
+        assert stored_object.content_type == "audio/ogg"
+        assert stored_object.key == "old.ogg"

--- a/pingpong/test_stream_audio_file_response.py
+++ b/pingpong/test_stream_audio_file_response.py
@@ -1,0 +1,105 @@
+import importlib
+
+import pytest
+
+from pingpong.audio_store import AudioStoreError
+
+server_module = importlib.import_module("pingpong.server")
+
+pytestmark = pytest.mark.asyncio
+
+
+class FakeStore:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+        self.calls: list[tuple[int | None, int | None]] = []
+
+    async def stream_file_range(self, key, start=None, end=None):
+        self.calls.append((start, end))
+        lo = start or 0
+        hi = (end + 1) if end is not None else len(self.payload)
+        yield self.payload[lo:hi]
+
+
+async def _body(response) -> bytes:
+    out = bytearray()
+    async for chunk in response.body_iterator:
+        out.extend(chunk.encode() if isinstance(chunk, str) else chunk)
+    return bytes(out)
+
+
+async def test_no_range_returns_full_200_with_accept_ranges():
+    payload = bytes(range(200))
+    store = FakeStore(payload)
+    resp = await server_module._stream_audio_file_response(
+        store=store,
+        key="a.webm",
+        content_length=len(payload),
+        content_type="audio/webm",
+        range_header=None,
+        store_error_log="x",
+        unexpected_error_log="y",
+        retrieval_error_detail="z",
+    )
+    assert resp.status_code == 200
+    assert resp.headers["accept-ranges"] == "bytes"
+    assert resp.headers["content-length"] == str(len(payload))
+    assert "content-range" not in resp.headers
+    assert await _body(resp) == payload
+
+
+async def test_range_returns_206_partial_content():
+    payload = bytes(range(200))
+    store = FakeStore(payload)
+    resp = await server_module._stream_audio_file_response(
+        store=store,
+        key="a.webm",
+        content_length=len(payload),
+        content_type="audio/webm",
+        range_header="bytes=50-99",
+        store_error_log="x",
+        unexpected_error_log="y",
+        retrieval_error_detail="z",
+    )
+    assert resp.status_code == 206
+    assert resp.headers["content-range"] == f"bytes 50-99/{len(payload)}"
+    assert resp.headers["content-length"] == "50"
+    assert store.calls == [(50, 99)]
+    assert await _body(resp) == payload[50:100]
+
+
+async def test_malformed_range_raises_416():
+    store = FakeStore(b"0123456789")
+    with pytest.raises(server_module.HTTPException) as exc:
+        await server_module._stream_audio_file_response(
+            store=store,
+            key="a.webm",
+            content_length=10,
+            content_type="audio/webm",
+            range_header="bytes=banana",
+            store_error_log="x",
+            unexpected_error_log="y",
+            retrieval_error_detail="z",
+        )
+    assert exc.value.status_code == 416
+    assert exc.value.headers["Accept-Ranges"] == "bytes"
+
+
+async def test_store_range_error_surfaces_as_416():
+    class FailingStore:
+        async def stream_file_range(self, key, start=None, end=None):
+            raise AudioStoreError(code=416, detail="Range entered is invalid")
+            yield b""  # pragma: no cover - generator marker
+
+    with pytest.raises(server_module.HTTPException) as exc:
+        await server_module._stream_audio_file_response(
+            store=FailingStore(),
+            key="a.webm",
+            content_length=100,
+            content_type="audio/webm",
+            range_header="bytes=0-",
+            store_error_log="x",
+            unexpected_error_log="y",
+            retrieval_error_detail="z",
+        )
+    assert exc.value.status_code == 416

--- a/pingpong/test_stream_audio_file_response.py
+++ b/pingpong/test_stream_audio_file_response.py
@@ -88,7 +88,7 @@ async def test_malformed_range_raises_416():
 async def test_store_range_error_surfaces_as_416():
     class FailingStore:
         async def stream_file_range(self, key, start=None, end=None):
-            raise AudioStoreError(code=416, detail="Range entered is invalid")
+            raise AudioStoreError(code=416, detail="Requested bytes unavailable")
             yield b""  # pragma: no cover - generator marker
 
     with pytest.raises(server_module.HTTPException) as exc:

--- a/pingpong/test_stream_audio_file_response.py
+++ b/pingpong/test_stream_audio_file_response.py
@@ -103,3 +103,47 @@ async def test_store_range_error_surfaces_as_416():
             retrieval_error_detail="z",
         )
     assert exc.value.status_code == 416
+
+
+async def test_store_error_status_is_preserved():
+    class FailingStore:
+        async def stream_file_range(self, key, start=None, end=None):
+            raise AudioStoreError(code=404, detail="Audio missing")
+            yield b""  # pragma: no cover - generator marker
+
+    with pytest.raises(server_module.HTTPException) as exc:
+        await server_module._stream_audio_file_response(
+            store=FailingStore(),
+            key="a.webm",
+            content_length=100,
+            content_type="audio/webm",
+            range_header=None,
+            store_error_log="x",
+            unexpected_error_log="y",
+            retrieval_error_detail="z",
+        )
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Audio missing"
+
+
+async def test_store_error_after_first_chunk_is_not_silenced():
+    class FailingStore:
+        async def stream_file_range(self, key, start=None, end=None):
+            yield b"first"
+            raise AudioStoreError(code=500, detail="stream failed")
+
+    resp = await server_module._stream_audio_file_response(
+        store=FailingStore(),
+        key="a.webm",
+        content_length=10,
+        content_type="audio/webm",
+        range_header=None,
+        store_error_log="x",
+        unexpected_error_log="y",
+        retrieval_error_detail="z",
+    )
+
+    iterator = resp.body_iterator.__aiter__()
+    assert await iterator.__anext__() == b"first"
+    with pytest.raises(AudioStoreError):
+        await iterator.__anext__()


### PR DESCRIPTION
## Lecture Slides (Preview)

### New Features
* Lecture Slides continuous narration is now generated and stored as WebM audio instead of Ogg, while preserving the Opus audio stream.
* Lecture Slides continuous narration now supports browser byte-range requests, allowing the native audio player to request only the needed portion of the narration during loading and seeking.
* Existing Lecture Slides continuous narration can be updated from Ogg to WebM using the new `m13_remux_lecture_slide_narration_to_webm` migration command.
* Narration audio responses now include byte-range metadata such as `Accept-Ranges`, accurate `Content-Length`, and `Content-Range` for partial responses.
* Invalid narration range requests now correctly return a `416` status code with appropriate metadata rather than attempting to stream invalid audio.

### Resolved Issues
* Fixed: Lecture Slides continuous narration may fail to seek or resume accurately.