### PR TITLE
feat: deployment_identifier and enforce non-local stores in production

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,9 +25,9 @@ public_url = "http://localhost:5173"
 # Whether the server is running in development mode. Should be `false` in prod.
 development = true
 
-# Human-readable deployment label for logs, traces, and other observability
-# metadata. Use stable values like "development", "staging", or "production".
-deployment_environment = "development"
+# Stable deployment identifier for logs, traces, and other observability
+# metadata. Use values like "development", "staging", or "production".
+deployment_identifier = "development"
 
 [artifact_store]
 # Store for temporarily storing thread exports for download

--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,10 @@ public_url = "http://localhost:5173"
 # Whether the server is running in development mode. Should be `false` in prod.
 development = true
 
+# Human-readable deployment label for logs, traces, and other observability
+# metadata. Use stable values like "development", "staging", or "production".
+deployment_environment = "development"
+
 [artifact_store]
 # Store for temporarily storing thread exports for download
 # accepts `s3` and `local`
@@ -58,6 +62,15 @@ type = "s3"
 # IF `s3`, set the s3 bucket to save exports to
 # e.g. save_target = "your-bucket-here"
 # IF `local`, set the directory to save exports to
+save_target = "/your/path/here"
+
+[lecture_video_audio_store]
+# Store for storing lecture video and lecture slide narrations
+# accepts `s3` and `local`
+type = "s3"
+# IF `s3`, set the s3 bucket to save narrations to
+# e.g. save_target = "your-bucket-here"
+# IF `local`, set the directory to save narrations to
 save_target = "/your/path/here"
 
 [db]

--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import os
 import tomllib
+from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal, Union
@@ -210,7 +211,7 @@ LMSInstance = Union[CanvasSettings]
 class LMSSettings(BaseSettings):
     """LMS connection settings."""
 
-    lms_instances: list[LMSInstance]
+    lms_instances: list[LMSInstance] = Field([])
 
 
 class InitSettings(BaseSettings):
@@ -239,7 +240,11 @@ class S3StoreSettings(BaseSettings):
         return S3ArtifactStore(self.save_target)
 
 
-class LocalStoreSettings(BaseSettings):
+class LocalDiskBackedSettings(BaseSettings):
+    """Marker for settings that write app-managed data to local disk."""
+
+
+class LocalStoreSettings(LocalDiskBackedSettings):
     """Settings for local storage."""
 
     type: Literal["local"] = "local"
@@ -266,7 +271,7 @@ class S3VideoStoreSettings(BaseSettings):
         return S3VideoStore(bucket=self.save_target, allow_unsigned=self.allow_unsigned)
 
 
-class LocalVideoStoreSettings(BaseSettings):
+class LocalVideoStoreSettings(LocalDiskBackedSettings):
     """Settings for Local Video Store"""
 
     type: Literal["local"] = "local"
@@ -291,7 +296,7 @@ class S3AudioStoreSettings(BaseSettings):
         return S3AudioStore(self.save_target)
 
 
-class LocalAudioStoreSettings(BaseSettings):
+class LocalAudioStoreSettings(LocalDiskBackedSettings):
     """Settings for local storage."""
 
     type: Literal["local"] = "local"
@@ -317,7 +322,7 @@ class AWSLTIKeyStoreSettings(BaseSettings):
         return LTIKeyManager(key_store)
 
 
-class LocalLTIKeyStoreSettings(BaseSettings):
+class LocalLTIKeyStoreSettings(LocalDiskBackedSettings):
     """Settings for local LTI key store."""
 
     type: Literal["local"] = "local"
@@ -653,30 +658,115 @@ class Config(BaseSettings):
     reload: int = Field(0)
     public_url: str = Field("http://localhost:8000")
     development: bool = Field(False)
-    artifact_store: ArtifactStoreSettings = LocalStoreSettings(
-        save_target="local_exports/thread_exports"
-    )
-    file_store: ArtifactStoreSettings = LocalStoreSettings(
-        save_target="local_exports/files"
-    )
-    audio_store: AudioStoreSettings = LocalAudioStoreSettings(
-        save_target="local_exports/voice_mode_recordings"
-    )
-    lecture_video_audio_store: AudioStoreSettings = LocalAudioStoreSettings(
-        save_target="local_exports/lecture_video_narrations"
-    )
+    deployment_environment: str = Field("unknown")
+    artifact_store: ArtifactStoreSettings
+    file_store: ArtifactStoreSettings
+    audio_store: AudioStoreSettings
+    lecture_video_audio_store: AudioStoreSettings
     video_store: VideoStoreSettings | None = Field(None)
     db: DbSettings
     auth: AuthSettings
     authz: AuthzSettings
     email: EmailSettings
-    lms: LMSSettings
+    lms: LMSSettings = Field(LMSSettings())
     lti: LTISettings | None = Field(None)
     sentry: SentrySettings = Field(SentrySettings())
     metrics: MetricsSettings = Field(MetricsSettings())
     init: InitSettings = Field(InitSettings())
     support: SupportSettings = Field(NoSupportSettings())
     upload: UploadSettings = Field(UploadSettings())
+
+    @staticmethod
+    def _development_enabled(data: dict[str, Any]) -> bool:
+        raw_development = data.get("development", False)
+        if isinstance(raw_development, bool):
+            return raw_development
+        if isinstance(raw_development, str):
+            return raw_development.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(raw_development)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _add_development_store_defaults(cls, data: object) -> object:
+        if not isinstance(data, dict) or not cls._development_enabled(data):
+            return data
+
+        mapped_data = dict(data)
+        mapped_data.setdefault(
+            "artifact_store",
+            {
+                "type": "local",
+                "save_target": "local_exports/thread_exports",
+            },
+        )
+        mapped_data.setdefault(
+            "file_store",
+            {
+                "type": "local",
+                "save_target": "local_exports/files",
+            },
+        )
+        mapped_data.setdefault(
+            "audio_store",
+            {
+                "type": "local",
+                "save_target": "local_exports/voice_mode_recordings",
+            },
+        )
+        mapped_data.setdefault(
+            "lecture_video_audio_store",
+            {
+                "type": "local",
+                "save_target": "local_exports/lecture_video_narrations",
+            },
+        )
+        return mapped_data
+
+    @classmethod
+    def _iter_local_disk_backed_paths(cls, value: object, path: str) -> Iterable[str]:
+        if isinstance(value, LocalDiskBackedSettings):
+            yield path
+            return
+
+        if isinstance(value, BaseSettings):
+            for field_name in type(value).model_fields:
+                child_path = f"{path}.{field_name}" if path else field_name
+                yield from cls._iter_local_disk_backed_paths(
+                    getattr(value, field_name), child_path
+                )
+            return
+
+        if isinstance(value, (list, tuple)):
+            for index, item in enumerate(value):
+                yield from cls._iter_local_disk_backed_paths(item, f"{path}[{index}]")
+            return
+
+        if isinstance(value, dict):
+            for key, item in value.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                yield from cls._iter_local_disk_backed_paths(item, child_path)
+
+    @model_validator(mode="after")
+    def _reject_local_disk_stores_outside_development(self):
+        if self.development:
+            return self
+
+        local_paths = sorted(
+            self._iter_local_disk_backed_paths(
+                {
+                    field_name: getattr(self, field_name)
+                    for field_name in type(self).model_fields
+                },
+                "",
+            )
+        )
+        if local_paths:
+            raise ValueError(
+                "Local disk-backed stores are only allowed when development is true. "
+                f"Configure non-local stores for: {', '.join(local_paths)}"
+            )
+
+        return self
 
     def url(self, path: str | None) -> str:
         """Return a URL relative to the public URL."""

--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -658,7 +658,7 @@ class Config(BaseSettings):
     reload: int = Field(0)
     public_url: str = Field("http://localhost:8000")
     development: bool = Field(False)
-    deployment_environment: str = Field("unknown")
+    deployment_identifier: str = Field("unknown")
     artifact_store: ArtifactStoreSettings
     file_store: ArtifactStoreSettings
     audio_store: AudioStoreSettings

--- a/pingpong/test_config_lti_settings.py
+++ b/pingpong/test_config_lti_settings.py
@@ -5,7 +5,6 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import BaseSettings
 
-import pingpong.config as config_module
 from pingpong.config import (
     Config,
     LEGACY_OPENID_CONFIGURATION_PATHS_DEFAULTS,
@@ -133,8 +132,11 @@ def test_config_rejects_local_nested_store_outside_development():
 
 def test_local_type_settings_are_marked_disk_backed():
     local_type_settings_classes = []
-    for cls in vars(config_module).values():
-        if not inspect.isclass(cls) or not issubclass(cls, BaseSettings):
+    settings_classes = [BaseSettings]
+    while settings_classes:
+        cls = settings_classes.pop()
+        settings_classes.extend(cls.__subclasses__())
+        if not inspect.isclass(cls) or cls.__module__ != Config.__module__:
             continue
 
         type_field = cls.model_fields.get("type")

--- a/pingpong/test_config_lti_settings.py
+++ b/pingpong/test_config_lti_settings.py
@@ -1,10 +1,150 @@
+import inspect
 import logging
 
 import pytest
 from pydantic import ValidationError
+from pydantic_settings import BaseSettings
 
-from pingpong.config import LEGACY_OPENID_CONFIGURATION_PATHS_DEFAULTS, LTISettings
+import pingpong.config as config_module
+from pingpong.config import (
+    Config,
+    LEGACY_OPENID_CONFIGURATION_PATHS_DEFAULTS,
+    LocalAudioStoreSettings,
+    LocalDiskBackedSettings,
+    LocalStoreSettings,
+    LTISettings,
+    SqliteSettings,
+    config,
+)
 from pingpong.lti.allowlist import generate_safe_lti_url
+
+
+def test_config_loads_deployment_environment():
+    assert config.deployment_environment == "test"
+
+
+def _s3_store_settings() -> dict[str, dict[str, str]]:
+    return {
+        "artifact_store": {"type": "s3", "save_target": "artifact-bucket"},
+        "file_store": {"type": "s3", "save_target": "file-bucket"},
+        "audio_store": {"type": "s3", "save_target": "audio-bucket"},
+        "lecture_video_audio_store": {
+            "type": "s3",
+            "save_target": "lecture-audio-bucket",
+        },
+    }
+
+
+def _minimal_config_settings() -> dict[str, object]:
+    return {
+        **_s3_store_settings(),
+        "db": SqliteSettings(path=":memory:"),
+        "auth": {"authn_methods": [], "secret_keys": [{"key": "secret"}]},
+        "authz": {"type": "openfga"},
+        "email": {"type": "mock"},
+    }
+
+
+def test_config_defaults_deployment_environment_to_unknown():
+    cfg = Config.model_validate(_minimal_config_settings())
+
+    assert cfg.deployment_environment == "unknown"
+    assert cfg.lms.lms_instances == []
+
+
+def test_config_injects_local_store_defaults_in_development():
+    cfg = Config.model_validate(
+        {
+            "development": True,
+            "db": SqliteSettings(path=":memory:"),
+            "auth": {"authn_methods": [], "secret_keys": [{"key": "secret"}]},
+            "authz": {"type": "openfga"},
+            "email": {"type": "mock"},
+        }
+    )
+
+    assert isinstance(cfg.artifact_store, LocalStoreSettings)
+    assert cfg.artifact_store.save_target == "local_exports/thread_exports"
+    assert isinstance(cfg.file_store, LocalStoreSettings)
+    assert cfg.file_store.save_target == "local_exports/files"
+    assert isinstance(cfg.audio_store, LocalAudioStoreSettings)
+    assert cfg.audio_store.save_target == "local_exports/voice_mode_recordings"
+    assert isinstance(cfg.lecture_video_audio_store, LocalAudioStoreSettings)
+    assert (
+        cfg.lecture_video_audio_store.save_target
+        == "local_exports/lecture_video_narrations"
+    )
+
+
+def test_config_requires_explicit_stores_outside_development():
+    with pytest.raises(ValidationError) as excinfo:
+        Config.model_validate(
+            {
+                "db": SqliteSettings(path=":memory:"),
+                "auth": {"authn_methods": [], "secret_keys": [{"key": "secret"}]},
+                "authz": {"type": "openfga"},
+                "email": {"type": "mock"},
+            }
+        )
+
+    error_text = str(excinfo.value)
+    assert "artifact_store" in error_text
+    assert "file_store" in error_text
+    assert "audio_store" in error_text
+    assert "lecture_video_audio_store" in error_text
+
+
+def test_config_rejects_local_disk_store_outside_development():
+    settings = {
+        **_minimal_config_settings(),
+        "artifact_store": {
+            "type": "local",
+            "save_target": "local_exports/thread_exports",
+        },
+    }
+
+    with pytest.raises(ValidationError) as excinfo:
+        Config.model_validate(settings)
+
+    error_text = str(excinfo.value)
+    assert (
+        "Local disk-backed stores are only allowed when development is true"
+        in error_text
+    )
+    assert "artifact_store" in error_text
+
+
+def test_config_rejects_local_nested_store_outside_development():
+    settings = {
+        **_minimal_config_settings(),
+        "lti": {"key_store": {"type": "local", "directory": "local_exports/lti_keys"}},
+    }
+
+    with pytest.raises(ValidationError) as excinfo:
+        Config.model_validate(settings)
+
+    error_text = str(excinfo.value)
+    assert (
+        "Local disk-backed stores are only allowed when development is true"
+        in error_text
+    )
+    assert "lti.key_store" in error_text
+
+
+def test_local_type_settings_are_marked_disk_backed():
+    local_type_settings_classes = []
+    for cls in vars(config_module).values():
+        if not inspect.isclass(cls) or not issubclass(cls, BaseSettings):
+            continue
+
+        type_field = cls.model_fields.get("type")
+        if type_field is not None and type_field.default == "local":
+            local_type_settings_classes.append(cls)
+
+    assert local_type_settings_classes
+    assert all(
+        issubclass(cls, LocalDiskBackedSettings) for cls in local_type_settings_classes
+    )
 
 
 def _base_lti_settings() -> dict[str, object]:

--- a/pingpong/test_config_lti_settings.py
+++ b/pingpong/test_config_lti_settings.py
@@ -19,8 +19,8 @@ from pingpong.config import (
 from pingpong.lti.allowlist import generate_safe_lti_url
 
 
-def test_config_loads_deployment_environment():
-    assert config.deployment_environment == "test"
+def test_config_loads_deployment_identifier():
+    assert config.deployment_identifier == "test"
 
 
 def _s3_store_settings() -> dict[str, dict[str, str]]:
@@ -45,10 +45,10 @@ def _minimal_config_settings() -> dict[str, object]:
     }
 
 
-def test_config_defaults_deployment_environment_to_unknown():
+def test_config_defaults_deployment_identifier_to_unknown():
     cfg = Config.model_validate(_minimal_config_settings())
 
-    assert cfg.deployment_environment == "unknown"
+    assert cfg.deployment_identifier == "unknown"
     assert cfg.lms.lms_instances == []
 
 

--- a/test_config.toml
+++ b/test_config.toml
@@ -1,6 +1,7 @@
 log_level = "DEBUG"
 public_url = "http://localhost:5173"
 development = true
+deployment_environment = "test"
 
 [artifact_store]
 type = "local"

--- a/test_config.toml
+++ b/test_config.toml
@@ -1,7 +1,7 @@
 log_level = "DEBUG"
 public_url = "http://localhost:5173"
 development = true
-deployment_environment = "test"
+deployment_identifier = "test"
 
 [artifact_store]
 type = "local"


### PR DESCRIPTION
## Internal
### New Features
* Use the new `deployment_identifier` base configuration option to specify a stable deployment identifier for logs, traces, and other observability metadata. Defaults to `unknown`.
* PingPong will now enforce that local disk-backed stores for `artifact_store`, `file_store`, `audio_store`, `lecture_video_audio_store`, `video_store` (when set) are only allowed when `development = true`.
### Updates & Improvements
* The LMS Settings configuration block is now optional when no LMS connection is needed.