### PR TITLE
feat(voice): enable traces

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,9 +25,9 @@ public_url = "http://localhost:5173"
 # Whether the server is running in development mode. Should be `false` in prod.
 development = true
 
-# Stable deployment identifier for logs, traces, and other observability
-# metadata. Use values like "development", "staging", or "production".
-deployment_identifier = "development"
+# Stable deployment identifier for logs, traces, and other observability metadata.
+# Development mode defaults this to "dev" when omitted. Production configs must set it.
+# deployment_identifier = "staging"
 
 [artifact_store]
 # Store for temporarily storing thread exports for download

--- a/pingpong/ai.py
+++ b/pingpong/ai.py
@@ -3842,6 +3842,14 @@ async def poll_vector_store_files(
         )
 
 
+def build_openai_safety_identifier(
+    response_safety_identifier: str | None,
+) -> str | None:
+    if not response_safety_identifier:
+        return None
+    return f"pp:v1:{response_safety_identifier}"
+
+
 async def run_response(
     cli: openai.AsyncClient,
     *,
@@ -3992,10 +4000,11 @@ async def run_response(
                 )
                 include_with.append("code_interpreter_call.outputs")
 
+            safety_identifier = build_openai_safety_identifier(
+                response_safety_identifier
+            )
             safety_identifier_setting: str | openai.NotGiven = (
-                f"pp:v1:{response_safety_identifier}"
-                if response_safety_identifier
-                else openai.NOT_GIVEN
+                safety_identifier if safety_identifier is not None else openai.NOT_GIVEN
             )
 
             # Make cleanup safe even when the OpenAI stream fails before TTS setup runs.

--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -751,7 +751,7 @@ class Config(BaseSettings):
     @model_validator(mode="after")
     def _validate_deployment_identifier(self):
         deployment_identifier = self.deployment_identifier.strip()
-        if deployment_identifier == "":
+        if not self.development and deployment_identifier == "":
             raise ValueError(
                 "deployment_identifier must be set when development is false."
             )

--- a/pingpong/config.py
+++ b/pingpong/config.py
@@ -658,7 +658,7 @@ class Config(BaseSettings):
     reload: int = Field(0)
     public_url: str = Field("http://localhost:8000")
     development: bool = Field(False)
-    deployment_identifier: str = Field("unknown")
+    deployment_identifier: str = Field("")
     artifact_store: ArtifactStoreSettings
     file_store: ArtifactStoreSettings
     audio_store: AudioStoreSettings
@@ -692,6 +692,8 @@ class Config(BaseSettings):
             return data
 
         mapped_data = dict(data)
+        if not str(mapped_data.get("deployment_identifier", "")).strip():
+            mapped_data["deployment_identifier"] = "dev"
         mapped_data.setdefault(
             "artifact_store",
             {
@@ -745,6 +747,17 @@ class Config(BaseSettings):
             for key, item in value.items():
                 child_path = f"{path}.{key}" if path else str(key)
                 yield from cls._iter_local_disk_backed_paths(item, child_path)
+
+    @model_validator(mode="after")
+    def _validate_deployment_identifier(self):
+        deployment_identifier = self.deployment_identifier.strip()
+        if deployment_identifier == "":
+            raise ValueError(
+                "deployment_identifier must be set when development is false."
+            )
+
+        self.deployment_identifier = deployment_identifier
+        return self
 
     @model_validator(mode="after")
     def _reject_local_disk_stores_outside_development(self):

--- a/pingpong/realtime.py
+++ b/pingpong/realtime.py
@@ -58,6 +58,11 @@ def _serialize_realtime_error(error) -> dict[str, str | None]:
     }
 
 
+def _is_realtime_session_update_error(error) -> bool:
+    param = getattr(error, "param", None)
+    return isinstance(param, str) and param.startswith("session.")
+
+
 def _has_non_empty_transcript(transcript_text: str | None) -> bool:
     if transcript_text is None:
         return False
@@ -987,15 +992,16 @@ async def handle_openai_events(
                         }
                     )
                 case "session.error" | "error":
-                    openai_connection_logger.error("Session error: %s", event.error)
-                    await browser_connection.send_json(
-                        {
-                            "type": "error",
-                            "error": _serialize_realtime_error(event.error),
-                        }
-                    )
-                    await browser_connection.close()
-                    return
+                    openai_connection_logger.exception(f"Session error: {event.error}")
+                    if _is_realtime_session_update_error(event.error):
+                        await browser_connection.send_json(
+                            {
+                                "type": "error",
+                                "error": _serialize_realtime_error(event.error),
+                            }
+                        )
+                        await browser_connection.close()
+                        return
                 case "session.ended":
                     openai_connection_logger.debug(f"Session ended: {event.session}")
                     await browser_connection.send_json(

--- a/pingpong/realtime.py
+++ b/pingpong/realtime.py
@@ -49,6 +49,15 @@ ConversationRole = Literal["user", "assistant"]
 UNSET_PREVIOUS_ITEM_ID = "__UNSET_PREVIOUS_ITEM_ID__"
 
 
+def _serialize_realtime_error(error) -> dict[str, str | None]:
+    return {
+        "type": "invalid_request_error",
+        "code": "openai_realtime_session",
+        "message": "We were unable to start the voice session.",
+        "param": None,
+    }
+
+
 def _has_non_empty_transcript(transcript_text: str | None) -> bool:
     if transcript_text is None:
         return False
@@ -978,7 +987,15 @@ async def handle_openai_events(
                         }
                     )
                 case "session.error" | "error":
-                    openai_connection_logger.exception(f"Session error: {event.error}")
+                    openai_connection_logger.error("Session error: %s", event.error)
+                    await browser_connection.send_json(
+                        {
+                            "type": "error",
+                            "error": _serialize_realtime_error(event.error),
+                        }
+                    )
+                    await browser_connection.close()
+                    return
                 case "session.ended":
                     openai_connection_logger.debug(f"Session ended: {event.session}")
                     await browser_connection.send_json(

--- a/pingpong/realtime.py
+++ b/pingpong/realtime.py
@@ -49,7 +49,8 @@ ConversationRole = Literal["user", "assistant"]
 UNSET_PREVIOUS_ITEM_ID = "__UNSET_PREVIOUS_ITEM_ID__"
 
 
-def _serialize_realtime_error(error) -> dict[str, str | None]:
+def _serialize_realtime_error(_error) -> dict[str, str | None]:
+    # Keep internal OpenAI details out of browser-visible errors.
     return {
         "type": "invalid_request_error",
         "code": "openai_realtime_session",
@@ -58,7 +59,10 @@ def _serialize_realtime_error(error) -> dict[str, str | None]:
     }
 
 
-def _is_realtime_session_update_error(error) -> bool:
+def _is_realtime_session_startup_error(error, session_updated: bool) -> bool:
+    if not session_updated:
+        return True
+
     param = getattr(error, "param", None)
     return isinstance(param, str) and param.startswith("session.")
 
@@ -933,6 +937,8 @@ async def handle_openai_events(
         openai_connection_logger, initial_output_index=initial_output_index
     )
 
+    session_updated = False
+
     try:
         async for event in realtime_connection:
             match event.type:
@@ -985,6 +991,7 @@ async def handle_openai_events(
                     openai_connection_logger.debug(
                         f"Session successfully updated: {event.session}"
                     )
+                    session_updated = True
                     await browser_connection.send_json(
                         {
                             "type": "session.updated",
@@ -993,7 +1000,7 @@ async def handle_openai_events(
                     )
                 case "session.error" | "error":
                     openai_connection_logger.exception(f"Session error: {event.error}")
-                    if _is_realtime_session_update_error(event.error):
+                    if _is_realtime_session_startup_error(event.error, session_updated):
                         await browser_connection.send_json(
                             {
                                 "type": "error",

--- a/pingpong/test_config_lti_settings.py
+++ b/pingpong/test_config_lti_settings.py
@@ -44,11 +44,38 @@ def _minimal_config_settings() -> dict[str, object]:
     }
 
 
-def test_config_defaults_deployment_identifier_to_unknown():
-    cfg = Config.model_validate(_minimal_config_settings())
+def test_config_requires_deployment_identifier_outside_development():
+    with pytest.raises(ValidationError) as e:
+        Config.model_validate(_minimal_config_settings())
 
-    assert cfg.deployment_identifier == "unknown"
+    assert "deployment_identifier must be set when development is false" in str(e.value)
+
+
+def test_config_loads_explicit_deployment_identifier_outside_development():
+    cfg = Config.model_validate(
+        {**_minimal_config_settings(), "deployment_identifier": "production"}
+    )
+
+    assert cfg.deployment_identifier == "production"
     assert cfg.lms.lms_instances == []
+
+
+def test_config_defaults_deployment_identifier_to_dev_in_development():
+    cfg = Config.model_validate({**_minimal_config_settings(), "development": True})
+
+    assert cfg.deployment_identifier == "dev"
+
+
+def test_config_defaults_blank_deployment_identifier_to_dev_in_development():
+    cfg = Config.model_validate(
+        {
+            **_minimal_config_settings(),
+            "development": True,
+            "deployment_identifier": "  ",
+        }
+    )
+
+    assert cfg.deployment_identifier == "dev"
 
 
 def test_config_injects_local_store_defaults_in_development():
@@ -96,6 +123,7 @@ def test_config_requires_explicit_stores_outside_development():
 def test_config_rejects_local_disk_store_outside_development():
     settings = {
         **_minimal_config_settings(),
+        "deployment_identifier": "production",
         "artifact_store": {
             "type": "local",
             "save_target": "local_exports/thread_exports",
@@ -116,6 +144,7 @@ def test_config_rejects_local_disk_store_outside_development():
 def test_config_rejects_local_nested_store_outside_development():
     settings = {
         **_minimal_config_settings(),
+        "deployment_identifier": "production",
         "lti": {"key_store": {"type": "local", "directory": "local_exports/lti_keys"}},
     }
 

--- a/pingpong/test_server_audio_websocket.py
+++ b/pingpong/test_server_audio_websocket.py
@@ -360,7 +360,7 @@ async def test_realtime_connection_updates_session_with_tracing(monkeypatch):
     handler.assert_awaited_once_with(websocket, "10", "20")
 
 
-async def test_openai_session_error_notifies_browser_and_closes_websocket():
+async def test_openai_session_update_error_notifies_browser_and_closes_websocket():
     websocket = DummyWebSocket()
     error = SimpleNamespace(
         message=("Invalid 'session.tracing.group_id': string does not match pattern."),
@@ -394,6 +394,32 @@ async def test_openai_session_error_notifies_browser_and_closes_websocket():
             },
         }
     ]
+
+
+async def test_openai_recoverable_error_is_logged_without_closing_websocket():
+    websocket = DummyWebSocket()
+    error = SimpleNamespace(
+        message="Temporary realtime error.",
+        type="server_error",
+        code="server_error",
+        event_id="event_1",
+        param=None,
+    )
+    realtime_connection = FakeRealtimeEventStream(
+        [SimpleNamespace(type="error", error=error)]
+    )
+
+    await realtime_module.handle_openai_events(
+        websocket,
+        realtime_connection,
+        openai_client=object(),
+        thread=SimpleNamespace(id=20, version=1),
+        openai_task_queue=asyncio.Queue(),
+        assistant_audio_tracker=realtime_module.RealtimeAssistantAudioTracker(),
+    )
+
+    assert websocket.closed is False
+    assert websocket.sent_json == []
 
 
 @pytest.mark.parametrize("has_recording,has_messages", [(True, False), (False, True)])

--- a/pingpong/test_server_audio_websocket.py
+++ b/pingpong/test_server_audio_websocket.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -8,6 +9,7 @@ from starlette.datastructures import State
 
 from pingpong import ai_models
 from pingpong import models
+from pingpong import realtime as realtime_module
 from pingpong import schemas
 from pingpong import websocket as websocket_module
 
@@ -49,6 +51,8 @@ async def test_audio_stream_uses_lti_session_when_cookie_missing(monkeypatch):
 
 def realtime_assistant(**overrides):
     defaults = {
+        "id": 30,
+        "assistant_id": "asst_30",
         "model": "gpt-4o-realtime-preview",
         "assistant_should_message_first": False,
         "reasoning_effort": None,
@@ -65,6 +69,58 @@ def realtime_assistant(**overrides):
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+class FakeRealtimeSession:
+    def __init__(self):
+        self.updated_sessions: list[dict] = []
+
+    async def update(self, *, session: dict) -> None:
+        self.updated_sessions.append(session)
+
+
+class FakeRealtimeResponse:
+    def __init__(self):
+        self.create_call_count = 0
+
+    async def create(self) -> None:
+        self.create_call_count += 1
+
+
+class FakeRealtimeConnection:
+    def __init__(self):
+        self.session = FakeRealtimeSession()
+        self.response = FakeRealtimeResponse()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class FakeRealtimeClient:
+    def __init__(self, connection: FakeRealtimeConnection):
+        self.connection = connection
+        self.connect_kwargs: dict | None = None
+
+    def connect(self, **kwargs):
+        self.connect_kwargs = kwargs
+        return self.connection
+
+
+class FakeOpenAIClient:
+    def __init__(self, connection: FakeRealtimeConnection):
+        self.realtime = FakeRealtimeClient(connection)
+
+
+class FakeRealtimeEventStream:
+    def __init__(self, events):
+        self.events = events
+
+    async def __aiter__(self):
+        for event in self.events:
+            yield event
 
 
 def test_realtime_session_uses_create_defaults_for_null_fields():
@@ -87,6 +143,128 @@ def test_realtime_session_uses_create_defaults_for_null_fields():
         "interrupt_response": True,
         "eagerness": "auto",
     }
+
+
+def test_realtime_session_includes_tracing_config():
+    tracing_config = {
+        "workflow_name": "PingPong Voice Mode",
+        "group_id": "pp_test_assistant_30",
+        "metadata": {"deployment_identifier": "test"},
+    }
+
+    session = websocket_module.build_realtime_session(
+        realtime_assistant(),
+        "Speak clearly.",
+        tracing_config,
+    )
+
+    assert session["tracing"] == tracing_config
+
+
+def test_realtime_pingpong_version_uses_sentry_release(monkeypatch):
+    monkeypatch.setenv("SENTRY_RELEASE", "pingpong@7.60.0+123")
+    websocket_module._get_pingpong_version.cache_clear()
+
+    try:
+        assert websocket_module._get_pingpong_version() == "pingpong@7.60.0+123"
+    finally:
+        websocket_module._get_pingpong_version.cache_clear()
+
+
+def test_realtime_pingpong_version_falls_back_to_local_dev_version(
+    monkeypatch, tmp_path
+):
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+    monkeypatch.setattr(websocket_module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        websocket_module, "_get_local_dev_version_suffix", lambda: "dev.abc123.dirty"
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "pingpong"\nversion = "7.61.0"\n',
+        encoding="utf-8",
+    )
+    websocket_module._get_pingpong_version.cache_clear()
+
+    try:
+        assert (
+            websocket_module._get_pingpong_version()
+            == "pingpong@7.61.0+dev.abc123.dirty"
+        )
+    finally:
+        websocket_module._get_pingpong_version.cache_clear()
+
+
+def test_realtime_tracing_config_includes_stable_filter_metadata(monkeypatch):
+    monkeypatch.setattr(websocket_module.config, "deployment_identifier", "staging")
+    monkeypatch.setattr(
+        websocket_module.config, "public_url", "https://example.edu/app"
+    )
+    monkeypatch.setattr(websocket_module, "_get_pingpong_version", lambda: "7.60.0")
+    thread = SimpleNamespace(
+        id=20,
+        thread_id="thread_20",
+        interaction_mode=schemas.InteractionMode.VOICE,
+    )
+    assistant = realtime_assistant(
+        id=30,
+        assistant_id="asst_30",
+        model="gpt-realtime-2",
+    )
+
+    tracing_config = websocket_module.build_realtime_tracing_config(
+        thread,
+        assistant,
+        "10",
+        "safety-id",
+    )
+
+    assert tracing_config == {
+        "workflow_name": "PingPong Voice Mode",
+        "group_id": "pp_staging_assistant_30",
+        "metadata": {
+            "metadata_version": "1",
+            "deployment_identifier": "staging",
+            "pingpong_version": "7.60.0",
+            "deployment_url": "example.edu",
+            "class": "10",
+            "assistant": "30",
+            "thread": "20",
+            "model": "gpt-realtime-2",
+            "safety_identifier": "safety-id",
+        },
+    }
+
+
+def test_realtime_tracing_config_omits_unavailable_pingpong_version(monkeypatch):
+    monkeypatch.setattr(websocket_module.config, "deployment_identifier", "staging")
+    monkeypatch.setattr(websocket_module, "_get_pingpong_version", lambda: None)
+    thread = SimpleNamespace(id=20, thread_id="thread_20")
+
+    tracing_config = websocket_module.build_realtime_tracing_config(
+        thread,
+        realtime_assistant(model="gpt-realtime-2"),
+        "10",
+    )
+
+    assert tracing_config["metadata"]["metadata_version"] == "1"
+    assert "pingpong_version" not in tracing_config["metadata"]
+
+
+def test_realtime_tracing_config_sanitizes_group_id(monkeypatch):
+    monkeypatch.setattr(
+        websocket_module.config, "deployment_identifier", "staging:blue/green"
+    )
+
+    tracing_config = websocket_module.build_realtime_tracing_config(
+        SimpleNamespace(id="thread:20/voice"),
+        realtime_assistant(id="assistant:30/voice", model="gpt-realtime-2"),
+        "10",
+    )
+
+    assert (
+        tracing_config["group_id"]
+        == "pp_staging_blue_green_assistant_assistant_30_voice"
+    )
 
 
 def test_realtime_session_adds_low_reasoning_by_default_for_gpt_realtime_2():
@@ -122,18 +300,100 @@ def test_realtime_session_uses_selected_transcription_model():
 
 
 def test_realtime_extra_headers_include_safety_identifier():
-    websocket = DummyWebSocket()
-    websocket.state["response_safety_identifier"] = "safety-id"
-
-    assert websocket_module.build_realtime_extra_headers(websocket) == {
-        "OpenAI-Safety-Identifier": "safety-id"
+    assert websocket_module.build_realtime_extra_headers("pp:v1:safety-id") == {
+        "OpenAI-Safety-Identifier": "pp:v1:safety-id",
     }
 
 
 def test_realtime_extra_headers_omit_missing_safety_identifier():
-    websocket = DummyWebSocket()
+    assert websocket_module.build_realtime_extra_headers(None) == {}
 
-    assert websocket_module.build_realtime_extra_headers(websocket) == {}
+
+async def test_realtime_connection_updates_session_with_tracing(monkeypatch):
+    monkeypatch.setattr(websocket_module.config, "deployment_identifier", "staging")
+    monkeypatch.setattr(
+        websocket_module.config, "public_url", "https://example.edu/app"
+    )
+    monkeypatch.setattr(websocket_module, "_get_pingpong_version", lambda: "7.60.0")
+    connection = FakeRealtimeConnection()
+    openai_client = FakeOpenAIClient(connection)
+    websocket = DummyWebSocket()
+    websocket.state["response_safety_identifier"] = "safety-id"
+    websocket.state["openai_client"] = openai_client
+    websocket.state["assistant"] = realtime_assistant(
+        id=30,
+        assistant_id="asst_30",
+        model="gpt-realtime-2",
+    )
+    websocket.state["thread"] = SimpleNamespace(
+        id=20,
+        thread_id="thread_20",
+        interaction_mode=schemas.InteractionMode.VOICE,
+    )
+    websocket.state["conversation_instructions"] = "Speak clearly."
+    handler = AsyncMock()
+    wrapped = websocket_module.ws_with_realtime_connection(handler)
+
+    await wrapped(websocket, "10", "20")
+
+    assert openai_client.realtime.connect_kwargs == {
+        "model": "gpt-realtime-2",
+        "extra_headers": {
+            "OpenAI-Safety-Identifier": "pp:v1:safety-id",
+        },
+    }
+    assert connection.session.updated_sessions[0]["tracing"] == {
+        "workflow_name": "PingPong Voice Mode",
+        "group_id": "pp_staging_assistant_30",
+        "metadata": {
+            "metadata_version": "1",
+            "deployment_identifier": "staging",
+            "pingpong_version": "7.60.0",
+            "deployment_url": "example.edu",
+            "class": "10",
+            "assistant": "30",
+            "thread": "20",
+            "model": "gpt-realtime-2",
+            "safety_identifier": "pp:v1:safety-id",
+        },
+    }
+    handler.assert_awaited_once_with(websocket, "10", "20")
+
+
+async def test_openai_session_error_notifies_browser_and_closes_websocket():
+    websocket = DummyWebSocket()
+    error = SimpleNamespace(
+        message=("Invalid 'session.tracing.group_id': string does not match pattern."),
+        type="invalid_request_error",
+        code="invalid_value",
+        event_id=None,
+        param="session.tracing.group_id",
+    )
+    realtime_connection = FakeRealtimeEventStream(
+        [SimpleNamespace(type="error", error=error)]
+    )
+
+    await realtime_module.handle_openai_events(
+        websocket,
+        realtime_connection,
+        openai_client=object(),
+        thread=SimpleNamespace(id=20, version=1),
+        openai_task_queue=asyncio.Queue(),
+        assistant_audio_tracker=realtime_module.RealtimeAssistantAudioTracker(),
+    )
+
+    assert websocket.closed is True
+    assert websocket.sent_json == [
+        {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "openai_realtime_session",
+                "message": "We were unable to start the voice session.",
+                "param": None,
+            },
+        }
+    ]
 
 
 @pytest.mark.parametrize("has_recording,has_messages", [(True, False), (False, True)])

--- a/pingpong/test_server_audio_websocket.py
+++ b/pingpong/test_server_audio_websocket.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -175,6 +176,7 @@ def test_realtime_pingpong_version_falls_back_to_local_dev_version(
     monkeypatch, tmp_path
 ):
     monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+    monkeypatch.setattr(websocket_module.config, "development", True)
     monkeypatch.setattr(websocket_module, "PROJECT_ROOT", tmp_path)
     monkeypatch.setattr(
         websocket_module, "_get_local_dev_version_suffix", lambda: "dev.abc123.dirty"
@@ -192,6 +194,30 @@ def test_realtime_pingpong_version_falls_back_to_local_dev_version(
         )
     finally:
         websocket_module._get_pingpong_version.cache_clear()
+
+
+def test_realtime_pingpong_version_warns_without_release_outside_development(
+    monkeypatch, tmp_path, caplog
+):
+    monkeypatch.delenv("SENTRY_RELEASE", raising=False)
+    monkeypatch.setattr(websocket_module.config, "development", False)
+    monkeypatch.setattr(websocket_module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        websocket_module, "_get_local_dev_version_suffix", lambda: "dev"
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "pingpong"\nversion = "7.61.0"\n',
+        encoding="utf-8",
+    )
+    websocket_module._get_pingpong_version.cache_clear()
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="realtime_openai"):
+            assert websocket_module._get_pingpong_version() == "pingpong@7.61.0+dev"
+    finally:
+        websocket_module._get_pingpong_version.cache_clear()
+
+    assert "SENTRY_RELEASE is not set" in caplog.text
 
 
 def test_realtime_tracing_config_includes_stable_filter_metadata(monkeypatch):
@@ -396,12 +422,12 @@ async def test_openai_session_update_error_notifies_browser_and_closes_websocket
     ]
 
 
-async def test_openai_recoverable_error_is_logged_without_closing_websocket():
+async def test_openai_startup_error_without_param_notifies_browser_and_closes_websocket():
     websocket = DummyWebSocket()
     error = SimpleNamespace(
-        message="Temporary realtime error.",
-        type="server_error",
-        code="server_error",
+        message="Model is unavailable.",
+        type="invalid_request_error",
+        code="model_unavailable",
         event_id="event_1",
         param=None,
     )
@@ -418,8 +444,52 @@ async def test_openai_recoverable_error_is_logged_without_closing_websocket():
         assistant_audio_tracker=realtime_module.RealtimeAssistantAudioTracker(),
     )
 
+    assert websocket.closed is True
+    assert websocket.sent_json == [
+        {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "openai_realtime_session",
+                "message": "We were unable to start the voice session.",
+                "param": None,
+            },
+        }
+    ]
+
+
+async def test_openai_recoverable_error_is_logged_without_closing_websocket():
+    websocket = DummyWebSocket()
+    error = SimpleNamespace(
+        message="Temporary realtime error.",
+        type="server_error",
+        code="server_error",
+        event_id="event_1",
+        param=None,
+    )
+    realtime_connection = FakeRealtimeEventStream(
+        [
+            SimpleNamespace(type="session.updated", session=SimpleNamespace()),
+            SimpleNamespace(type="error", error=error),
+        ]
+    )
+
+    await realtime_module.handle_openai_events(
+        websocket,
+        realtime_connection,
+        openai_client=object(),
+        thread=SimpleNamespace(id=20, version=1),
+        openai_task_queue=asyncio.Queue(),
+        assistant_audio_tracker=realtime_module.RealtimeAssistantAudioTracker(),
+    )
+
     assert websocket.closed is False
-    assert websocket.sent_json == []
+    assert websocket.sent_json == [
+        {
+            "type": "session.updated",
+            "message": "Connected to OpenAI.",
+        }
+    ]
 
 
 @pytest.mark.parametrize("has_recording,has_messages", [(True, False), (False, True)])

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -167,7 +167,7 @@ def build_realtime_tracing_config(
 
     return {
         "workflow_name": REALTIME_TRACE_WORKFLOW_NAME,
-        "group_id": f"pp_{group_deployment_identifier}_assistant_{group_assistant_identifier}",
+        "group_id": f"pp_{group_deployment_identifier}_assistant_{group_assistant_identifier}!!!!",
         "metadata": metadata,
     }
 

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -167,7 +167,7 @@ def build_realtime_tracing_config(
 
     return {
         "workflow_name": REALTIME_TRACE_WORKFLOW_NAME,
-        "group_id": f"pp_{group_deployment_identifier}_assistant_{group_assistant_identifier}!!!!",
+        "group_id": f"pp_{group_deployment_identifier}_assistant_{group_assistant_identifier}",
         "metadata": metadata,
     }
 

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -1,6 +1,12 @@
-from functools import wraps
+from functools import cache, wraps
 import logging
+import os
+import re
+import subprocess
+import tomllib
 from typing import Any, cast
+from pathlib import Path
+from urllib.parse import urlparse
 
 from sqlalchemy import select
 
@@ -8,6 +14,7 @@ from pingpong import models, schemas
 from pingpong.ai_models import get_reasoning_effort_map
 from pingpong.ai import (
     OpenAIClientType,
+    build_openai_safety_identifier,
     get_openai_client_by_class_id,
     inject_timestamp_to_instructions,
 )
@@ -51,8 +58,124 @@ def build_realtime_reasoning(assistant: models.Assistant) -> dict[str, str] | No
     return {"effort": reasoning_effort_map[reasoning_effort]}
 
 
+REALTIME_TRACE_WORKFLOW_NAME = "PingPong Voice Mode"
+REALTIME_TRACE_METADATA_VERSION = "1"
+REALTIME_TRACE_GROUP_ID_DISALLOWED_PATTERN = re.compile(r"[^A-Za-z0-9_-]+")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _stringify_trace_metadata(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "value"):
+        value = value.value
+    text = str(value).strip()
+    return text or None
+
+
+def _add_trace_metadata(metadata: dict[str, str], key: str, value: Any) -> None:
+    text = _stringify_trace_metadata(value)
+    if text is not None:
+        metadata[key] = text
+
+
+def _sanitize_trace_group_id_part(value: Any) -> str:
+    text = _stringify_trace_metadata(value) or "unknown"
+    sanitized = REALTIME_TRACE_GROUP_ID_DISALLOWED_PATTERN.sub("_", text).strip("_-")
+    return sanitized or "unknown"
+
+
+def _get_pyproject_version() -> str | None:
+    try:
+        pyproject = tomllib.loads(
+            (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        return None
+    return _stringify_trace_metadata(project.get("version"))
+
+
+def _run_git_command(*args: str) -> str | None:
+    try:
+        output = subprocess.check_output(
+            ["git", *args],
+            cwd=PROJECT_ROOT,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1,
+        )
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+    return _stringify_trace_metadata(output)
+
+
+def _get_local_dev_version_suffix() -> str:
+    short_sha = _run_git_command("rev-parse", "--short", "HEAD")
+    if short_sha is None:
+        return "dev"
+
+    suffix = f"dev.{short_sha}"
+    if _run_git_command("status", "--short"):
+        suffix += ".dirty"
+    return suffix
+
+
+@cache
+def _get_pingpong_version() -> str | None:
+    sentry_release = _stringify_trace_metadata(os.environ.get("SENTRY_RELEASE"))
+    if sentry_release is not None:
+        return sentry_release
+
+    pyproject_version = _get_pyproject_version()
+    if pyproject_version is None:
+        return None
+    return f"pingpong@{pyproject_version}+{_get_local_dev_version_suffix()}"
+
+
+def build_realtime_tracing_config(
+    thread: models.Thread,
+    assistant: models.Assistant,
+    class_id: str,
+    safety_identifier: str | None = None,
+) -> dict[str, Any]:
+    deployment_identifier = config.deployment_identifier
+    group_deployment_identifier = _sanitize_trace_group_id_part(deployment_identifier)
+    group_assistant_identifier = _sanitize_trace_group_id_part(
+        getattr(assistant, "id", None)
+    )
+    deployment_hostname = urlparse(config.public_url).hostname
+
+    metadata = {
+        "metadata_version": REALTIME_TRACE_METADATA_VERSION,
+        "deployment_identifier": deployment_identifier,
+    }
+    _add_trace_metadata(metadata, "pingpong_version", _get_pingpong_version())
+    _add_trace_metadata(metadata, "deployment_url", deployment_hostname)
+    _add_trace_metadata(metadata, "class", class_id)
+    _add_trace_metadata(metadata, "assistant", getattr(assistant, "id", None))
+    _add_trace_metadata(metadata, "thread", getattr(thread, "id", None))
+    _add_trace_metadata(metadata, "model", assistant.model)
+    _add_trace_metadata(metadata, "safety_identifier", safety_identifier)
+
+    return {
+        "workflow_name": REALTIME_TRACE_WORKFLOW_NAME,
+        "group_id": f"pp_{group_deployment_identifier}_assistant_{group_assistant_identifier}",
+        "metadata": metadata,
+    }
+
+
 def build_realtime_session(
-    assistant: models.Assistant, conversation_instructions: str
+    assistant: models.Assistant,
+    conversation_instructions: str,
+    tracing_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     realtime_vad_mode = _coerce_realtime_enum(
         schemas.RealtimeVadMode,
@@ -137,17 +260,16 @@ def build_realtime_session(
     reasoning = build_realtime_reasoning(assistant)
     if reasoning is not None:
         session["reasoning"] = reasoning
+    if tracing_config is not None:
+        session["tracing"] = tracing_config
 
     return session
 
 
 def build_realtime_extra_headers(
-    browser_connection: StateWebSocket,
+    safety_identifier: str | None,
 ) -> dict[str, str]:
-    safety_identifier = getattr(
-        browser_connection.state, "response_safety_identifier", None
-    )
-    if not isinstance(safety_identifier, str) or not safety_identifier:
+    if safety_identifier is None:
         return {}
 
     return {"OpenAI-Safety-Identifier": safety_identifier}
@@ -406,14 +528,42 @@ def ws_with_single_realtime_session(func):
 
 def ws_with_realtime_connection(func):
     @wraps(func)
-    async def wrapper(browser_connection: StateWebSocket, *args, **kwargs):
+    async def wrapper(
+        browser_connection: StateWebSocket,
+        class_id: str,
+        thread_id: str,
+        *args,
+        **kwargs,
+    ):
         openai_client: OpenAIClientType = browser_connection.state["openai_client"]
         assistant: models.Assistant = browser_connection.state["assistant"]
+        thread: models.Thread = browser_connection.state["thread"]
         conversation_instructions: str = browser_connection.state[
             "conversation_instructions"
         ]
-        session = build_realtime_session(assistant, conversation_instructions)
-        extra_headers = build_realtime_extra_headers(browser_connection)
+        response_safety_identifier = getattr(
+            browser_connection.state, "response_safety_identifier", None
+        )
+        if not (
+            isinstance(response_safety_identifier, str) and response_safety_identifier
+        ):
+            safety_identifier = None
+        else:
+            safety_identifier = build_openai_safety_identifier(
+                response_safety_identifier
+            )
+        tracing_config = build_realtime_tracing_config(
+            thread,
+            assistant,
+            class_id,
+            safety_identifier,
+        )
+        session = build_realtime_session(
+            assistant,
+            conversation_instructions,
+            tracing_config,
+        )
+        extra_headers = build_realtime_extra_headers(safety_identifier)
         try:
             async with openai_client.realtime.connect(
                 model=assistant.model,
@@ -423,7 +573,7 @@ def ws_with_realtime_connection(func):
                 await realtime_connection.session.update(session=session)
                 if assistant.assistant_should_message_first:
                     await realtime_connection.response.create()
-                await func(browser_connection, *args, **kwargs)
+                await func(browser_connection, class_id, thread_id, *args, **kwargs)
         except Exception as e:
             openai_connection_logger.exception(f"Error in Realtime connection: {e}")
             await browser_connection.send_json(

--- a/pingpong/websocket.py
+++ b/pingpong/websocket.py
@@ -134,6 +134,12 @@ def _get_pingpong_version() -> str | None:
     if sentry_release is not None:
         return sentry_release
 
+    if not config.development:
+        openai_connection_logger.warning(
+            "SENTRY_RELEASE is not set; realtime trace versions will use the "
+            "local development fallback."
+        )
+
     pyproject_version = _get_pyproject_version()
     if pyproject_version is None:
         return None
@@ -148,9 +154,7 @@ def build_realtime_tracing_config(
 ) -> dict[str, Any]:
     deployment_identifier = config.deployment_identifier
     group_deployment_identifier = _sanitize_trace_group_id_part(deployment_identifier)
-    group_assistant_identifier = _sanitize_trace_group_id_part(
-        getattr(assistant, "id", None)
-    )
+    group_assistant_identifier = _sanitize_trace_group_id_part(assistant.id)
     deployment_hostname = urlparse(config.public_url).hostname
 
     metadata = {
@@ -160,8 +164,8 @@ def build_realtime_tracing_config(
     _add_trace_metadata(metadata, "pingpong_version", _get_pingpong_version())
     _add_trace_metadata(metadata, "deployment_url", deployment_hostname)
     _add_trace_metadata(metadata, "class", class_id)
-    _add_trace_metadata(metadata, "assistant", getattr(assistant, "id", None))
-    _add_trace_metadata(metadata, "thread", getattr(thread, "id", None))
+    _add_trace_metadata(metadata, "assistant", assistant.id)
+    _add_trace_metadata(metadata, "thread", thread.id)
     _add_trace_metadata(metadata, "model", assistant.model)
     _add_trace_metadata(metadata, "safety_identifier", safety_identifier)
 


### PR DESCRIPTION
## Voice Mode
### New Features
* Voice mode sessions now include a tracing configuration. Voice mode traces are grouped by deployment and assistant, making it easier to filter and compare sessions across environments. Voice mode trace metadata includes the deployment identifier, PingPong version when available, deployment hostname, class, assistant, thread, model, and PingPong safety identifier.

### Resolved Issues
* Fixed: Voice mode startup may fail silently and cause a UI hang when OpenAI returns a Realtime session error during session setup. PingPong now sends a user-facing Voice session startup error to the browser and closes the websocket.
* Fixed: The safety identifier sent during Voice mode sessions may not match the Chat mode template.

## Internal
### Updates & Improvements
* Development configs now default `deployment_identifier` to `dev` when omitted or blank. Specifying a `deployment_identifier` is now required outside development.